### PR TITLE
save host when using dash manifest

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -3190,7 +3190,8 @@ get "/api/manifest/dash/id/:id" do |env|
       url = url.rchop("</BaseURL>")
 
       if local
-        url = URI.parse(url).full_path
+        uri = URI.parse(url)
+        url = "#{uri.full_path}host/#{uri.host}/"
       end
 
       "<BaseURL>#{url}</BaseURL>"


### PR DESCRIPTION
In the case that the dash manifest is provided by youtube, we just chop the host off and then guess it later by using the mn and fvip query args

https://github.com/iv-org/invidious/blob/master/src/invidious.cr#L3486

I found that there are situations where that doesn't give the correct host, and we get a host not found error.  Instead, we should put the host in the query args like we do for the other proxy requests so the invidious instance hits exactly the host that was originally specified in the manifest.