### PR TITLE
Replace the riot.im link with a matrix.to link

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,4 +262,4 @@ Liberapay: https://liberapay.com/iv-org/
 
 ## Contact
 
-Feel free to join our [Matrix server](https://riot.im/app/#/room/#invidious:matrix.org), or #invidious on freenode. Both platform are bridged together.
+Feel free to join our [Matrix room](https://matrix.to/#/#invidious:matrix.org), or #invidious on freenode. Both platforms are bridged together.


### PR DESCRIPTION
Riot.im URL "force" a client while matrix.to list every available client and how to join the room with them.

Riot.im is also deprecated since Riot was renamed to Element.