### PR TITLE
Fix ytInitialData parsing

### DIFF
--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -597,7 +597,7 @@ def create_notification_stream(env, topics, connection_channel)
 end
 
 def extract_initial_data(body) : Hash(String, JSON::Any)
-  initial_data = body.match(/(window\["ytInitialData"\]|var\s+ytInitialData)\s*=\s*(?<info>.*?);+\s*\n/).try &.["info"] || "{}"
+  initial_data = body.match(/(window\["ytInitialData"\]|var\s+ytInitialData)\s*=\s*(?<info>.*?);+(\s*\n|<\/script>)/m).try &.["info"] || "{}"
   if initial_data.starts_with?("JSON.parse(\"")
     return JSON.parse(JSON.parse(%({"initial_data":"#{initial_data[12..-3]}"}))["initial_data"].as_s).as_h
   else

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -839,8 +839,7 @@ def extract_polymer_config(body)
     params[f] = player_response[f] if player_response[f]?
   end
 
-  yt_initial_data = body.match(/(window\["ytInitialData"\]|var\s+ytInitialData)\s*=\s*(?<info>.*?);\s*\n/)
-    .try { |r| JSON.parse(r["info"]).as_h }
+  yt_initial_data = extract_initial_data(body)
 
   params["relatedVideos"] = yt_initial_data.try &.["playerOverlays"]?.try &.["playerOverlayRenderer"]?
     .try &.["endScreen"]?.try &.["watchNextEndScreenRenderer"]?.try &.["results"]?.try &.as_a.compact_map { |r|


### PR DESCRIPTION
This fixes two problems:
- the `ytInitialData` JSON chunk may contain newlines, fixed with the `m` flag
- the `ytInitialData` JSON chunk may be followed by `;</script>`

All parsing of `ytInitialData` now uses the `extract_initial_data` helper function. If YouTube changes things around again debugging is made easy by adding `File.new("tmp.html", body)` to `extract_initial_data`.

Closes https://github.com/iv-org/invidious/issues/1488