### PR TITLE
Improve error message 2

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -64,7 +64,7 @@ HTTP_CHUNK_SIZE            = 10485760 # ~10MB
 
 CURRENT_BRANCH  = {{ "#{`git branch | sed -n '/* /s///p'`.strip}" }}
 CURRENT_COMMIT  = {{ "#{`git rev-list HEAD --max-count=1 --abbrev-commit`.strip}" }}
-CURRENT_VERSION = {{ "#{`git describe --tags --abbrev=0`.strip}" }}
+CURRENT_VERSION = {{ "#{`git log -1 --format=%cs | sed s/-/./g`.strip}" }}
 
 # This is used to determine the `?v=` on the end of file URLs (for cache busting). We
 # only need to expire modified assets, so we can use this to find the last commit that changes


### PR DESCRIPTION
**Switch to date based versioning scheme**

Since no new tags are created for releases the version has been frozen for some
time, with only the commit hash changing.

Versions based on the latest commit date make it much easier to identify them.

**Improve error message 2**

The long backtrace has been moved into a `<details>` HTML element, as suggested
by @B0pol. To make the error still visible it has been added to the top under
`Title:`. This also encourages informative issue titles.

Closes https://github.com/iv-org/invidious/issues/1507