### PR TITLE
Remove duplicate Referrer-Policy

### DIFF
--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -4,7 +4,6 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="referrer" content="no-referrer">
     <%= yield_content "header" %>
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=<%= ASSET_COMMIT %>">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=<%= ASSET_COMMIT %>">


### PR DESCRIPTION
A duplicate Referrer-Policy and hardcoded into the HTML is considered bad practice because it introduces a misconception about the actual referrer policy that is in place on the whole website. For instance some pages are in a specific referrer policy but other ones in another referrer policy, as an administrator this complicates the task of auditing a website in order to improve its security.

The referrer policy is already included in this line of code: https://github.com/iv-org/invidious/blob/master/src/invidious.cr#L203 and the browser will take it into accounts at the very start before even loading the HTML.

Moreover, applying the referrer policy in the headers allows the maintainer of the instance to have the flexibility of changing it using a proxy webserver like NGINX or Apache, just like it's already the case for [`Content-Security-Policy`](https://github.com/iv-org/invidious/blob/master/src/invidious.cr#L202), [`X-Content-Type-Options`](https://github.com/iv-org/invidious/blob/master/src/invidious.cr#L196) and [`X-XSS-Protection`](https://github.com/iv-org/invidious/blob/master/src/invidious.cr#L195).

Finally, security audit tools who analyse the websites will give an incorrect result of the actual referrer policy because most of them only look for the HTTP headers and not in the actual HTML code.