### PR TITLE
[Helm] add service type values and InitContainer to wait for Postgres

### DIFF
--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: invidious
 description: Invidious is an alternative front-end to YouTube
-version: 1.0.0
+version: 1.1.0
 appVersion: 0.20.1
 keywords:
 - youtube

--- a/kubernetes/templates/deployment.yaml
+++ b/kubernetes/templates/deployment.yaml
@@ -50,4 +50,5 @@ spec:
           httpGet:
             port: 3000
             path: /
+          initialDelaySeconds: 15
       restartPolicy: Always

--- a/kubernetes/templates/deployment.yaml
+++ b/kubernetes/templates/deployment.yaml
@@ -23,6 +23,13 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+      initContainers:
+        - name: wait-for-postgresql
+          image: postgres
+          args:
+          - /bin/sh
+          - -c
+          - until pg_isready -h {{ .Values.config.db.host }} -p {{ .Values.config.db.port }} -U {{ .Values.config.db.port }}; do echo waiting for database; sleep 2; done;
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/kubernetes/templates/deployment.yaml
+++ b/kubernetes/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           args:
           - /bin/sh
           - -c
-          - until pg_isready -h {{ .Values.config.db.host }} -p {{ .Values.config.db.port }} -U {{ .Values.config.db.port }}; do echo waiting for database; sleep 2; done;
+          - until pg_isready -h {{ .Values.config.db.host }} -p {{ .Values.config.db.port }} -U {{ .Values.config.db.user }}; do echo waiting for database; sleep 2; done;
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/kubernetes/templates/service.yaml
+++ b/kubernetes/templates/service.yaml
@@ -7,10 +7,14 @@ metadata:
     chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
 spec:
+  type: {{ .Values.service.type }}
   ports:
   - name: http
-    port: 3000
+    port: {{ .Values.service.port }}
     targetPort: 3000
   selector:
     app: {{ template "invidious.name" . }}
     release: {{ .Release.Name }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -16,7 +16,7 @@ autoscaling:
 service:
   type: clusterIP
   port: 3000
-  # loadBalancerIP:
+  #loadBalancerIP:
 
 resources: {}
   #requests:

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -13,6 +13,11 @@ autoscaling:
   maxReplicas: 16
   targetCPUUtilizationPercentage: 50
 
+service:
+  type: clusterIP
+  port: 3000
+  # loadBalancerIP:
+
 resources: {}
   #requests:
   #  cpu: 100m


### PR DESCRIPTION
The Service type really should be there to change the type of service and external port in Helm chart values. This does not change the default helm install behaviour in terms of Service type since Kubernetes default is clusterIP.

I also added a initContainer to check if postgres is up and ready to serve before starting Invidious.