### PR TITLE
Fix #1382 : Playlists missing first video

### DIFF
--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -483,7 +483,7 @@ def extract_playlist_videos(initial_data : Hash(String, JSON::Any))
         published:      Time.utc,
         plid:           plid,
         live_now:       live,
-        index:          index - 1,
+        index:          index,
       })
     end
   end


### PR DESCRIPTION
The index was set to index - 1, causing the first video to be shifted in fetch_playlist_videos#L448 (because of its index being -1 lower than it should) and thus not displayed on playlist page.