### PR TITLE
Fix invidious version for docker image

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -64,7 +64,7 @@ HTTP_CHUNK_SIZE            = 10485760 # ~10MB
 
 CURRENT_BRANCH  = {{ "#{`git branch | sed -n '/* /s///p'`.strip}" }}
 CURRENT_COMMIT  = {{ "#{`git rev-list HEAD --max-count=1 --abbrev-commit`.strip}" }}
-CURRENT_VERSION = {{ "#{`git log -1 --format=%ci | date -I -f - | sed s/-/./g`.strip}" }}
+CURRENT_VERSION = {{ "#{`git log -1 --format=%ci | awk '{print $1}' | sed s/-/./g`.strip}" }}
 
 # This is used to determine the `?v=` on the end of file URLs (for cache busting). We
 # only need to expire modified assets, so we can use this to find the last commit that changes


### PR DESCRIPTION
As Alpine-Linux per default uses the busybox date command, the -f option is not available and the build will fail.