### PR TITLE
Increase colour contrast of light theme links

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -9,10 +9,15 @@ body {
   background-color: rgb(255, 0, 0, 0.5);
 }
 
-.channel-profile > * {
+.channel-profile {
   font-size: 1.17em;
   font-weight: bold;
-  vertical-align: middle;
+  display: flex;
+  align-items: center;
+}
+
+.channel-profile > span {
+    padding-left: 0.5em
 }
 
 .channel-profile > img {

--- a/assets/css/lighttheme.css
+++ b/assets/css/lighttheme.css
@@ -1,10 +1,11 @@
 a:hover,
-a:active {
-  color: #167ac6 !important;
+a:focus {
+  color: #075A9E !important;
+  text-decoration: underline;
 }
 
 a {
-  color: #61809b;
+  color: #335d7a;
   text-decoration: none;
 }
 


### PR DESCRIPTION
These darker shades of blue have at minimum 7:1 [contrast ratio](https://webaim.org/resources/contrastchecker/) against a white background, conforming to [WCAG AAA](https://www.w3.org/TR/WCAG21/#contrast-enhanced). Also links are now underlined when hovered or focused.

This is only a subtle change and improves accessibility for the visually impaired and is generally easier to read, reduces eye strain and so on. What do you think?

Also, I'm not familiar with the code base, I just used the browser dev tools to experiment with tweaking the style sheets, so please let me know whether I've made changes in the right places.

There are possibly other areas where colour contrast (and accessibly in general) could be improved. If this PR is acceptable then I may have a go at tweaking those too.

Cheers.
