### PR TITLE
Remove HTTPS from channel thumbnail in search

### DIFF
--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -225,7 +225,7 @@ def extract_item(item : JSON::Any, author_fallback : String? = nil, author_id_fa
     author = i["title"]["simpleText"]?.try &.as_s || author_fallback || ""
     author_id = i["channelId"]?.try &.as_s || author_id_fallback || ""
 
-    author_thumbnail = i["thumbnail"]["thumbnails"]?.try &.as_a[0]?.try { |u| "https:#{u["url"]}" } || ""
+    author_thumbnail = i["thumbnail"]["thumbnails"]?.try &.as_a[0]?.try &.["url"]?.try &.as_s || ""
     subscriber_count = i["subscriberCountText"]?.try &.["simpleText"]?.try &.as_s.try { |s| short_text_to_number(s.split(" ")[0]) } || 0
 
     auto_generated = false


### PR DESCRIPTION
Update the handling to the channel thumbnail in search to be consistent with other pages (video, channel).  The url from yt may have either https or nothing at the front, and this causes breakages when it is already there.  See: /search?q=ai+channel  This channel thumbnail is handled correctly when viewing the channel and videos, but not in search.

All of the usages of this call URI.full_path anyways, so this code does not give us any benefit.

Fixes #1704 

