### PR TITLE
Support "Database URL" in addition to existing DB-related parameters

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -6,6 +6,8 @@ db:
   host: localhost
   port: 5432
   dbname: invidious
+# alternatively, you can also set the URL directly - if both are provided then the latter takes precedence
+# database_url: postgres://kemal:kemal@localhost:5432/invidious
 full_refresh: false
 https_only: false
 domain:

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -162,8 +162,13 @@ end
 
 # Start jobs
 
-Invidious::Jobs.register Invidious::Jobs::RefreshChannelsJob.new(PG_DB)
-Invidious::Jobs.register Invidious::Jobs::RefreshFeedsJob.new(PG_DB)
+if CONFIG.channel_threads > 0
+  Invidious::Jobs.register Invidious::Jobs::RefreshChannelsJob.new(PG_DB)
+end
+
+if CONFIG.feed_threads > 0
+  Invidious::Jobs.register Invidious::Jobs::RefreshFeedsJob.new(PG_DB)
+end
 
 DECRYPT_FUNCTION = DecryptFunction.new(CONFIG.decrypt_polling)
 if CONFIG.decrypt_polling

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -30,11 +30,8 @@ require "./invidious/*"
 require "./invidious/routes/**"
 require "./invidious/jobs/**"
 
-ENV_CONFIG_NAME = "INVIDIOUS_CONFIG"
-
-CONFIG_STR = ENV.has_key?(ENV_CONFIG_NAME) ? ENV.fetch(ENV_CONFIG_NAME) : File.read("config/config.yml")
-CONFIG     = Config.from_yaml(CONFIG_STR)
-HMAC_KEY   = CONFIG.hmac_key || Random::Secure.hex(32)
+CONFIG   = Config.load
+HMAC_KEY = CONFIG.hmac_key || Random::Secure.hex(32)
 
 PG_URL = URI.new(
   scheme: "postgres",

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -33,16 +33,7 @@ require "./invidious/jobs/**"
 CONFIG   = Config.load
 HMAC_KEY = CONFIG.hmac_key || Random::Secure.hex(32)
 
-PG_URL = URI.new(
-  scheme: "postgres",
-  user: CONFIG.db.user,
-  password: CONFIG.db.password,
-  host: CONFIG.db.host,
-  port: CONFIG.db.port,
-  path: CONFIG.db.dbname,
-)
-
-PG_DB           = DB.open PG_URL
+PG_DB           = DB.open CONFIG.database_url
 ARCHIVE_URL     = URI.parse("https://archive.org")
 LOGIN_URL       = URI.parse("https://accounts.google.com")
 PUBSUB_URL      = URI.parse("https://pubsubhubbub.appspot.com")
@@ -192,7 +183,7 @@ if CONFIG.captcha_key
 end
 
 connection_channel = Channel({Bool, Channel(PQ::Notification)}).new(32)
-Invidious::Jobs.register Invidious::Jobs::NotificationJob.new(connection_channel, PG_URL)
+Invidious::Jobs.register Invidious::Jobs::NotificationJob.new(connection_channel, CONFIG.database_url)
 
 Invidious::Jobs.start_all
 

--- a/src/invidious/helpers/errors.cr
+++ b/src/invidious/helpers/errors.cr
@@ -7,7 +7,7 @@ class InfoException < Exception
 end
 
 macro error_template(*args)
-  error_template_helper(env, config, locale, {{*args}})
+  error_template_helper(env, locale, {{*args}})
 end
 
 def github_details(summary : String, content : String)
@@ -22,9 +22,9 @@ def github_details(summary : String, content : String)
   return HTML.escape(details)
 end
 
-def error_template_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, exception : Exception)
+def error_template_helper(env : HTTP::Server::Context, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, exception : Exception)
   if exception.is_a?(InfoException)
-    return error_template_helper(env, config, locale, status_code, exception.message || "")
+    return error_template_helper(env, locale, status_code, exception.message || "")
   end
   env.response.content_type = "text/html"
   env.response.status_code = status_code
@@ -43,7 +43,7 @@ def error_template_helper(env : HTTP::Server::Context, config : Config, locale :
   return templated "error"
 end
 
-def error_template_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, message : String)
+def error_template_helper(env : HTTP::Server::Context, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, message : String)
   env.response.content_type = "text/html"
   env.response.status_code = status_code
   error_message = translate(locale, message)
@@ -51,31 +51,31 @@ def error_template_helper(env : HTTP::Server::Context, config : Config, locale :
 end
 
 macro error_atom(*args)
-  error_atom_helper(env, config, locale, {{*args}})
+  error_atom_helper(env, locale, {{*args}})
 end
 
-def error_atom_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, exception : Exception)
+def error_atom_helper(env : HTTP::Server::Context, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, exception : Exception)
   if exception.is_a?(InfoException)
-    return error_atom_helper(env, config, locale, status_code, exception.message || "")
+    return error_atom_helper(env, locale, status_code, exception.message || "")
   end
   env.response.content_type = "application/atom+xml"
   env.response.status_code = status_code
   return "<error>#{exception.inspect_with_backtrace}</error>"
 end
 
-def error_atom_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, message : String)
+def error_atom_helper(env : HTTP::Server::Context, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, message : String)
   env.response.content_type = "application/atom+xml"
   env.response.status_code = status_code
   return "<error>#{message}</error>"
 end
 
 macro error_json(*args)
-  error_json_helper(env, config, locale, {{*args}})
+  error_json_helper(env, locale, {{*args}})
 end
 
-def error_json_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, exception : Exception, additional_fields : Hash(String, Object) | Nil)
+def error_json_helper(env : HTTP::Server::Context, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, exception : Exception, additional_fields : Hash(String, Object) | Nil)
   if exception.is_a?(InfoException)
-    return error_json_helper(env, config, locale, status_code, exception.message || "", additional_fields)
+    return error_json_helper(env, locale, status_code, exception.message || "", additional_fields)
   end
   env.response.content_type = "application/json"
   env.response.status_code = status_code
@@ -86,11 +86,11 @@ def error_json_helper(env : HTTP::Server::Context, config : Config, locale : Has
   return error_message.to_json
 end
 
-def error_json_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, exception : Exception)
-  return error_json_helper(env, config, locale, status_code, exception, nil)
+def error_json_helper(env : HTTP::Server::Context, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, exception : Exception)
+  return error_json_helper(env, locale, status_code, exception, nil)
 end
 
-def error_json_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, message : String, additional_fields : Hash(String, Object) | Nil)
+def error_json_helper(env : HTTP::Server::Context, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, message : String, additional_fields : Hash(String, Object) | Nil)
   env.response.content_type = "application/json"
   env.response.status_code = status_code
   error_message = {"error" => message}
@@ -100,6 +100,6 @@ def error_json_helper(env : HTTP::Server::Context, config : Config, locale : Has
   return error_message.to_json
 end
 
-def error_json_helper(env : HTTP::Server::Context, config : Config, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, message : String)
-  error_json_helper(env, config, locale, status_code, message, nil)
+def error_json_helper(env : HTTP::Server::Context, locale : Hash(String, JSON::Any) | Nil, status_code : Int32, message : String)
+  error_json_helper(env, locale, status_code, message, nil)
 end

--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -115,6 +115,63 @@ class Config
       return false
     end
   end
+
+  def self.load
+    # Load config from file or YAML string env var
+    env_config_file = "INVIDIOUS_CONFIG_FILE"
+    env_config_yaml = "INVIDIOUS_CONFIG"
+
+    config_file = ENV.has_key?(env_config_file) ? ENV.fetch(env_config_file) : "config/config.yml"
+    config_yaml = ENV.has_key?(env_config_yaml) ? ENV.fetch(env_config_yaml) : File.read(config_file)
+
+    config = Config.from_yaml(config_yaml)
+
+    # Update config from env vars (upcased and prefixed with "INVIDIOUS_")
+    {% for ivar in Config.instance_vars %}
+        {% env_id = "INVIDIOUS_#{ivar.id.upcase}" %}
+
+        if ENV.has_key?({{env_id}})
+            # puts %(Config.{{ivar.id}} : Loading from env var {{env_id}})
+            env_value = ENV.fetch({{env_id}})
+            success = false
+
+            # Use YAML converter if specified
+            {% ann = ivar.annotation(::YAML::Field) %}
+            {% if ann && ann[:converter] %}
+                puts %(Config.{{ivar.id}} : Parsing "#{env_value}" as {{ivar.type}} with {{ann[:converter]}} converter)
+                config.{{ivar.id}} = {{ann[:converter]}}.from_yaml(YAML::ParseContext.new, YAML::Nodes.parse(ENV.fetch({{env_id}})).nodes[0])
+                puts %(Config.{{ivar.id}} : Set to #{config.{{ivar.id}}})
+                success = true
+
+            # Use regular YAML parser otherwise
+            {% else %}
+                {% ivar_types = ivar.type.union? ? ivar.type.union_types : [ivar.type] %}
+                # Sort types to avoid parsing nulls and numbers as strings
+                {% ivar_types = ivar_types.sort_by { |ivar_type| ivar_type == Nil ? 0 : ivar_type == Int32 ? 1 : 2 } %}
+                {{ivar_types}}.each do |ivar_type|
+                    if !success
+                        begin
+                            # puts %(Config.{{ivar.id}} : Trying to parse "#{env_value}" as #{ivar_type})
+                            config.{{ivar.id}} = ivar_type.from_yaml(env_value)
+                            puts %(Config.{{ivar.id}} : Set to #{config.{{ivar.id}}} (#{ivar_type}))
+                            success = true
+                        rescue
+                            # nop
+                        end
+                    end
+                end
+            {% end %}
+
+            # Exit on fail
+            if !success
+                puts %(Config.{{ivar.id}} failed to parse #{env_value} as {{ivar.type}})
+                exit(1)
+            end
+        end
+    {% end %}
+
+    return config
+  end
 end
 
 struct DBConfig

--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -225,7 +225,7 @@ def extract_item(item : JSON::Any, author_fallback : String? = nil, author_id_fa
     author = i["title"]["simpleText"]?.try &.as_s || author_fallback || ""
     author_id = i["channelId"]?.try &.as_s || author_id_fallback || ""
 
-    author_thumbnail = i["thumbnail"]["thumbnails"]?.try &.as_a[0]?.try { |u| "https:#{u["url"]}" } || ""
+    author_thumbnail = i["thumbnail"]["thumbnails"]?.try &.as_a[0]?.try &.["url"]?.try &.as_s || ""
     subscriber_count = i["subscriberCountText"]?.try &.["simpleText"]?.try &.as_s.try { |s| short_text_to_number(s.split(" ")[0]) } || 0
 
     auto_generated = false

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -280,9 +280,9 @@ def arg_array(array, start = 1)
   return args
 end
 
-def make_host_url(config, kemal_config)
-  ssl = config.https_only || kemal_config.ssl
-  port = config.external_port || kemal_config.port
+def make_host_url(kemal_config)
+  ssl = CONFIG.https_only || kemal_config.ssl
+  port = CONFIG.external_port || kemal_config.port
 
   if ssl
     scheme = "https://"
@@ -297,11 +297,11 @@ def make_host_url(config, kemal_config)
     port = ""
   end
 
-  if !config.domain
+  if !CONFIG.domain
     return ""
   end
 
-  host = config.domain.not_nil!.lchop(".")
+  host = CONFIG.domain.not_nil!.lchop(".")
 
   return "#{scheme}#{host}#{port}"
 end
@@ -345,7 +345,7 @@ def sha256(text)
   return digest.final.hexstring
 end
 
-def subscribe_pubsub(topic, key, config)
+def subscribe_pubsub(topic, key)
   case topic
   when .match(/^UC[A-Za-z0-9_-]{22}$/)
     topic = "channel_id=#{topic}"

--- a/src/invidious/jobs/refresh_channels_job.cr
+++ b/src/invidious/jobs/refresh_channels_job.cr
@@ -1,12 +1,11 @@
 class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
   private getter db : DB::Database
-  private getter config : Config
 
-  def initialize(@db, @config)
+  def initialize(@db)
   end
 
   def begin
-    max_fibers = config.channel_threads
+    max_fibers = CONFIG.channel_threads
     lim_fibers = max_fibers
     active_fibers = 0
     active_channel = Channel(Bool).new
@@ -31,7 +30,7 @@ class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
           spawn do
             begin
               LOGGER.trace("RefreshChannelsJob: #{id} fiber : Fetching channel")
-              channel = fetch_channel(id, db, config.full_refresh)
+              channel = fetch_channel(id, db, CONFIG.full_refresh)
 
               lim_fibers = max_fibers
 

--- a/src/invidious/jobs/refresh_feeds_job.cr
+++ b/src/invidious/jobs/refresh_feeds_job.cr
@@ -1,12 +1,11 @@
 class Invidious::Jobs::RefreshFeedsJob < Invidious::Jobs::BaseJob
   private getter db : DB::Database
-  private getter config : Config
 
-  def initialize(@db, @config)
+  def initialize(@db)
   end
 
   def begin
-    max_fibers = config.feed_threads
+    max_fibers = CONFIG.feed_threads
     active_fibers = 0
     active_channel = Channel(Bool).new
 

--- a/src/invidious/jobs/statistics_refresh_job.cr
+++ b/src/invidious/jobs/statistics_refresh_job.cr
@@ -21,9 +21,8 @@ class Invidious::Jobs::StatisticsRefreshJob < Invidious::Jobs::BaseJob
   }
 
   private getter db : DB::Database
-  private getter config : Config
 
-  def initialize(@db, @config, @software_config : Hash(String, String))
+  def initialize(@db, @software_config : Hash(String, String))
   end
 
   def begin
@@ -43,7 +42,7 @@ class Invidious::Jobs::StatisticsRefreshJob < Invidious::Jobs::BaseJob
       "version" => @software_config["version"],
       "branch"  => @software_config["branch"],
     }
-    STATISTICS["openRegistration"] = config.registration_enabled
+    STATISTICS["openRegistration"] = CONFIG.registration_enabled
   end
 
   private def refresh_stats

--- a/src/invidious/jobs/subscribe_to_feeds_job.cr
+++ b/src/invidious/jobs/subscribe_to_feeds_job.cr
@@ -1,15 +1,14 @@
 class Invidious::Jobs::SubscribeToFeedsJob < Invidious::Jobs::BaseJob
   private getter db : DB::Database
   private getter hmac_key : String
-  private getter config : Config
 
-  def initialize(@db, @config, @hmac_key)
+  def initialize(@db, @hmac_key)
   end
 
   def begin
     max_fibers = 1
-    if config.use_pubsub_feeds.is_a?(Int32)
-      max_fibers = config.use_pubsub_feeds.as(Int32)
+    if CONFIG.use_pubsub_feeds.is_a?(Int32)
+      max_fibers = CONFIG.use_pubsub_feeds.as(Int32)
     end
 
     active_fibers = 0
@@ -30,7 +29,7 @@ class Invidious::Jobs::SubscribeToFeedsJob < Invidious::Jobs::BaseJob
 
           spawn do
             begin
-              response = subscribe_pubsub(ucid, hmac_key, config)
+              response = subscribe_pubsub(ucid, hmac_key)
 
               if response.status_code >= 400
                 LOGGER.error("SubscribeToFeedsJob: #{ucid} : #{response.body}")

--- a/src/invidious/routes/base_route.cr
+++ b/src/invidious/routes/base_route.cr
@@ -1,6 +1,2 @@
 abstract class Invidious::Routes::BaseRoute
-  private getter config : Config
-
-  def initialize(@config)
-  end
 end

--- a/src/invidious/routes/login.cr
+++ b/src/invidious/routes/login.cr
@@ -6,7 +6,7 @@ class Invidious::Routes::Login < Invidious::Routes::BaseRoute
 
     return env.redirect "/feed/subscriptions" if user
 
-    if !config.login_enabled
+    if !CONFIG.login_enabled
       return error_template(400, "Login has been disabled by administrator.")
     end
 
@@ -33,7 +33,7 @@ class Invidious::Routes::Login < Invidious::Routes::BaseRoute
 
     referer = get_referer(env, "/feed/subscriptions")
 
-    if !config.login_enabled
+    if !CONFIG.login_enabled
       return error_template(403, "Login has been disabled by administrator.")
     end
 
@@ -274,14 +274,14 @@ class Invidious::Routes::Login < Invidious::Routes::BaseRoute
 
         host = URI.parse(env.request.headers["Host"]).host
 
-        if Kemal.config.ssl || config.https_only
+        if Kemal.config.ssl || CONFIG.https_only
           secure = true
         else
           secure = false
         end
 
         cookies.each do |cookie|
-          if Kemal.config.ssl || config.https_only
+          if Kemal.config.ssl || CONFIG.https_only
             cookie.secure = secure
           else
             cookie.secure = secure
@@ -330,14 +330,14 @@ class Invidious::Routes::Login < Invidious::Routes::BaseRoute
           sid = Base64.urlsafe_encode(Random::Secure.random_bytes(32))
           PG_DB.exec("INSERT INTO session_ids VALUES ($1, $2, $3)", sid, email, Time.utc)
 
-          if Kemal.config.ssl || config.https_only
+          if Kemal.config.ssl || CONFIG.https_only
             secure = true
           else
             secure = false
           end
 
-          if config.domain
-            env.response.cookies["SID"] = HTTP::Cookie.new(name: "SID", domain: "#{config.domain}", value: sid, expires: Time.utc + 2.years,
+          if CONFIG.domain
+            env.response.cookies["SID"] = HTTP::Cookie.new(name: "SID", domain: "#{CONFIG.domain}", value: sid, expires: Time.utc + 2.years,
               secure: secure, http_only: true)
           else
             env.response.cookies["SID"] = HTTP::Cookie.new(name: "SID", value: sid, expires: Time.utc + 2.years,
@@ -354,7 +354,7 @@ class Invidious::Routes::Login < Invidious::Routes::BaseRoute
           env.response.cookies << cookie
         end
       else
-        if !config.registration_enabled
+        if !CONFIG.registration_enabled
           return error_template(400, "Registration has been disabled by administrator.")
         end
 
@@ -369,7 +369,7 @@ class Invidious::Routes::Login < Invidious::Routes::BaseRoute
 
         password = password.byte_slice(0, 55)
 
-        if config.captcha_enabled
+        if CONFIG.captcha_enabled
           captcha_type = env.params.body["captcha_type"]?
           answer = env.params.body["answer"]?
           change_type = env.params.body["change_type"]?
@@ -445,14 +445,14 @@ class Invidious::Routes::Login < Invidious::Routes::BaseRoute
         view_name = "subscriptions_#{sha256(user.email)}"
         PG_DB.exec("CREATE MATERIALIZED VIEW #{view_name} AS #{MATERIALIZED_VIEW_SQL.call(user.email)}")
 
-        if Kemal.config.ssl || config.https_only
+        if Kemal.config.ssl || CONFIG.https_only
           secure = true
         else
           secure = false
         end
 
-        if config.domain
-          env.response.cookies["SID"] = HTTP::Cookie.new(name: "SID", domain: "#{config.domain}", value: sid, expires: Time.utc + 2.years,
+        if CONFIG.domain
+          env.response.cookies["SID"] = HTTP::Cookie.new(name: "SID", domain: "#{CONFIG.domain}", value: sid, expires: Time.utc + 2.years,
             secure: secure, http_only: true)
         else
           env.response.cookies["SID"] = HTTP::Cookie.new(name: "SID", value: sid, expires: Time.utc + 2.years,

--- a/src/invidious/routes/user_preferences.cr
+++ b/src/invidious/routes/user_preferences.cr
@@ -146,8 +146,8 @@ class Invidious::Routes::UserPreferences < Invidious::Routes::BaseRoute
       user = user.as(User)
       PG_DB.exec("UPDATE users SET preferences = $1 WHERE email = $2", preferences, user.email)
 
-      if config.admins.includes? user.email
-        config.default_user_preferences.default_home = env.params.body["admin_default_home"]?.try &.as(String) || config.default_user_preferences.default_home
+      if CONFIG.admins.includes? user.email
+        CONFIG.default_user_preferences.default_home = env.params.body["admin_default_home"]?.try &.as(String) || CONFIG.default_user_preferences.default_home
 
         admin_feed_menu = [] of String
         4.times do |index|
@@ -156,40 +156,39 @@ class Invidious::Routes::UserPreferences < Invidious::Routes::BaseRoute
             admin_feed_menu << option
           end
         end
-        config.default_user_preferences.feed_menu = admin_feed_menu
+        CONFIG.default_user_preferences.feed_menu = admin_feed_menu
 
         popular_enabled = env.params.body["popular_enabled"]?.try &.as(String)
         popular_enabled ||= "off"
-        config.popular_enabled = popular_enabled == "on"
+        CONFIG.popular_enabled = popular_enabled == "on"
 
         captcha_enabled = env.params.body["captcha_enabled"]?.try &.as(String)
         captcha_enabled ||= "off"
-        config.captcha_enabled = captcha_enabled == "on"
+        CONFIG.captcha_enabled = captcha_enabled == "on"
 
         login_enabled = env.params.body["login_enabled"]?.try &.as(String)
         login_enabled ||= "off"
-        config.login_enabled = login_enabled == "on"
+        CONFIG.login_enabled = login_enabled == "on"
 
         registration_enabled = env.params.body["registration_enabled"]?.try &.as(String)
         registration_enabled ||= "off"
-        config.registration_enabled = registration_enabled == "on"
+        CONFIG.registration_enabled = registration_enabled == "on"
 
         statistics_enabled = env.params.body["statistics_enabled"]?.try &.as(String)
         statistics_enabled ||= "off"
-        config.statistics_enabled = statistics_enabled == "on"
+        CONFIG.statistics_enabled = statistics_enabled == "on"
 
-        CONFIG.default_user_preferences = config.default_user_preferences
-        File.write("config/config.yml", config.to_yaml)
+        File.write("config/config.yml", CONFIG.to_yaml)
       end
     else
-      if Kemal.config.ssl || config.https_only
+      if Kemal.config.ssl || CONFIG.https_only
         secure = true
       else
         secure = false
       end
 
-      if config.domain
-        env.response.cookies["PREFS"] = HTTP::Cookie.new(name: "PREFS", domain: "#{config.domain}", value: preferences, expires: Time.utc + 2.years,
+      if CONFIG.domain
+        env.response.cookies["PREFS"] = HTTP::Cookie.new(name: "PREFS", domain: "#{CONFIG.domain}", value: preferences, expires: Time.utc + 2.years,
           secure: secure, http_only: true)
       else
         env.response.cookies["PREFS"] = HTTP::Cookie.new(name: "PREFS", value: preferences, expires: Time.utc + 2.years,
@@ -234,14 +233,14 @@ class Invidious::Routes::UserPreferences < Invidious::Routes::BaseRoute
 
       preferences = preferences.to_json
 
-      if Kemal.config.ssl || config.https_only
+      if Kemal.config.ssl || CONFIG.https_only
         secure = true
       else
         secure = false
       end
 
-      if config.domain
-        env.response.cookies["PREFS"] = HTTP::Cookie.new(name: "PREFS", domain: "#{config.domain}", value: preferences, expires: Time.utc + 2.years,
+      if CONFIG.domain
+        env.response.cookies["PREFS"] = HTTP::Cookie.new(name: "PREFS", domain: "#{CONFIG.domain}", value: preferences, expires: Time.utc + 2.years,
           secure: secure, http_only: true)
       else
         env.response.cookies["PREFS"] = HTTP::Cookie.new(name: "PREFS", value: preferences, expires: Time.utc + 2.years,

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -1,14 +1,14 @@
 module Invidious::Routing
   macro get(path, controller, method = :handle)
     get {{ path }} do |env|
-      controller_instance = {{ controller }}.new(config)
+      controller_instance = {{ controller }}.new
       controller_instance.{{ method.id }}(env)
     end
   end
 
   macro post(path, controller, method = :handle)
     post {{ path }} do |env|
-      controller_instance = {{ controller }}.new(config)
+      controller_instance = {{ controller }}.new
       controller_instance.{{ method.id }}(env)
     end
   end

--- a/src/invidious/users.cr
+++ b/src/invidious/users.cr
@@ -173,6 +173,20 @@ struct Preferences
     end
   end
 
+  module URIConverter
+    def self.to_yaml(value : URI, yaml : YAML::Nodes::Builder)
+      yaml.scalar value.normalize!
+    end
+
+    def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : URI
+      if node.is_a?(YAML::Nodes::Scalar)
+        URI.parse node.value
+      else
+        node.raise "Expected scalar, not #{node.class}"
+      end
+    end
+  end
+
   module ProcessString
     def self.to_json(value : String, json : JSON::Builder)
       json.string value

--- a/src/invidious/views/preferences.ecr
+++ b/src/invidious/views/preferences.ecr
@@ -208,14 +208,14 @@
                 </div>
 
                 <% # Web notifications are only supported over HTTPS %>
-                <% if Kemal.config.ssl || config.https_only %>
+                <% if Kemal.config.ssl || CONFIG.https_only %>
                     <div class="pure-control-group">
                         <a href="#" data-onclick="notification_requestPermission"><%= translate(locale, "Enable web notifications") %></a>
                     </div>
                 <% end %>
             <% end %>
 
-            <% if env.get?("user") && config.admins.includes? env.get?("user").as(User).email %>
+            <% if env.get?("user") && CONFIG.admins.includes? env.get?("user").as(User).email %>
                 <legend><%= translate(locale, "Administrator preferences") %></legend>
 
                 <div class="pure-control-group">
@@ -240,28 +240,28 @@
 
                 <div class="pure-control-group">
                     <label for="popular_enabled"><%= translate(locale, "Popular enabled: ") %></label>
-                    <input name="popular_enabled" id="popular_enabled" type="checkbox" <% if config.popular_enabled %>checked<% end %>>
+                    <input name="popular_enabled" id="popular_enabled" type="checkbox" <% if CONFIG.popular_enabled %>checked<% end %>>
                 </div>
 
 
                 <div class="pure-control-group">
                     <label for="captcha_enabled"><%= translate(locale, "CAPTCHA enabled: ") %></label>
-                    <input name="captcha_enabled" id="captcha_enabled" type="checkbox" <% if config.captcha_enabled %>checked<% end %>>
+                    <input name="captcha_enabled" id="captcha_enabled" type="checkbox" <% if CONFIG.captcha_enabled %>checked<% end %>>
                 </div>
 
                 <div class="pure-control-group">
                     <label for="login_enabled"><%= translate(locale, "Login enabled: ") %></label>
-                    <input name="login_enabled" id="login_enabled" type="checkbox" <% if config.login_enabled %>checked<% end %>>
+                    <input name="login_enabled" id="login_enabled" type="checkbox" <% if CONFIG.login_enabled %>checked<% end %>>
                 </div>
 
                 <div class="pure-control-group">
                     <label for="registration_enabled"><%= translate(locale, "Registration enabled: ") %></label>
-                    <input name="registration_enabled" id="registration_enabled" type="checkbox" <% if config.registration_enabled %>checked<% end %>>
+                    <input name="registration_enabled" id="registration_enabled" type="checkbox" <% if CONFIG.registration_enabled %>checked<% end %>>
                 </div>
 
                 <div class="pure-control-group">
                     <label for="statistics_enabled"><%= translate(locale, "Report statistics: ") %></label>
-                    <input name="statistics_enabled" id="statistics_enabled" type="checkbox" <% if config.statistics_enabled %>checked<% end %>>
+                    <input name="statistics_enabled" id="statistics_enabled" type="checkbox" <% if CONFIG.statistics_enabled %>checked<% end %>>
                 </div>
             <% end %>
 

--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -87,7 +87,7 @@
                                 <i class="icon ion-ios-cog"></i>
                             </a>
                         </div>
-                        <% if config.login_enabled %>
+                        <% if CONFIG.login_enabled %>
                             <div class="pure-u-1-3">
                                 <a href="/login?referer=<%= env.get?("current_page") %>" class="pure-menu-heading">
                                     <%= translate(locale, "Log in") %>


### PR DESCRIPTION
This PR adds support for using a `database_url` parameter (commonplace in other web frameworks, and recommended by the ["12-factor app" manifest](https://12factor.net/backing-services)) for configuring the DB instead of using separate parameters. This is to facilitate running Invidious in PaaS environments such as Heroku or its self-hosted alternatives ([Dokku](http://dokku.viewdocs.io/dokku/) in my case).

This parameter can be provided in the YAML config (and in the environment as `INVIDIOUS_DATABASE_URL` thanks to a separate PR that's already been merged). The existing `db` structure is also supported, so the change should be backwards-compatible. Note that if both are provided, then the `database_url` takes precedence over the `db` structure.