### PR TITLE
Fix watch videos

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -2621,6 +2621,8 @@ end
 
     begin
       playlist = get_playlist(PG_DB, plid, locale)
+    rescue ex : InfoException
+      next error_json(404, ex)
     rescue ex
       next error_json(404, "Playlist does not exist.")
     end

--- a/src/invidious/helpers/errors.cr
+++ b/src/invidious/helpers/errors.cr
@@ -26,6 +26,7 @@ def error_template_helper(env : HTTP::Server::Context, config : Config, locale :
   if exception.is_a?(InfoException)
     return error_template_helper(env, config, locale, status_code, exception.message || "")
   end
+  env.response.content_type = "text/html"
   env.response.status_code = status_code
   issue_template = %(Title: `#{exception.message} (#{exception.class})`)
   issue_template += %(\nDate: `#{Time::Format::ISO_8601_DATE_TIME.format(Time.utc)}`)
@@ -43,6 +44,7 @@ def error_template_helper(env : HTTP::Server::Context, config : Config, locale :
 end
 
 def error_template_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, message : String)
+  env.response.content_type = "text/html"
   env.response.status_code = status_code
   error_message = translate(locale, message)
   return templated "error"


### PR DESCRIPTION
**Set content type for HTML error helpers**

This fixes `Unexpected char '<' at 1:1` errors caused by content type mismatch.

**Fix `watch_videos` endpoint**

Playlists created by `watch_videos` do not have an author which caused a crash
previously.

