### PR TITLE
Remove on-hover tooltip from player

### DIFF
--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -1,4 +1,4 @@
-<video style="outline:none;width:100%;background-color:#000" playsinline poster="<%= thumbnail %>" title="<%= HTML.escape(video.title) %>"
+<video style="outline:none;width:100%;background-color:#000" playsinline poster="<%= thumbnail %>"
     id="player" class="on-video_player video-js player-style-<%= params.player_style %>"
     <% if params.autoplay %>autoplay<% end %>
     <% if params.video_loop %>loop<% end %>


### PR DESCRIPTION
Using the player on latest Safari, the tooltip appears and stays stuck for long even when switching to fullscreen which is annoying. You need to explicitly click anywhere to dismiss that stuck tooltip.

This doesn't seem to happen in Firefox so I am not sure whether this is a browser bug, but in any case I don't see any value in keeping this tooltip so maybe we can just remove it?