### PR TITLE
Make number of columns in feed customizable

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "الإصدار الحالي: "
+    "Current version: ": "الإصدار الحالي: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/bn_BD.json
+++ b/locales/bn_BD.json
@@ -353,5 +353,6 @@
     "Videos": "",
     "Playlists": "",
     "Community": "",
-    "Current version: ": ""
+    "Current version: ": "",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -414,5 +414,6 @@
     "location": "umístění",
     "hdr": "HDR",
     "filter": "filtr",
-    "Current version: ": ""
+    "Current version: ": "",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/da.json
+++ b/locales/da.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": ""
+    "Current version: ": "",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "Aktuelle Version: "
+    "Current version: ": "Aktuelle Version: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/el.json
+++ b/locales/el.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "Τρέχουσα έκδοση: "
+    "Current version: ": "Τρέχουσα έκδοση: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -414,5 +414,6 @@
     "location": "Location",
     "hdr": "HDR",
     "filter": "Filter",
-    "Current version: ": "Current version: "
+    "Current version: ": "Current version: ",
+    "Number of videos shown per row: ": "Number of videos shown per row: "
 }

--- a/locales/eo.json
+++ b/locales/eo.json
@@ -414,5 +414,6 @@
     "location": "loko",
     "hdr": "granddinamikgama",
     "filter": "filtri",
-    "Current version: ": "Nuna versio: "
+    "Current version: ": "Nuna versio: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -414,5 +414,6 @@
     "location": "ubicación",
     "hdr": "hdr",
     "filter": "filtro",
-    "Current version: ": "Versión actual: "
+    "Current version: ": "Versión actual: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -336,5 +336,6 @@
     "Videos": "",
     "Playlists": "",
     "Community": "",
-    "Current version: ": ""
+    "Current version: ": "",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/fa.json
+++ b/locales/fa.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "نسخه فعلی: "
+    "Current version: ": "نسخه فعلی: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "Tämänhetkinen versio: "
+    "Current version: ": "Tämänhetkinen versio: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -414,5 +414,6 @@
     "location": "emplacement",
     "hdr": "HDR",
     "filter": "filtrer",
-    "Current version: ": "Version actuelle : "
+    "Current version: ": "Version actuelle : ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/he.json
+++ b/locales/he.json
@@ -414,5 +414,6 @@
     "location": "מיקום",
     "hdr": "HDR",
     "filter": "סינון",
-    "Current version: ": "הגרסה הנוכחית: "
+    "Current version: ": "הגרסה הנוכחית: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -414,5 +414,6 @@
     "location": "lokacija",
     "hdr": "hdr",
     "filter": "filtar",
-    "Current version: ": "Trenutačna verzija: "
+    "Current version: ": "Trenutačna verzija: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/hu-HU.json
+++ b/locales/hu-HU.json
@@ -335,5 +335,6 @@
     "Videos": "Videók",
     "Playlists": "Playlistek",
     "Community": "Közösség",
-    "Current version: ": "Jelenlegi verzió: "
+    "Current version: ": "Jelenlegi verzió: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/id.json
+++ b/locales/id.json
@@ -414,5 +414,6 @@
     "location": "lokasi",
     "hdr": "hdr",
     "filter": "saring",
-    "Current version: ": "Versi saat ini: "
+    "Current version: ": "Versi saat ini: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/is.json
+++ b/locales/is.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "Núverandi útgáfa: "
+    "Current version: ": "Núverandi útgáfa: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "Versione attuale: "
+    "Current version: ": "Versione attuale: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "現在のバージョン: "
+    "Current version: ": "現在のバージョン: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/nb-NO.json
+++ b/locales/nb-NO.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "Gjeldende versjon: "
+    "Current version: ": "Gjeldende versjon: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "Huidige versie: "
+    "Current version: ": "Huidige versie: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "Aktualna wersja: "
+    "Current version: ": "Aktualna wersja: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "Versão atual: "
+    "Current version: ": "Versão atual: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "Versão atual: "
+    "Current version: ": "Versão atual: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "Versiunea actuală: "
+    "Current version: ": "Versiunea actuală: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "Текущая версия: "
+    "Current version: ": "Текущая версия: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/si.json
+++ b/locales/si.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": ""
+    "Current version: ": "",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -353,5 +353,6 @@
     "Videos": "",
     "Playlists": "",
     "Community": "",
-    "Current version: ": ""
+    "Current version: ": "",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/sr.json
+++ b/locales/sr.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": ""
+    "Current version: ": "",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/sr_Cyrl.json
+++ b/locales/sr_Cyrl.json
@@ -336,5 +336,6 @@
     "Videos": "",
     "Playlists": "",
     "Community": "",
-    "Current version: ": "Тренутна верзија: "
+    "Current version: ": "Тренутна верзија: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/sv-SE.json
+++ b/locales/sv-SE.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "Nuvarande version: "
+    "Current version: ": "Nuvarande version: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -414,5 +414,6 @@
     "location": "konum",
     "hdr": "HDR",
     "filter": "filtrele",
-    "Current version: ": "Şu anki sürüm: "
+    "Current version: ": "Şu anki sürüm: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "Поточна версія: "
+    "Current version: ": "Поточна версія: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -414,5 +414,6 @@
     "location": "",
     "hdr": "",
     "filter": "",
-    "Current version: ": "当前版本: "
+    "Current version: ": "当前版本: ",
+    "Number of videos shown per row: ": ""
 }

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -414,5 +414,6 @@
     "location": "位置",
     "hdr": "HDR",
     "filter": "篩選條件",
-    "Current version: ": "目前版本： "
+    "Current version: ": "目前版本： ",
+    "Number of videos shown per row: ": ""
 }

--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -33,6 +33,7 @@ struct ConfigPreferences
   property continue : Bool = false
   property continue_autoplay : Bool = true
   property dark_mode : String = ""
+  property feed_cols : Int32 = 4
   property latest_only : Bool = false
   property listen : Bool = false
   property local : Bool = false

--- a/src/invidious/routes/preferences.cr
+++ b/src/invidious/routes/preferences.cr
@@ -97,6 +97,9 @@ class Invidious::Routes::PreferencesRoute < Invidious::Routes::BaseRoute
     max_results = env.params.body["max_results"]?.try &.as(String).to_i?
     max_results ||= CONFIG.default_user_preferences.max_results
 
+    feed_cols = env.params.body["feed_cols"]?.try &.as(String).to_i?
+    feed_cols ||= CONFIG.default_user_preferences.feed_cols
+
     sort = env.params.body["sort"]?.try &.as(String)
     sort ||= CONFIG.default_user_preferences.sort
 
@@ -122,6 +125,7 @@ class Invidious::Routes::PreferencesRoute < Invidious::Routes::BaseRoute
       continue:               continue,
       continue_autoplay:      continue_autoplay,
       dark_mode:              dark_mode,
+      feed_cols:              feed_cols,
       latest_only:            latest_only,
       listen:                 listen,
       local:                  local,

--- a/src/invidious/users.cr
+++ b/src/invidious/users.cr
@@ -51,7 +51,7 @@ struct Preferences
   @[YAML::Field(converter: Preferences::BoolToString)]
   property dark_mode : String = CONFIG.default_user_preferences.dark_mode
 
-  @[JSON::Field(converter: Preferences::ClampInt)]
+  @[JSON::Field(converter: Preferences::ClampFeedCols)]
   property feed_cols : Int32 = CONFIG.default_user_preferences.feed_cols
   property latest_only : Bool = CONFIG.default_user_preferences.latest_only
   property listen : Bool = CONFIG.default_user_preferences.listen
@@ -144,6 +144,36 @@ struct Preferences
 
     def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Int32
       node.value.clamp(0, MAX_ITEMS_PER_PAGE)
+    end
+  end
+
+  module ClampFeedCols
+    def self.to_json(value : Int32, json : JSON::Builder)
+      case value.clamp(2, 8)
+      when 7
+        # Pure CSS does not have pure-g-*-1-7
+        json.number 8
+      else
+        json.number value.clamp(2, 8)
+      end
+    end
+
+    def self.from_json(value : JSON::PullParser) : Int32
+      value.read_int.clamp(2, 8).to_i32
+    end
+
+    def self.to_yaml(value : Int32, yaml : YAML::Nodes::Builder)
+      case value.clamp(2, 8)
+      when 7
+        # Pure CSS does not have pure-g-*-1-7
+        yaml.scalar 8
+      else
+        yaml.scalar value.clamp(2, 8)
+      end
+    end
+
+    def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Int32
+      node.value.clamp(2, 9)
     end
   end
 

--- a/src/invidious/users.cr
+++ b/src/invidious/users.cr
@@ -50,6 +50,9 @@ struct Preferences
   @[JSON::Field(converter: Preferences::BoolToString)]
   @[YAML::Field(converter: Preferences::BoolToString)]
   property dark_mode : String = CONFIG.default_user_preferences.dark_mode
+
+  @[JSON::Field(converter: Preferences::ClampInt)]
+  property feed_cols : Int32 = CONFIG.default_user_preferences.feed_cols
   property latest_only : Bool = CONFIG.default_user_preferences.latest_only
   property listen : Bool = CONFIG.default_user_preferences.listen
   property local : Bool = CONFIG.default_user_preferences.local

--- a/src/invidious/views/components/item.ecr
+++ b/src/invidious/views/components/item.ecr
@@ -1,4 +1,5 @@
-<div class="pure-u-1 pure-u-md-1-4">
+<% feed_cols = env.get("preferences").as(Preferences).feed_cols %>
+<div class="pure-u-1 pure-u-md-1-<%= feed_cols %>">
     <div class="h-box">
         <% case item when %>
         <% when SearchChannel %>

--- a/src/invidious/views/history.ecr
+++ b/src/invidious/views/history.ecr
@@ -30,7 +30,8 @@
 <div class="pure-g">
     <% watched.each_slice(4) do |slice| %>
             <% slice.each do |item| %>
-                <div class="pure-u-1 pure-u-md-1-4">
+                <% feed_cols = env.get("preferences").as(Preferences).feed_cols %>
+                <div class="pure-u-1 pure-u-md-1-<%= feed_cols %>">
                     <div class="h-box">
                         <a style="width:100%" href="/watch?v=<%= item %>">
                             <% if !env.get("preferences").as(Preferences).thin_mode %>

--- a/src/invidious/views/preferences.ecr
+++ b/src/invidious/views/preferences.ecr
@@ -174,7 +174,7 @@
 
             <div class="pure-control-group">
                 <label for="feed_cols"><%= translate(locale, "Number of videos shown per row: ") %></label>
-                <input name="feed_cols" id="feed_cols" type="number" value="<%= preferences.feed_cols %>">
+                <input name="feed_cols" id="feed_cols" type="number" value="<%= preferences.feed_cols %>" min="2" max="8">
             </div>
 
             <% if env.get? "user" %>

--- a/src/invidious/views/preferences.ecr
+++ b/src/invidious/views/preferences.ecr
@@ -172,6 +172,11 @@
                 <% end %>
             </div>
 
+            <div class="pure-control-group">
+                <label for="feed_cols"><%= translate(locale, "Number of videos shown per row: ") %></label>
+                <input name="feed_cols" id="feed_cols" type="number" value="<%= preferences.feed_cols %>">
+            </div>
+
             <% if env.get? "user" %>
                 <legend><%= translate(locale, "Subscription preferences") %></legend>
 


### PR DESCRIPTION
Closes #1018. Add a new preference `feed_cols` and use it to determine the width of each video relative to the feed.

Please note that this only works when the value of `feed_cols` is a factor of 5 or 24, because of the way that Pure CSS's [grid system](https://purecss.io/grids/) works. If it would be beneficial to give the user a warning or to reject invalid inputs instead of blindly following the user's request (which would cause the number of columns to be effectively 1), I could also implement that.