### PR TITLE
Add `popular-enabled` option

### DIFF
--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -60,7 +60,7 @@ struct ConfigPreferences
   end
 end
 
-struct Config
+class Config
   include YAML::Serializable
 
   property channel_threads : Int32                 # Number of threads to use for crawling videos from channels (for updating subscriptions)
@@ -71,6 +71,7 @@ struct Config
   property hmac_key : String?                      # HMAC signing key for CSRF tokens and verifying pubsub subscriptions
   property domain : String?                        # Domain to be used for links to resources on the site where an absolute URL is required
   property use_pubsub_feeds : Bool | Int32 = false # Subscribe to channels using PubSubHubbub (requires domain, hmac_key)
+  property popular_enabled : Bool = true
   property captcha_enabled : Bool = true
   property login_enabled : Bool = true
   property registration_enabled : Bool = true

--- a/src/invidious/routes/home.cr
+++ b/src/invidious/routes/home.cr
@@ -5,30 +5,24 @@ class Invidious::Routes::Home < Invidious::Routes::BaseRoute
     user = env.get? "user"
 
     case preferences.default_home
-    when ""
-      templated "empty"
     when "Popular"
-      templated "popular"
+      env.redirect "/feed/popular"
     when "Trending"
       env.redirect "/feed/trending"
     when "Subscriptions"
       if user
         env.redirect "/feed/subscriptions"
       else
-        templated "popular"
+        env.redirect "/feed/popular"
       end
     when "Playlists"
       if user
         env.redirect "/view_all_playlists"
       else
-        templated "popular"
+        env.redirect "/feed/popular"
       end
     else
       templated "empty"
     end
-  end
-
-  private def popular_videos
-    Jobs::PullPopularVideosJob::POPULAR_VIDEOS.get
   end
 end

--- a/src/invidious/routes/user_preferences.cr
+++ b/src/invidious/routes/user_preferences.cr
@@ -154,6 +154,10 @@ class Invidious::Routes::UserPreferences < Invidious::Routes::BaseRoute
         end
         config.default_user_preferences.feed_menu = admin_feed_menu
 
+        popular_enabled = env.params.body["popular_enabled"]?.try &.as(String)
+        popular_enabled ||= "off"
+        config.popular_enabled = popular_enabled == "on"
+
         captcha_enabled = env.params.body["captcha_enabled"]?.try &.as(String)
         captcha_enabled ||= "off"
         config.captcha_enabled = captcha_enabled == "on"

--- a/src/invidious/views/message.ecr
+++ b/src/invidious/views/message.ecr
@@ -1,0 +1,12 @@
+<% content_for "header" do %>
+<meta name="description" content="<%= translate(locale, "An alternative front-end to YouTube") %>">
+<title>
+    Invidious
+</title>
+<% end %>
+
+<%= rendered "components/feed_menu" %>
+
+<p>
+    <%= message %>
+</p>

--- a/src/invidious/views/preferences.ecr
+++ b/src/invidious/views/preferences.ecr
@@ -228,6 +228,12 @@
                 </div>
 
                 <div class="pure-control-group">
+                    <label for="popular_enabled"><%= translate(locale, "Popular enabled: ") %></label>
+                    <input name="popular_enabled" id="popular_enabled" type="checkbox" <% if config.popular_enabled %>checked<% end %>>
+                </div>
+
+
+                <div class="pure-control-group">
                     <label for="captcha_enabled"><%= translate(locale, "CAPTCHA enabled: ") %></label>
                     <input name="captcha_enabled" id="captcha_enabled" type="checkbox" <% if config.captcha_enabled %>checked<% end %>>
                 </div>


### PR DESCRIPTION
This is similar to the removed `top-enabled` option but for the Popular feed.
The instance needs to be restarted if the feed was enabled.

Editing admin options on the preferences page is also fixed.

The handling of the feed pages now only happens in a single place.

Instead of redirecting:
  - The Top feed now displays a message that it was removed from Invidious.
  - The Popular feed now displays a message that it was disabled if it was.