### PR TITLE
Fix storyboards

### DIFF
--- a/src/invidious/helpers/handlers.cr
+++ b/src/invidious/helpers/handlers.cr
@@ -61,7 +61,7 @@ class Kemal::ExceptionHandler
 end
 
 class FilteredCompressHandler < Kemal::Handler
-  exclude ["/videoplayback", "/videoplayback/*", "/vi/*", "/ggpht/*", "/api/v1/auth/notifications"]
+  exclude ["/videoplayback", "/videoplayback/*", "/vi/*", "/sb/*", "/ggpht/*", "/api/v1/auth/notifications"]
   exclude ["/api/v1/auth/notifications", "/data_control"], "POST"
 
   def call(env)


### PR DESCRIPTION
This pull request solves two issues:
- Storyboards are served from both `i.ytimg.com` and `i9.ytimg.com` but invidious currently only proxies the ones from `i.ytimg.com`
- Proxied storyboards currently don't set the Content-Type and are compressed

Note that this relies on having `config.domain` set, if it is unset storyboards will not load. For local testing it can be set to `localhost` or `0.0.0.0`.

Related issue #1342

CC @resttime @raycheung