### PR TITLE
Add Previous/Next page buttons at the top of the page

### DIFF
--- a/src/invidious/views/search.ecr
+++ b/src/invidious/views/search.ecr
@@ -2,6 +2,24 @@
 <title><%= search_query.not_nil!.size > 30 ? HTML.escape(query.not_nil![0,30].rstrip(".") + "...") : HTML.escape(query.not_nil!) %> - Invidious</title>
 <% end %>
 
+<div class="pure-g h-box v-box">
+    <div class="pure-u-1 pure-u-lg-1-5">
+        <% if page > 1 %>
+            <a href="/search?q=<%= HTML.escape(query.not_nil!) %>&page=<%= page - 1 %>">
+                <%= translate(locale, "Previous page") %>
+            </a>
+        <% end %>
+    </div>
+    <div class="pure-u-1 pure-u-lg-3-5"></div>
+    <div class="pure-u-1 pure-u-lg-1-5" style="text-align:right">
+        <% if count >= 20 %>
+            <a href="/search?q=<%= HTML.escape(query.not_nil!) %>&page=<%= page + 1 %>">
+                <%= translate(locale, "Next page") %>
+            </a>
+        <% end %>
+    </div>
+</div>
+
 <div class="pure-g">
     <% videos.each_slice(4) do |slice| %>
         <% slice.each do |item| %>


### PR DESCRIPTION
Resolves issue #832 

Added buttons of previous and next page at the top of the page. Preview:
![Screenshot from 2019-11-20 15-57-33](https://user-images.githubusercontent.com/49662698/69268961-d3920a80-0bae-11ea-8f89-ee21e1b1068c.png)
