### PR TITLE
Increase YouTube request timeout

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -104,7 +104,7 @@ LOCALES = {
   "zh-TW" => load_locale("zh-TW"),
 }
 
-YT_POOL = QUICPool.new(YT_URL, capacity: CONFIG.pool_size, timeout: 0.1)
+YT_POOL = QUICPool.new(YT_URL, capacity: CONFIG.pool_size, timeout: 2)
 
 config = CONFIG
 logger = Invidious::LogHandler.new

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -104,7 +104,7 @@ LOCALES = {
   "zh-TW" => load_locale("zh-TW"),
 }
 
-YT_POOL = QUICPool.new(YT_URL, capacity: CONFIG.pool_size, timeout: 2)
+YT_POOL = QUICPool.new(YT_URL, capacity: CONFIG.pool_size, timeout: 2.0)
 
 config = CONFIG
 logger = Invidious::LogHandler.new


### PR DESCRIPTION
From 0.1 seconds to 2 seconds.

The default timeout is five seconds (`QUICPool` in `src/invidious/helpers/utils.cr`)
but it seems to have been chose randomly. If reads continue to time out the
timeout can be increased again.