### PR TITLE
Fix youtube subscription import

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -1492,9 +1492,10 @@ post "/data_control" do |env|
           end
         end
       when "import_youtube"
-        subscriptions = XML.parse(body)
-        user.subscriptions += subscriptions.xpath_nodes(%q(//outline[@type="rss"])).map do |channel|
-          channel["xmlUrl"].match(/UC[a-zA-Z0-9_-]{22}/).not_nil![0]
+        subscriptions = JSON.parse(body)
+
+        user.subscriptions += subscriptions.as_a.compact_map do |entry|
+          entry["snippet"]["resourceId"]["channelId"].as_s
         end
         user.subscriptions.uniq!
 

--- a/src/invidious/views/data_control.ecr
+++ b/src/invidious/views/data_control.ecr
@@ -14,7 +14,7 @@
 
             <div class="pure-control-group">
                 <label for="import_youtube">
-                    <a rel="noopener" target="_blank" href="https://support.google.com/youtube/answer/6224202?hl=en">
+                    <a rel="noopener" target="_blank" href="https://github.com/schwukas/invidious/wiki/Export-YouTube-subscriptions">
                         <%= translate(locale, "Import YouTube subscriptions") %>
                     </a>
                 </label>

--- a/src/invidious/views/data_control.ecr
+++ b/src/invidious/views/data_control.ecr
@@ -14,7 +14,7 @@
 
             <div class="pure-control-group">
                 <label for="import_youtube">
-                    <a rel="noopener" target="_blank" href="https://github.com/schwukas/invidious/wiki/Export-YouTube-subscriptions">
+                    <a rel="noopener" target="_blank" href="https://github.com/iv-org/documentation/blob/master/Export-YouTube-subscriptions.md">
                         <%= translate(locale, "Import YouTube subscriptions") %>
                     </a>
                 </label>


### PR DESCRIPTION
This PR fixes the broken YouTube subscription import mentioned in #1301 or rather adapts the new format and structure for the parser. I also included a link to the instructions on how to export your subscriptions as a JSON file. This link is only temporary as it links to my fork but can be easily swapped for a URL to the documentation repo or similar before merging. 

There's probably a more elegant solution for parsing the JSON. Feel free to heavily criticise this, as I'm not at all familiar with Crystal. I promise I won't cry :slightly_smiling_face: 