### PR TITLE
Close http clients after use

### DIFF
--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -269,6 +269,8 @@ def fetch_reddit_comments(id, sort_by = "confidence")
     raise InfoException.new("Could not fetch comments")
   end
 
+  client.close
+
   comments = result[1].data.as(RedditListing).children
   return comments, thread
 end

--- a/src/invidious/helpers/proxy.cr
+++ b/src/invidious/helpers/proxy.cr
@@ -108,7 +108,9 @@ def filter_proxies(proxies)
       proxy = HTTPProxy.new(proxy_host: proxy[:ip], proxy_port: proxy[:port])
       client.set_proxy(proxy)
 
-      client.head("/").status_code == 200
+      status_ok = client.head("/").status_code == 200
+      client.close
+      status_ok
     rescue ex
       false
     end
@@ -132,6 +134,7 @@ def get_nova_proxies(country_code = "US")
   headers["Referer"] = "https://www.proxynova.com/proxy-server-list/country-#{country_code}/"
 
   response = client.get("/proxy-server-list/country-#{country_code}/", headers)
+  client.close
   document = XML.parse_html(response.body)
 
   proxies = [] of {ip: String, port: Int32, score: Float64}
@@ -177,6 +180,7 @@ def get_spys_proxies(country_code = "US")
   }
 
   response = client.post("/free-proxy-list/#{country_code}/", headers, form: body)
+  client.close
   20.times do
     if response.status_code == 200
       break

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -101,6 +101,15 @@ def make_client(url : URI, region = nil)
   return client
 end
 
+def make_client(url : URI, region = nil, &block)
+  client = make_client(url, region)
+  begin
+    yield client
+  ensure
+    client.close
+  end
+end
+
 def decode_length_seconds(string)
   length_seconds = string.gsub(/[^0-9:]/, "").split(":").map &.to_i
   length_seconds = [0] * (3 - length_seconds.size) + length_seconds
@@ -361,7 +370,7 @@ def subscribe_pubsub(topic, key, config)
     "hub.secret"        => key.to_s,
   }
 
-  return make_client(PUBSUB_URL).post("/subscribe", form: body)
+  return make_client(PUBSUB_URL, &.post("/subscribe", form: body))
 end
 
 def parse_range(range)

--- a/src/invidious/jobs/bypass_captcha_job.cr
+++ b/src/invidious/jobs/bypass_captcha_job.cr
@@ -91,6 +91,8 @@ class Invidious::Jobs::BypassCaptchaJob < Invidious::Jobs::BaseJob
               },
             }.to_json).body)
 
+            captcha_client.close
+
             raise response["error"].as_s if response["error"]?
             task_id = response["taskId"].as_i
 

--- a/src/invidious/users.cr
+++ b/src/invidious/users.cr
@@ -427,7 +427,7 @@ def generate_captcha(key, db)
 end
 
 def generate_text_captcha(key, db)
-  response = make_client(TEXTCAPTCHA_URL).get("/omarroth@protonmail.com.json").body
+  response = make_client(TEXTCAPTCHA_URL, &.get("/omarroth@protonmail.com.json").body)
   response = JSON.parse(response)
 
   tokens = response["a"].as_a.map do |answer|


### PR DESCRIPTION
The crystal http client maintains a keepalive connection to the other
server which stays alive for some time. This should be closed if the
client instance is not used again to avoid hogging resources