### PR TITLE
Add Subscription Traces

### DIFF
--- a/src/invidious/jobs/refresh_channels_job.cr
+++ b/src/invidious/jobs/refresh_channels_job.cr
@@ -7,9 +7,9 @@ class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
   end
 
   def begin
-    max_threads = config.channel_threads
-    lim_threads = max_threads
-    active_threads = 0
+    max_fibers = config.channel_threads
+    lim_fibers = max_fibers
+    active_fibers = 0
     active_channel = Channel(Bool).new
     backoff = 1.seconds
 
@@ -19,26 +19,26 @@ class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
         rs.each do
           id = rs.read(String)
 
-          if active_threads >= lim_threads
+          if active_fibers >= lim_fibers
             if active_channel.receive
-              active_threads -= 1
+              active_fibers -= 1
             end
           end
 
-          active_threads += 1
+          active_fibers += 1
           spawn do
             begin
               logger.trace("RefreshChannelsJob: Fetching channel #{id}")
               channel = fetch_channel(id, db, config.full_refresh)
 
-              lim_threads = max_threads
+              lim_fibers = max_fibers
               db.exec("UPDATE channels SET updated = $1, author = $2, deleted = false WHERE id = $3", Time.utc, channel.author, id)
             rescue ex
               logger.error("RefreshChannelsJob: #{id} : #{ex.message}")
               if ex.message == "Deleted or invalid channel"
                 db.exec("UPDATE channels SET updated = $1, deleted = true WHERE id = $2", Time.utc, id)
               else
-                lim_threads = 1
+                lim_fibers = 1
                 logger.error("RefreshChannelsJob: #{id} : backing off for #{backoff}s")
                 sleep backoff
                 if backoff < 1.days

--- a/src/invidious/jobs/refresh_channels_job.cr
+++ b/src/invidious/jobs/refresh_channels_job.cr
@@ -20,18 +20,23 @@ class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
           id = rs.read(String)
 
           if active_fibers >= lim_fibers
+            logger.trace("RefreshChannelsJob: Fiber limit reached, waiting...")
             if active_channel.receive
+              logger.trace("RefreshChannelsJob: Fiber limit ok, continuing")
               active_fibers -= 1
             end
           end
 
+          logger.trace("RefreshChannelsJob: #{id} : Spawning fiber")
           active_fibers += 1
           spawn do
             begin
-              logger.trace("RefreshChannelsJob: Fetching channel #{id}")
-              channel = fetch_channel(id, db, config.full_refresh)
+              logger.trace("RefreshChannelsJob: #{id} fiber : Fetching channel")
+              channel = fetch_channel(id, db, logger, config.full_refresh)
 
               lim_fibers = max_fibers
+
+              logger.trace("RefreshChannelsJob: #{id} fiber : Updating DB")
               db.exec("UPDATE channels SET updated = $1, author = $2, deleted = false WHERE id = $3", Time.utc, channel.author, id)
             rescue ex
               logger.error("RefreshChannelsJob: #{id} : #{ex.message}")
@@ -39,7 +44,7 @@ class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
                 db.exec("UPDATE channels SET updated = $1, deleted = true WHERE id = $2", Time.utc, id)
               else
                 lim_fibers = 1
-                logger.error("RefreshChannelsJob: #{id} : backing off for #{backoff}s")
+                logger.error("RefreshChannelsJob: #{id} fiber : backing off for #{backoff}s")
                 sleep backoff
                 if backoff < 1.days
                   backoff += backoff
@@ -47,13 +52,15 @@ class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
                   backoff = 1.days
                 end
               end
+            ensure
+              logger.trace("RefreshChannelsJob: #{id} fiber : Done")
+              active_channel.send(true)
             end
-
-            active_channel.send(true)
           end
         end
       end
 
+      logger.debug("RefreshChannelsJob: Done, sleeping for one minute")
       sleep 1.minute
       Fiber.yield
     end

--- a/src/invidious/jobs/refresh_feeds_job.cr
+++ b/src/invidious/jobs/refresh_feeds_job.cr
@@ -7,8 +7,8 @@ class Invidious::Jobs::RefreshFeedsJob < Invidious::Jobs::BaseJob
   end
 
   def begin
-    max_threads = config.feed_threads
-    active_threads = 0
+    max_fibers = config.feed_threads
+    active_fibers = 0
     active_channel = Channel(Bool).new
 
     loop do
@@ -17,13 +17,13 @@ class Invidious::Jobs::RefreshFeedsJob < Invidious::Jobs::BaseJob
           email = rs.read(String)
           view_name = "subscriptions_#{sha256(email)}"
 
-          if active_threads >= max_threads
+          if active_fibers >= max_fibers
             if active_channel.receive
-              active_threads -= 1
+              active_fibers -= 1
             end
           end
 
-          active_threads += 1
+          active_fibers += 1
           spawn do
             begin
               # Drop outdated views

--- a/src/invidious/jobs/subscribe_to_feeds_job.cr
+++ b/src/invidious/jobs/subscribe_to_feeds_job.cr
@@ -8,12 +8,12 @@ class Invidious::Jobs::SubscribeToFeedsJob < Invidious::Jobs::BaseJob
   end
 
   def begin
-    max_threads = 1
+    max_fibers = 1
     if config.use_pubsub_feeds.is_a?(Int32)
-      max_threads = config.use_pubsub_feeds.as(Int32)
+      max_fibers = config.use_pubsub_feeds.as(Int32)
     end
 
-    active_threads = 0
+    active_fibers = 0
     active_channel = Channel(Bool).new
 
     loop do
@@ -21,13 +21,13 @@ class Invidious::Jobs::SubscribeToFeedsJob < Invidious::Jobs::BaseJob
         rs.each do
           ucid = rs.read(String)
 
-          if active_threads >= max_threads.as(Int32)
+          if active_fibers >= max_fibers.as(Int32)
             if active_channel.receive
-              active_threads -= 1
+              active_fibers -= 1
             end
           end
 
-          active_threads += 1
+          active_fibers += 1
 
           spawn do
             begin

--- a/src/invidious/routes/login.cr
+++ b/src/invidious/routes/login.cr
@@ -267,7 +267,7 @@ class Invidious::Routes::Login < Invidious::Routes::BaseRoute
           raise "Couldn't get SID."
         end
 
-        user, sid = get_user(sid, headers, PG_DB)
+        user, sid = get_user(sid, headers, PG_DB, logger)
 
         # We are now logged in
         traceback << "done.<br/>"

--- a/src/invidious/users.cr
+++ b/src/invidious/users.cr
@@ -269,12 +269,12 @@ struct Preferences
   end
 end
 
-def get_user(sid, headers, db, refresh = true)
+def get_user(sid, headers, db, logger, refresh = true)
   if email = db.query_one?("SELECT email FROM session_ids WHERE id = $1", sid, as: String)
     user = db.query_one("SELECT * FROM users WHERE email = $1", email, as: User)
 
     if refresh && Time.utc - user.updated > 1.minute
-      user, sid = fetch_user(sid, headers, db)
+      user, sid = fetch_user(sid, headers, db, logger)
       user_array = user.to_a
       user_array[4] = user_array[4].to_json # User preferences
       args = arg_array(user_array)
@@ -292,7 +292,7 @@ def get_user(sid, headers, db, refresh = true)
       end
     end
   else
-    user, sid = fetch_user(sid, headers, db)
+    user, sid = fetch_user(sid, headers, db, logger)
     user_array = user.to_a
     user_array[4] = user_array[4].to_json # User preferences
     args = arg_array(user.to_a)
@@ -313,7 +313,7 @@ def get_user(sid, headers, db, refresh = true)
   return user, sid
 end
 
-def fetch_user(sid, headers, db)
+def fetch_user(sid, headers, db, logger)
   feed = YT_POOL.client &.get("/subscription_manager?disable_polymer=1", headers)
   feed = XML.parse_html(feed.body)
 
@@ -326,7 +326,7 @@ def fetch_user(sid, headers, db)
     end
   end
 
-  channels = get_batch_channels(channels, db, false, false)
+  channels = get_batch_channels(channels, db, logger, false, false)
 
   email = feed.xpath_node(%q(//a[@class="yt-masthead-picker-header yt-masthead-picker-active-account"]))
   if email


### PR DESCRIPTION
**Rename threads to fibers**

The config and command line options haven't been changed.

**Add RefreshChannelsJob traces**

Traces can be enabled with `-l trace`.

The problem with subscriptions is that sometimes requests to YouTube never
finish. As soon as that happens `channel-threads` times subscriptions stop
being refreshed. This is most likely a problem with the lsquick bindings.

