### PR TITLE
Fix storyboard not loading images from i.ytimg.com

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -257,7 +257,7 @@ before_all do |env|
     extra_media_csp += " https://*.googlevideo.com:443"
   end
   # TODO: Remove style-src's 'unsafe-inline', requires to remove all inline styles (<style> [..] </style>, style=" [..] ")
-  env.response.headers["Content-Security-Policy"] = "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; manifest-src 'self'; media-src 'self' blob:#{extra_media_csp}"
+  env.response.headers["Content-Security-Policy"] = "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src https://i.ytimg.com 'self' data:; font-src 'self' data:; connect-src 'self'; manifest-src 'self'; media-src 'self' blob:#{extra_media_csp}"
   env.response.headers["Referrer-Policy"] = "same-origin"
 
   if (Kemal.config.ssl || config.https_only) && config.hsts


### PR DESCRIPTION
The `Content-Security-Policy` is not allowing the browser to load images from `i.ytimg.com`, which are images of the storyboard.