### PR TITLE
Make DB migrations idempotent.

### DIFF
--- a/config/sql/annotations.sql
+++ b/config/sql/annotations.sql
@@ -2,11 +2,11 @@
 
 -- DROP TABLE public.annotations;
 
-CREATE TABLE public.annotations
+CREATE TABLE IF NOT EXISTS public.annotations
 (
   id text NOT NULL,
   annotations xml,
   CONSTRAINT annotations_id_key UNIQUE (id)
 );
 
-GRANT ALL ON TABLE public.annotations TO kemal;
+GRANT ALL ON TABLE public.annotations TO current_user;

--- a/config/sql/channel_videos.sql
+++ b/config/sql/channel_videos.sql
@@ -2,7 +2,7 @@
 
 -- DROP TABLE public.channel_videos;
 
-CREATE TABLE public.channel_videos
+CREATE TABLE IF NOT EXISTS public.channel_videos
 (
   id text NOT NULL,
   title text,
@@ -17,13 +17,13 @@ CREATE TABLE public.channel_videos
   CONSTRAINT channel_videos_id_key UNIQUE (id)
 );
 
-GRANT ALL ON TABLE public.channel_videos TO kemal;
+GRANT ALL ON TABLE public.channel_videos TO current_user;
 
 -- Index: public.channel_videos_ucid_idx
 
 -- DROP INDEX public.channel_videos_ucid_idx;
 
-CREATE INDEX channel_videos_ucid_idx
+CREATE INDEX IF NOT EXISTS channel_videos_ucid_idx
   ON public.channel_videos
   USING btree
   (ucid COLLATE pg_catalog."default");

--- a/config/sql/channels.sql
+++ b/config/sql/channels.sql
@@ -2,7 +2,7 @@
 
 -- DROP TABLE public.channels;
 
-CREATE TABLE public.channels
+CREATE TABLE IF NOT EXISTS public.channels
 (
   id text NOT NULL,
   author text,
@@ -12,13 +12,13 @@ CREATE TABLE public.channels
   CONSTRAINT channels_id_key UNIQUE (id)
 );
 
-GRANT ALL ON TABLE public.channels TO kemal;
+GRANT ALL ON TABLE public.channels TO current_user;
 
 -- Index: public.channels_id_idx
 
 -- DROP INDEX public.channels_id_idx;
 
-CREATE INDEX channels_id_idx
+CREATE INDEX IF NOT EXISTS channels_id_idx
   ON public.channels
   USING btree
   (id COLLATE pg_catalog."default");

--- a/config/sql/nonces.sql
+++ b/config/sql/nonces.sql
@@ -2,20 +2,20 @@
 
 -- DROP TABLE public.nonces;
 
-CREATE TABLE public.nonces
+CREATE TABLE IF NOT EXISTS public.nonces
 (
   nonce text,
   expire timestamp with time zone,
   CONSTRAINT nonces_id_key UNIQUE (nonce)
 );
 
-GRANT ALL ON TABLE public.nonces TO kemal;
+GRANT ALL ON TABLE public.nonces TO current_user;
 
 -- Index: public.nonces_nonce_idx
 
 -- DROP INDEX public.nonces_nonce_idx;
 
-CREATE INDEX nonces_nonce_idx
+CREATE INDEX IF NOT EXISTS nonces_nonce_idx
   ON public.nonces
   USING btree
   (nonce COLLATE pg_catalog."default");

--- a/config/sql/playlist_videos.sql
+++ b/config/sql/playlist_videos.sql
@@ -2,7 +2,7 @@
 
 -- DROP TABLE public.playlist_videos;
 
-CREATE TABLE playlist_videos
+CREATE TABLE IF NOT EXISTS playlist_videos
 (
     title text,
     id text,
@@ -16,4 +16,4 @@ CREATE TABLE playlist_videos
     PRIMARY KEY (index,plid)
 );
 
-GRANT ALL ON TABLE public.playlist_videos TO kemal;
+GRANT ALL ON TABLE public.playlist_videos TO current_user;

--- a/config/sql/playlists.sql
+++ b/config/sql/playlists.sql
@@ -13,7 +13,7 @@ CREATE TYPE public.privacy AS ENUM
 
 -- DROP TABLE public.playlists;
 
-CREATE TABLE public.playlists
+CREATE TABLE IF NOT EXISTS public.playlists
 (
     title text,
     id text primary key,
@@ -26,4 +26,4 @@ CREATE TABLE public.playlists
     index int8[]
 );
 
-GRANT ALL ON public.playlists TO kemal;
+GRANT ALL ON public.playlists TO current_user;

--- a/config/sql/session_ids.sql
+++ b/config/sql/session_ids.sql
@@ -2,7 +2,7 @@
 
 -- DROP TABLE public.session_ids;
 
-CREATE TABLE public.session_ids
+CREATE TABLE IF NOT EXISTS public.session_ids
 (
   id text NOT NULL,
   email text,
@@ -10,13 +10,13 @@ CREATE TABLE public.session_ids
   CONSTRAINT session_ids_pkey PRIMARY KEY (id)
 );
 
-GRANT ALL ON TABLE public.session_ids TO kemal;
+GRANT ALL ON TABLE public.session_ids TO current_user;
 
 -- Index: public.session_ids_id_idx
 
 -- DROP INDEX public.session_ids_id_idx;
 
-CREATE INDEX session_ids_id_idx
+CREATE INDEX IF NOT EXISTS session_ids_id_idx
   ON public.session_ids
   USING btree
   (id COLLATE pg_catalog."default");

--- a/config/sql/users.sql
+++ b/config/sql/users.sql
@@ -2,7 +2,7 @@
 
 -- DROP TABLE public.users;
 
-CREATE TABLE public.users
+CREATE TABLE IF NOT EXISTS public.users
 (
   updated timestamp with time zone,
   notifications text[],
@@ -16,13 +16,13 @@ CREATE TABLE public.users
   CONSTRAINT users_email_key UNIQUE (email)
 );
 
-GRANT ALL ON TABLE public.users TO kemal;
+GRANT ALL ON TABLE public.users TO current_user;
 
 -- Index: public.email_unique_idx
 
 -- DROP INDEX public.email_unique_idx;
 
-CREATE UNIQUE INDEX email_unique_idx
+CREATE UNIQUE INDEX IF NOT EXISTS email_unique_idx
   ON public.users
   USING btree
   (lower(email) COLLATE pg_catalog."default");

--- a/config/sql/videos.sql
+++ b/config/sql/videos.sql
@@ -2,7 +2,7 @@
 
 -- DROP TABLE public.videos;
 
-CREATE TABLE public.videos
+CREATE TABLE IF NOT EXISTS public.videos
 (
   id text NOT NULL,
   info text,
@@ -10,13 +10,13 @@ CREATE TABLE public.videos
   CONSTRAINT videos_pkey PRIMARY KEY (id)
 );
 
-GRANT ALL ON TABLE public.videos TO kemal;
+GRANT ALL ON TABLE public.videos TO current_user;
 
 -- Index: public.id_idx
 
 -- DROP INDEX public.id_idx;
 
-CREATE UNIQUE INDEX id_idx
+CREATE UNIQUE INDEX IF NOT EXISTS id_idx
   ON public.videos
   USING btree
   (id COLLATE pg_catalog."default");

--- a/docker/init-invidious-db.sh
+++ b/docker/init-invidious-db.sh
@@ -5,12 +5,12 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
   CREATE USER postgres;
 EOSQL
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/channels.sql
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/videos.sql
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/channel_videos.sql
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/users.sql
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/session_ids.sql
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/nonces.sql
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/annotations.sql
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/playlists.sql
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/playlist_videos.sql
+psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/channels.sql
+psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/videos.sql
+psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/channel_videos.sql
+psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/users.sql
+psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/session_ids.sql
+psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/nonces.sql
+psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/annotations.sql
+psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/playlists.sql
+psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/playlist_videos.sql


### PR DESCRIPTION
Fixes #1772

This is more of a discussion than anything else - the provided code will work and maybe should be merged, but I don't think it's a complete solution.

Currently we don't seem to have a good system for database migrations. The scripts in `config/migrate-scripts` seem to be written manually, hardcode a database name and username, expect to be ran on the local machine and don't use the SQL files in `config/sql` (so it's one extra thing that needs to be manually kept in sync). They're also not aware of the current database state, so an automated deployment pipeline can't tell whether it needs to run them (or if they were already applied) and the SQL in there doesn't seem to be idempotent which means it will fail because those tables are already there.

I don't think implementing our own migration system is the way to go. If Crystal has something "standard" for it I suggest we use that, otherwise we could consider [Alembic](https://alembic.sqlalchemy.org/en/latest/)?

The reason behind this is that I'm trying (well, I've succeeded - with workarounds and hacks) to deploy Invidious on a PaaS such as Dokku. The PaaS deploy process allows you to run a "post-release" command which is where database migrations should go. Most web frameworks automatically detect which migrations are applied so it's safe to run the command on every deploy even if no migrations are pending; unfortunately Invidious does not have this. This change makes the migrations idempotent (by using `IF NOT EXISTS` on the create statements) so any subsequent runs will not error out.