### PR TITLE
fix: channel info parsing

### DIFF
--- a/src/invidious/channels.cr
+++ b/src/invidious/channels.cr
@@ -801,11 +801,11 @@ def get_about_info(ucid, locale)
     raise InfoException.new(error_message)
   end
 
-  author = about.xpath_node(%q(//meta[@name="title"])).not_nil!["content"]
-  author_url = about.xpath_node(%q(//link[@rel="canonical"])).not_nil!["href"]
-  author_thumbnail = about.xpath_node(%q(//link[@rel="image_src"])).not_nil!["href"]
+  author = initdata["metadata"]["channelMetadataRenderer"]["title"].as_s
+  author_url = initdata["metadata"]["channelMetadataRenderer"]["channelUrl"].as_s
+  author_thumbnail = initdata["metadata"]["channelMetadataRenderer"]["avatar"]["thumbnails"][0]["url"].as_s
 
-  ucid = about.xpath_node(%q(//meta[@itemprop="channelId"])).not_nil!["content"]
+  ucid = initdata["metadata"]["channelMetadataRenderer"]["externalId"].as_s
 
   # Raises a KeyError on failure.
   banners = initdata["header"]["c4TabbedHeaderRenderer"]?.try &.["banner"]?.try &.["thumbnails"]?

--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -598,7 +598,7 @@ def create_notification_stream(env, topics, connection_channel)
 end
 
 def extract_initial_data(body) : Hash(String, JSON::Any)
-  return JSON.parse(body.match(/(window\["ytInitialData"\]|var\s*ytInitialData)\s*=\s*(JSON\.parse\(")?(?<info>\{.*?\})("\))?;/m).try &.["info"] || "{}").as_h
+  return JSON.parse(body.match(/(window\["ytInitialData"\]|var\s*ytInitialData)\s*=\s*(?<info>\{.*?\});/mx).try &.["info"] || "{}").as_h
 end
 
 def proxy_file(response, env)


### PR DESCRIPTION
Fix https://github.com/iv-org/invidious/issues/1494 and https://github.com/iv-org/invidious/issues/1505

Youtube does not always contains `channelUrl` or `avatar` from his xhtml API.
So trying to parse the xhtml may (sometime) trigger a `NilAssertionError`.
Hopefully, we are still able to collect the data from the parsed json.

Also, this patch simplified the regex since after MANY tests, `JSON\.parse\("` was never used \o/ !
But `/mx` was added instead of simply `/m`.