### PR TITLE
Switch theme on `DOMContentLoaded` event instead of `load` event

### DIFF
--- a/assets/js/themes.js
+++ b/assets/js/themes.js
@@ -22,7 +22,7 @@ window.addEventListener('storage', function (e) {
     }
 });
 
-window.addEventListener('load', function () {
+window.addEventListener('DOMContentLoaded', function () {
     window.localStorage.setItem('dark_mode', document.getElementById('dark_mode_pref').textContent);
     // Update localStorage if dark mode preference changed on preferences page
     update_mode(window.localStorage.dark_mode);


### PR DESCRIPTION
This doesn't fix the issue of the bright flash but makes it shorter.

The `load` event is fired when the page and all resources are fully
loaded while the `DOMContentLoaded` event is fired when initial HTML
document has been completely loaded and parsed, without waiting for
stylesheets, images, and subframes to finish loading.

See https://github.com/iv-org/invidious/issues/945