### PR TITLE
Allow setting a custom anti-CAPTCHA API URL

### DIFF
--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -93,8 +93,9 @@ struct Config
   property admin_email : String = "omarroth@protonmail.com"        # Email for bug reports
 
   @[YAML::Field(converter: Preferences::StringToCookies)]
-  property cookies : HTTP::Cookies = HTTP::Cookies.new # Saved cookies in "name1=value1; name2=value2..." format
-  property captcha_key : String? = nil                 # Key for Anti-Captcha
+  property cookies : HTTP::Cookies = HTTP::Cookies.new               # Saved cookies in "name1=value1; name2=value2..." format
+  property captcha_key : String? = nil                               # Key for Anti-Captcha
+  property captcha_api_url : String = "https://api.anti-captcha.com" # API URL for Anti-Captcha
 
   def disabled?(option)
     case disabled = CONFIG.disable_proxy

--- a/src/invidious/jobs/bypass_captcha_job.cr
+++ b/src/invidious/jobs/bypass_captcha_job.cr
@@ -23,7 +23,8 @@ class Invidious::Jobs::BypassCaptchaJob < Invidious::Jobs::BaseJob
 
             headers = response.cookies.add_request_headers(HTTP::Headers.new)
 
-            response = JSON.parse(HTTP::Client.post("https://api.anti-captcha.com/createTask", body: {
+            response = JSON.parse(HTTP::Client.post(config.captcha_api_url + "/createTask",
+              headers: HTTP::Headers{"Content-Type" => "application/json"}, body: {
               "clientKey" => config.captcha_key,
               "task"      => {
                 "type"                => "NoCaptchaTaskProxyless",
@@ -39,7 +40,8 @@ class Invidious::Jobs::BypassCaptchaJob < Invidious::Jobs::BaseJob
             loop do
               sleep 10.seconds
 
-              response = JSON.parse(HTTP::Client.post("https://api.anti-captcha.com/getTaskResult", body: {
+              response = JSON.parse(HTTP::Client.post(config.captcha_api_url + "/getTaskResult",
+                headers: HTTP::Headers{"Content-Type" => "application/json"}, body: {
                 "clientKey" => config.captcha_key,
                 "taskId"    => task_id,
               }.to_json).body)
@@ -76,9 +78,10 @@ class Invidious::Jobs::BypassCaptchaJob < Invidious::Jobs::BaseJob
               inputs[node["name"]] = node["value"]
             end
 
-            captcha_client = HTTPClient.new(URI.parse("https://api.anti-captcha.com"))
+            captcha_client = HTTPClient.new(URI.parse(config.captcha_api_url))
             captcha_client.family = config.force_resolve || Socket::Family::INET
-            response = JSON.parse(captcha_client.post("/createTask", body: {
+            response = JSON.parse(captcha_client.post("/createTask",
+              headers: HTTP::Headers{"Content-Type" => "application/json"}, body: {
               "clientKey" => config.captcha_key,
               "task"      => {
                 "type"                => "NoCaptchaTaskProxyless",
@@ -94,7 +97,8 @@ class Invidious::Jobs::BypassCaptchaJob < Invidious::Jobs::BaseJob
             loop do
               sleep 10.seconds
 
-              response = JSON.parse(captcha_client.post("/getTaskResult", body: {
+              response = JSON.parse(captcha_client.post("/getTaskResult",
+                headers: HTTP::Headers{"Content-Type" => "application/json"}, body: {
                 "clientKey" => config.captcha_key,
                 "taskId"    => task_id,
               }.to_json).body)


### PR DESCRIPTION
In the light of #1256 I'm currently developing an alternative to Anti-Captcha.com and I cloned the API of Anti-Captcha.com.

I'll soon release the project to the community but meanwhile I created this PR for a future usage of my API or other custom Anti-Captcha API developed by other developers.

This PR is difficult to test so in order to render the task easier to test add this code after the 8th line:
```crystal
response = JSON.parse(HTTP::Client.post(config.captcha_api_url + "/createTask", 
  headers: HTTP::Headers{"Content-Type" => "application/json"}, body: {
    "clientKey" => config.captcha_key,
    "task"      => {
      "type"                => "test",
      "websiteURL"          => "https://example.com/",
      "websiteKey"          => "test"
    },
}.to_json).body)
puts response
```

This requires to have `captcha_key` parameter set to a random word or your actual Anti-Captcha key in the `config.yml`.
If you get either one of these two lines then you just have confirmed that this PR works:
- `{"errorId" => 1, "errorCode" => "ERROR_KEY_DOES_NOT_EXIST", "errorDescription" => "Account authorization key not found in the system"}`
- `{"errorId" => 23, "errorCode" => "ERROR_TASK_NOT_SUPPORTED", "errorDescription" => "Task type is not supported or inproperly printed. Please check \"type\" parameter in task object. Test your requests at https://api.anti-captcha.com/test"}`

You may also set `captcha_api_url` parameter in your `config.yml` file to `https://api.anti-captcha.com` in order to confirm that this new parameter works correctly.