### PR TITLE
do not add local to xhr when in videoplayback

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -42,7 +42,7 @@ var shareOptions = {
 }
 
 videojs.Hls.xhr.beforeRequest = function(options) {
-    if (options.uri.indexOf('local=true') === -1) {
+    if (options.uri.indexOf('videoplayback') === -1 && options.uri.indexOf('local=true') === -1) {
         options.uri = options.uri + '?local=true';
     }
     return options;


### PR DESCRIPTION
I previously added this logic to allow the frontend to automatically distignuish if native hls is possible and use proxy if not (we must always use proxy for xhr due to cors)  We do not need to have this for the videoplayback call it is only needed for the playlist call to get the proxied media urls.

I also thought this would only apply to hls because in the javascript it says videojs.Hls.xhr.beforeRequest but it seems to affect the dash as well.

On some systems, other people reported issues caused by this on the videoplayback endpoint so I make it only do it for the manifest.
#1569 