### PR TITLE
WIP:docker: use alpine flavor of postgres image

### DIFF
--- a/docker/Dockerfile.postgres
+++ b/docker/Dockerfile.postgres
@@ -1,4 +1,4 @@
-FROM postgres:10
+FROM postgres:10-alpine
 
 ENV POSTGRES_USER postgres
 # Do not require a PostgreSQL superuser password.

--- a/docker/entrypoint.postgres.sh
+++ b/docker/entrypoint.postgres.sh
@@ -5,7 +5,7 @@ if [ ! -f /var/lib/postgresql/data/setupFinished ]; then
     echo "### first run - setting up invidious database"
     /usr/local/bin/docker-entrypoint.sh postgres &
     sleep 10
-    until runuser -l postgres -c 'pg_isready' 2>/dev/null; do
+    until su postgres -c 'pg_isready' 2>/dev/null; do
         >&2 echo "### Postgres is unavailable - waiting"
         sleep 5
     done


### PR DESCRIPTION
Image size reduced by over 68%, from `230MB` down to `72.4MB`.
Additionally, this seems to free around 2GB of intermediary images.