### PR TITLE
Use the new version of lsquic.cr

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -26,7 +26,7 @@ dependencies:
     version: ~> 0.1.2
   lsquic:
     github: iv-org/lsquic.cr
-    version: ~> 2.18.1
+    version: ~> 2.18.1-1
 
 crystal: 0.35.1
 


### PR DESCRIPTION
Use: https://github.com/iv-org/lsquic.cr/releases/tag/v2.18.1-1