### PR TITLE
Disable autocorrect in search input

### DIFF
--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -36,7 +36,7 @@
                 <div class="pure-u-1 pure-u-md-12-24 searchbar">
                     <form class="pure-form" action="/search" method="get">
                         <fieldset>
-                            <input type="search" style="width:100%" name="q" placeholder="<%= translate(locale, "search") %>" value="<%= env.get?("search").try {|x| HTML.escape(x.as(String)) } %>">
+                            <input type="search" style="width:100%" name="q" placeholder="<%= translate(locale, "search") %>" value="<%= env.get?("search").try {|x| HTML.escape(x.as(String)) } %>" autocomplete="off" spellcheck="false" autocorrect="off">
                         </fieldset>
                     </form>
                 </div>


### PR DESCRIPTION
On mobile it's generally annoying and just gets in the way, especially when the autocorrect language is set to something else than English.