### PR TITLE
Update the cryptocurrency addresses and replace the Liberapay link with a link to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@
 - No CLA
 - [Multilingual](https://hosted.weblate.org/projects/invidious/#languages) (translated into many languages)
 
+## Donate:
+
+Bitcoin (BTC): [bc1qfhe7rq3lqzuayzjxzyt9waz9ytrs09kla3tsgr](bitcoin:bc1qfhe7rq3lqzuayzjxzyt9waz9ytrs09kla3tsgr)
+
+Monero (XMR): [41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3LXqkEJBrCZBgPTwJrDp1FrZJfycGPR](monero:41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3LXqkEJBrCZBgPTwJrDp1FrZJfycGPR)
+
 ## Screenshots:
 
 | Player                                                                                                                  | Preferences                                                                                                             | Subscriptions                                                                                                               |

--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -114,15 +114,15 @@
                         </a>
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
-                        <i class="icon ion-logo-bitcoin"></i>
+                        <i class="icon wallet-outline"></i>
                         BTC: <a href="bitcoin:bc1qfhe7rq3lqzuayzjxzyt9waz9ytrs09kla3tsgr">bc1qfhe7rq3lqzuayzjxzyt9waz9ytrs09kla3tsgr</a>
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
-                        <i class="icon ion-logo-bitcoin"></i>
+                        <i class="icon wallet-outline"></i>
                         Monero: <a href="monero:41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3LXqkEJBrCZBgPTwJrDp1FrZJfycGPR">Click here</a>
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
-                        <i class="icon ion-logo-usd"></i>
+                        <i class="icon wallet-outline"></i>
                         <a href="#">Liberapay</a>
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">

--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -119,7 +119,7 @@
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
                         <i class="icon wallet-outline"></i>
-                        Monero: <a href="monero:41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3LXqkEJBrCZBgPTwJrDp1FrZJfycGPR">Click here</a>
+                        XMR: <a href="monero:41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3LXqkEJBrCZBgPTwJrDp1FrZJfycGPR">Click here</a>
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
                         <i class="icon wallet-outline"></i>

--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -122,8 +122,8 @@
                         XMR: <a href="monero:41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3LXqkEJBrCZBgPTwJrDp1FrZJfycGPR">Click here</a>
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
-                        <i class="icon wallet-outline"></i>
-                        <a href="#">Liberapay</a>
+                        <i class="icon"></i>
+                        <a href="https://github.com/iv-org/documentation">Documentation</a>
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
                         <i class="icon ion-logo-javascript"></i>

--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -115,15 +115,15 @@
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
                         <i class="icon ion-logo-bitcoin"></i>
-                        BTC: <a href="bitcoin:356DpZyMXu6rYd55Yqzjs29n79kGKWcYrY">356DpZyMXu6rYd55Yqzjs29n79kGKWcYrY</a>
+                        BTC: <a href="bitcoin:bc1qfhe7rq3lqzuayzjxzyt9waz9ytrs09kla3tsgr">bc1qfhe7rq3lqzuayzjxzyt9waz9ytrs09kla3tsgr</a>
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
                         <i class="icon ion-logo-bitcoin"></i>
-                        BCH: <a href="bitcoincash:qq4ptclkzej5eza6a50et5ggc58hxsq5aylqut2npk">qq4ptclkzej5eza6a50et5ggc58hxsq5aylqut2npk</a>
+                        Monero: <a href="monero:41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3LXqkEJBrCZBgPTwJrDp1FrZJfycGPR">Click here</a>
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
                         <i class="icon ion-logo-usd"></i>
-                        <a href="https://liberapay.com/omarroth">Liberapay</a>
+                        <a href="#">Liberapay</a>
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
                         <i class="icon ion-logo-javascript"></i>


### PR DESCRIPTION
New cryptocurrency wallets were created, this PR update the donation addresses and remove the Liberapay link ~~(but it doesn't remove the "place" where it is to avoid breaking the UI~~ **Edit:** Liberapay link replaced with a link to the documentation).

Both @Perflyst and me (@TheFrenchGhosty) have access to the wallets.

Related: https://github.com/iv-org/invidious/issues/1411

Pinging @Perflyst so that he can check that I'm indeed using the correct addresses.