### PR TITLE
Fix feed menu overlap at iPad screen widths

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -60,6 +60,22 @@ body {
   color: rgb(255, 0, 0);
 }
 
+.feed-menu {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.feed-menu-item {
+  text-align: center;
+}
+
+@media screen and (max-width: 640px) {
+  .feed-menu-item {
+    flex: 0 0 40%;
+  }
+}
+
 .h-box {
   padding-left: 1em;
   padding-right: 1em;

--- a/src/invidious/views/components/feed_menu.ecr
+++ b/src/invidious/views/components/feed_menu.ecr
@@ -1,19 +1,11 @@
-<div class="h-box pure-g">
-    <div class="pure-u-1 pure-u-md-1-4"></div>
-    <div class="pure-u-1 pure-u-md-1-2">
-        <div class="pure-g">
-            <% feed_menu = env.get("preferences").as(Preferences).feed_menu.dup %>
-            <% if !env.get?("user") %>
-                <% feed_menu.reject! {|item| {"Subscriptions", "Playlists"}.includes? item} %>
-            <% end %>
-            <% feed_menu.each do |feed| %>
-                <div class="pure-u-1-2 pure-u-md-1-<%= feed_menu.size %>">
-                    <a href="/feed/<%= feed.downcase %>" class="pure-menu-heading" style="text-align:center">
-                        <%= translate(locale, feed) %>
-                    </a>
-                </div>
-            <% end %>
-        </div>
-    </div>
-    <div class="pure-u-1 pure-u-md-1-4"></div>
+<div class="feed-menu">
+    <% feed_menu = env.get("preferences").as(Preferences).feed_menu.dup %>
+    <% if !env.get?("user") %>
+        <% feed_menu.reject! {|item| {"Subscriptions", "Playlists"}.includes? item} %>
+    <% end %>
+    <% feed_menu.each do |feed| %>
+        <a href="/feed/<%= feed.downcase %>" class="feed-menu-item pure-menu-heading">
+            <%= translate(locale, feed) %>
+        </a>
+    <% end %>
 </div>


### PR DESCRIPTION
Fixes: #1122 

The grid system in use caused long words in the feed menu to overlap one another. Sticking with the grid layout and increasing the column width given to the menu increases complexity as it spreads out the signed out user's feed menu as well which only has two items. Switching to flex-box greatly simplifies the html layout but new css had to be added.

## Before
<img width="875" alt="CleanShot 2020-10-07 at 22 59 14@2x" src="https://user-images.githubusercontent.com/17329408/95413466-21138500-08f1-11eb-8719-72b83509e908.png">

## After
<img width="878" alt="CleanShot 2020-10-07 at 22 59 46@2x" src="https://user-images.githubusercontent.com/17329408/95413467-2244b200-08f1-11eb-921c-98a5c31f1ae1.png">
