### PR TITLE
Set preferences before conditional breaks in before_all

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -246,12 +246,13 @@ spawn do
 end
 
 before_all do |env|
-  begin
-    preferences = Preferences.from_json(env.request.cookies["PREFS"]?.try &.value || "{}")
+  preferences = begin
+    Preferences.from_json(env.request.cookies["PREFS"]?.try &.value || "{}")
   rescue
-    preferences = Preferences.from_json("{}")
+    Preferences.from_json("{}")
   end
 
+  env.set "preferences", preferences
   env.response.headers["X-XSS-Protection"] = "1; mode=block"
   env.response.headers["X-Content-Type-Options"] = "nosniff"
   extra_media_csp = ""
@@ -298,6 +299,7 @@ before_all do |env|
         }, HMAC_KEY, PG_DB, 1.week)
 
         preferences = user.preferences
+        env.set "preferences", preferences
 
         env.set "sid", sid
         env.set "csrf_token", csrf_token
@@ -319,6 +321,7 @@ before_all do |env|
         }, HMAC_KEY, PG_DB, 1.week)
 
         preferences = user.preferences
+        env.set "preferences", preferences
 
         env.set "sid", sid
         env.set "csrf_token", csrf_token
@@ -336,7 +339,6 @@ before_all do |env|
   preferences.dark_mode = dark_mode
   preferences.thin_mode = thin_mode
   preferences.locale = locale
-  env.set "preferences", preferences
 
   current_page = env.request.path
   if env.request.query


### PR DESCRIPTION
Fixes #1386 

Invidious has a chunk of code that runs before every request https://github.com/iv-org/invidious/blob/989317e5d399b275f4ebf28878a8a558fa23bd55/src/invidious.cr#L248

On certain requests, the whole chunk of code does not run https://github.com/iv-org/invidious/blob/989317e5d399b275f4ebf28878a8a558fa23bd55/src/invidious.cr#L269-L278

I found in at least one of them that a template is rendered ([like this one](https://github.com/iv-org/invidious/blob/989317e5d399b275f4ebf28878a8a558fa23bd55/src/invidious.cr#L5439)) and every template attempts to pull the preferences from the env. The way the code worked with the early break from the `before_all`, the preferences was not set on the env which causes an error.

This change makes sure that the preferences are set on the env before the early break. My guess is that this error has been hiding a real error.