### PR TITLE
do not proxy hls livestrem on supported browser

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -41,7 +41,15 @@ var shareOptions = {
     embedCode: "<iframe id='ivplayer' width='640' height='360' src='" + embed_url + "' style='border:none;'></iframe>"
 }
 
+videojs.Hls.xhr.beforeRequest = function(options) {
+    if (options.uri.indexOf('local=true') === -1) {
+        options.uri = options.uri + '?local=true';
+    }
+    return options;
+};
+
 var player = videojs('player', options);
+
 
 if (location.pathname.startsWith('/embed/')) {
     player.overlay({

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -197,6 +197,7 @@ before_all do |env|
   extra_media_csp = ""
   if CONFIG.disabled?("local") || !preferences.local
     extra_media_csp += " https://*.googlevideo.com:443"
+    extra_media_csp += " https://*.youtube.com:443"
   end
   # TODO: Remove style-src's 'unsafe-inline', requires to remove all inline styles (<style> [..] </style>, style=" [..] ")
   env.response.headers["Content-Security-Policy"] = "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; manifest-src 'self'; media-src 'self' blob:#{extra_media_csp}"

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -4,7 +4,7 @@
     <% if params.video_loop %>loop<% end %>
     <% if params.controls %>controls<% end %>>
     <% if (hlsvp = video.hls_manifest_url) && !CONFIG.disabled?("livestreams") %>
-        <source src="<%= URI.parse(hlsvp).full_path %>?local=true" type="application/x-mpegURL" label="livestream">
+        <source src="<%= URI.parse(hlsvp).full_path %><% if params.local %>?local=true<% end %>" type="application/x-mpegURL" label="livestream">
     <% else %>
         <% if params.listen %>
             <% audio_streams.each_with_index do |fmt, i| %>


### PR DESCRIPTION
### Issue ###

Currently, invidious proxies all livestream video data.  I have seen that the generally proxied hls livestream has poor performance and lag.  For some browsers, the browser can play hls natively, meaning we are not restricted by xhr same-origin restrictions.  Some browsers which support this:
* mobile browsers (safari, chrome, firefox  on ios and android)
* safari

### Change ###
This change allows the livestream to proceed without proxying if a supported browser is being used. If the browser is not supported, or the proxy option is selected in the options, then proxy will be used.
1. Unsupported browser - behavior should be unaffected.
1. Supported browser and proxy disabled - use native hls support and connect directly to youtube server.
1. Supported browser and proxy enabled - use native hls support and connect to proxy.


### testing ###
1. Tested on macos firefox and chrome - behavior is the same
1. Tested on macos safari - stream is not proxied unless proxy is selected in options
1. Tested on android firefox - stream is not proxied unless selected in options