### PR TITLE
Ensure all crystal dependencies are installed before running CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ jobs:
       language: crystal
       crystal: latest
       before_install:
+        - sudo apt-get update
+        - sudo apt-get -y install gcc pkg-config git tzdata libpcre3-dev libevent-dev libyaml-dev libgmp-dev libssl-dev libxml2-dev
         - shards update
         - shards install
       install:


### PR DESCRIPTION
I give a try to fix the CI, but it seems it already has been fixed on the side of Travis, as the update and install steps I added is run without any effects. @Perflyst could you  run the CI on master without merging my PR to check?