### PR TITLE
Remove "Top" feed option from preferences

### DIFF
--- a/src/invidious/routes/user_preferences.cr
+++ b/src/invidious/routes/user_preferences.cr
@@ -74,7 +74,7 @@ class Invidious::Routes::UserPreferences < Invidious::Routes::BaseRoute
     default_home = env.params.body["default_home"]?.try &.as(String) || CONFIG.default_user_preferences.default_home
 
     feed_menu = [] of String
-    5.times do |index|
+    4.times do |index|
       option = env.params.body["feed_menu[#{index}]"]?.try &.as(String) || ""
       if !option.empty?
         feed_menu << option
@@ -146,7 +146,7 @@ class Invidious::Routes::UserPreferences < Invidious::Routes::BaseRoute
         config.default_user_preferences.default_home = env.params.body["admin_default_home"]?.try &.as(String) || config.default_user_preferences.default_home
 
         admin_feed_menu = [] of String
-        5.times do |index|
+        4.times do |index|
           option = env.params.body["admin_feed_menu[#{index}]"]?.try &.as(String) || ""
           if !option.empty?
             admin_feed_menu << option

--- a/src/invidious/views/preferences.ecr
+++ b/src/invidious/views/preferences.ecr
@@ -130,9 +130,9 @@
             </div>
 
             <% if env.get?("user") %>
-                <% feed_options = {"", "Popular", "Top", "Trending", "Subscriptions", "Playlists"} %>
+                <% feed_options = {"", "Popular", "Trending", "Subscriptions", "Playlists"} %>
             <% else %>
-                <% feed_options = {"", "Popular", "Top", "Trending"} %>
+                <% feed_options = {"", "Popular", "Trending"} %>
             <% end %>
 
             <div class="pure-control-group">


### PR DESCRIPTION
The Top feed used to be a feed based on YouTube ratings. Once YouTube removed
publicly available ratings the Top feed was removed from Invidious but the
option to display a link to it remained.

This change might cause the feed menu preferences to change in unexpected ways the first time preferences are updated.
- Instance admins should update the default feed menu preference to avoid any issues.
- If bug reports come in about the feed menu reordering itself they can be ignored.