### PR TITLE
Use large thumbnail for channels in search

### DIFF
--- a/src/invidious/views/components/item.ecr
+++ b/src/invidious/views/components/item.ecr
@@ -5,7 +5,7 @@
             <a style="width:100%" href="/channel/<%= item.ucid %>">
                 <% if !env.get("preferences").as(Preferences).thin_mode %>
                     <center>
-                        <img style="width:56.25%" src="/ggpht<%= URI.parse(item.author_thumbnail).request_target %>"/>
+                        <img style="width:56.25%" src="/ggpht<%= URI.parse(item.author_thumbnail).request_target.gsub(/=s\d+/, "=s176") %>"/>
                     </center>
                 <% end %>
                 <p><%= item.author %></p>


### PR DESCRIPTION
This uses a larger thumbnail resolution in the search results for channels, so it is not so pixellated.  This is a dynamic endpoint on yt side, so any resolution can be specified, but I use 176 because that is what yt uses.

Fixes #1705 