### PR TITLE
Fix broken build - install crystal 35.1 in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       
       - name: Install Crystal
         uses: oprypin/install-crystal@v1.2.4
+        with:
+          crystal: 0.35.1
       
       - name: Cache Shards
         uses: actions/cache@v2


### PR DESCRIPTION
The crystal 36.0 release introduced several breaking changes which fail the build, including #1719.

The long term solution should be to update the code to be compatible with the crystal changes, but for the short term this resolves the failing build.