### PR TITLE
Add backtraces to errors

### DIFF
--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -92,7 +92,7 @@ def fetch_youtube_comments(id, db, cursor, format, locale, thin_mode, region, so
   response = JSON.parse(response.body)
 
   if !response["response"]["continuationContents"]?
-    raise translate(locale, "Could not fetch comments")
+    raise InfoException.new("Could not fetch comments")
   end
 
   response = response["response"]["continuationContents"]
@@ -266,7 +266,7 @@ def fetch_reddit_comments(id, sort_by = "confidence")
 
     thread = result[0].data.as(RedditListing).children[0].data.as(RedditLink)
   else
-    raise "Got error code #{search_results.status_code}"
+    raise InfoException.new("Could not fetch comments")
   end
 
   comments = result[1].data.as(RedditListing).children

--- a/src/invidious/helpers/errors.cr
+++ b/src/invidious/helpers/errors.cr
@@ -1,0 +1,90 @@
+# InfoExceptions are for displaying information to the user.
+#
+# An InfoException might or might not indicate that something went wrong.
+# Historically Invidious didn't differentiate between these two options, so to
+# maintain previous functionality InfoExceptions do not print backtraces.
+class InfoException < Exception
+end
+
+macro error_template(*args)
+  error_template_helper(env, config, locale, {{*args}})
+end
+
+def error_template_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, exception : Exception)
+  if exception.is_a?(InfoException)
+    return error_template_helper(env, config, locale, status_code, exception.message || "")
+  end
+  env.response.status_code = status_code
+  error_message = <<-END_HTML
+    Looks like you've found a bug in Invidious. Feel free to open a new issue
+    <a href="https://github.com/iv-org/invidious/issues">here</a>
+    or send an email to
+    <a href="mailto:#{CONFIG.admin_email}">#{CONFIG.admin_email}</a>.
+    <br>
+    <br>
+    <br>
+    Please include the following text in your message:
+    <pre style="padding: 20px; background: rgba(0, 0, 0, 0.12345);">#{exception.inspect_with_backtrace}</pre>
+  END_HTML
+  return templated "error"
+end
+
+def error_template_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, message : String)
+  env.response.status_code = status_code
+  error_message = translate(locale, message)
+  return templated "error"
+end
+
+macro error_atom(*args)
+  error_atom_helper(env, config, locale, {{*args}})
+end
+
+def error_atom_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, exception : Exception)
+  if exception.is_a?(InfoException)
+    return error_atom_helper(env, config, locale, status_code, exception.message || "")
+  end
+  env.response.content_type = "application/atom+xml"
+  env.response.status_code = status_code
+  return "<error>#{exception.inspect_with_backtrace}</error>"
+end
+
+def error_atom_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, message : String)
+  env.response.content_type = "application/atom+xml"
+  env.response.status_code = status_code
+  return "<error>#{message}</error>"
+end
+
+macro error_json(*args)
+  error_json_helper(env, config, locale, {{*args}})
+end
+
+def error_json_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, exception : Exception, additional_fields : Hash(String, Object) | Nil)
+  if exception.is_a?(InfoException)
+    return error_json_helper(env, config, locale, status_code, exception.message || "", additional_fields)
+  end
+  env.response.content_type = "application/json"
+  env.response.status_code = status_code
+  error_message = {"error" => exception.message, "errorBacktrace" => exception.inspect_with_backtrace}
+  if additional_fields
+    error_message = error_message.merge(additional_fields)
+  end
+  return error_message.to_json
+end
+
+def error_json_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, exception : Exception)
+  return error_json_helper(env, config, locale, status_code, exception, nil)
+end
+
+def error_json_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, message : String, additional_fields : Hash(String, Object) | Nil)
+  env.response.content_type = "application/json"
+  env.response.status_code = status_code
+  error_message = {"error" => message}
+  if additional_fields
+    error_message = error_message.merge(additional_fields)
+  end
+  return error_message.to_json
+end
+
+def error_json_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, message : String)
+  error_json_helper(env, config, locale, status_code, message, nil)
+end

--- a/src/invidious/mixes.cr
+++ b/src/invidious/mixes.cr
@@ -30,7 +30,7 @@ def fetch_mix(rdid, video_id, cookies = nil, locale = nil)
   initial_data = extract_initial_data(response.body)
 
   if !initial_data["contents"]["twoColumnWatchNextResults"]["playlist"]?
-    raise translate(locale, "Could not create mix.")
+    raise InfoException.new("Could not create mix.")
   end
 
   playlist = initial_data["contents"]["twoColumnWatchNextResults"]["playlist"]["playlist"]

--- a/src/invidious/routes/embed/index.cr
+++ b/src/invidious/routes/embed/index.cr
@@ -8,9 +8,7 @@ class Invidious::Routes::Embed::Index < Invidious::Routes::BaseRoute
         offset = env.params.query["index"]?.try &.to_i? || 0
         videos = get_playlist_videos(PG_DB, playlist, offset: offset, locale: locale)
       rescue ex
-        error_message = ex.message
-        env.response.status_code = 500
-        return templated "error"
+        return error_template(500, ex)
       end
 
       url = "/embed/#{videos[0].id}?#{env.params.query}"

--- a/src/invidious/routes/embed/show.cr
+++ b/src/invidious/routes/embed/show.cr
@@ -38,9 +38,7 @@ class Invidious::Routes::Embed::Show < Invidious::Routes::BaseRoute
           offset = env.params.query["index"]?.try &.to_i? || 0
           videos = get_playlist_videos(PG_DB, playlist, offset: offset, locale: locale)
         rescue ex
-          error_message = ex.message
-          env.response.status_code = 500
-          return templated "error"
+          return error_template(500, ex)
         end
 
         url = "/embed/#{videos[0].id}"
@@ -63,8 +61,7 @@ class Invidious::Routes::Embed::Show < Invidious::Routes::BaseRoute
       env.params.query.delete_all("channel")
 
       if !video_id || video_id == "live_stream"
-        error_message = "Video is unavailable."
-        return templated "error"
+        return error_template(500, "Video is unavailable.")
       end
 
       url = "/embed/#{video_id}"
@@ -100,9 +97,7 @@ class Invidious::Routes::Embed::Show < Invidious::Routes::BaseRoute
     rescue ex : VideoRedirect
       return env.redirect env.request.resource.gsub(id, ex.video_id)
     rescue ex
-      error_message = ex.message
-      env.response.status_code = 500
-      return templated "error"
+      return error_template(500, ex)
     end
 
     if preferences.annotations_subscribed &&

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -12,9 +12,7 @@ class Invidious::Routes::Watch < Invidious::Routes::BaseRoute
       id = env.params.query["v"]
 
       if env.params.query["v"].empty?
-        error_message = "Invalid parameters."
-        env.response.status_code = 400
-        return templated "error"
+        return error_template(400, "Invalid parameters.")
       end
 
       if id.size > 11
@@ -56,10 +54,8 @@ class Invidious::Routes::Watch < Invidious::Routes::BaseRoute
     rescue ex : VideoRedirect
       return env.redirect env.request.resource.gsub(id, ex.video_id)
     rescue ex
-      error_message = ex.message
-      env.response.status_code = 500
       logger.puts("#{id} : #{ex.message}")
-      return templated "error"
+      return error_template(500, ex)
     end
 
     if preferences.annotations_subscribed &&


### PR DESCRIPTION
Error handling has been reworked to always go through the new `error_template`,
`error_json` and `error_atom` macros.
They all accept a status code followed by a string message or an exception
object. `error_json` accepts a hash with additional fields as third argument.

If the second argument is an exception a backtrace will be printed, if it is a
string only the string is printed. Since up till now only the exception message
was printed a new `InfoException` class was added for situations where no
backtrace is intended but a string cannot be used.

`error_template` with a string message automatically localizes the message.
Missing error translations have been collected in https://github.com/iv-org/invidious/issues/1497
`error_json` with a string message does not localize the message. This is the
same as previous behavior. If translations are desired for `error_json` they
can be added easily but those error messages have not been collected yet.

Uncaught exceptions previously only printed a generic message ("Looks like
you've found a bug in Invidious. [...]"). They still print that message
but now also include a backtrace.