### PR TITLE
Fix downloads

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -3372,7 +3372,7 @@ get "/latest_version" do |env|
       env.redirect "/api/v1/captions/#{id}?label=#{label}&title=#{title}"
       next
     else
-      itag = download_widget["itag"].as_s
+      itag = download_widget["itag"].as_s.to_i
       local = "true"
     end
   end


### PR DESCRIPTION
The `itag` is now converted to a number, matching the `itag` of
`Video.adaptive_fmts` and `Video.fmt_stream`.