### PR TITLE
Support "Database URL" in addition to existing DB-related parameters

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -6,6 +6,8 @@ db:
   host: localhost
   port: 5432
   dbname: invidious
+# alternatively, the database URL can be provided directly - if both are set then the latter takes precedence
+# database_url: postgres://kemal:kemal@localhost:5432/invidious
 full_refresh: false
 https_only: false
 domain:

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -33,16 +33,7 @@ require "./invidious/jobs/**"
 CONFIG   = Config.load
 HMAC_KEY = CONFIG.hmac_key || Random::Secure.hex(32)
 
-PG_URL = URI.new(
-  scheme: "postgres",
-  user: CONFIG.db.user,
-  password: CONFIG.db.password,
-  host: CONFIG.db.host,
-  port: CONFIG.db.port,
-  path: CONFIG.db.dbname,
-)
-
-PG_DB           = DB.open PG_URL
+PG_DB           = DB.open CONFIG.database_url
 ARCHIVE_URL     = URI.parse("https://archive.org")
 LOGIN_URL       = URI.parse("https://accounts.google.com")
 PUBSUB_URL      = URI.parse("https://pubsubhubbub.appspot.com")
@@ -192,7 +183,7 @@ if CONFIG.captcha_key
 end
 
 connection_channel = Channel({Bool, Channel(PQ::Notification)}).new(32)
-Invidious::Jobs.register Invidious::Jobs::NotificationJob.new(connection_channel, PG_URL)
+Invidious::Jobs.register Invidious::Jobs::NotificationJob.new(connection_channel, CONFIG.database_url)
 
 Invidious::Jobs.start_all
 

--- a/src/invidious/users.cr
+++ b/src/invidious/users.cr
@@ -173,6 +173,20 @@ struct Preferences
     end
   end
 
+  module URIConverter
+    def self.to_yaml(value : URI, yaml : YAML::Nodes::Builder)
+      yaml.scalar value.normalize!
+    end
+
+    def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : URI
+      if node.is_a?(YAML::Nodes::Scalar)
+        URI.parse node.value
+      else
+        node.raise "Expected scalar, not #{node.class}"
+      end
+    end
+  end
+
   module ProcessString
     def self.to_json(value : String, json : JSON::Builder)
       json.string value


### PR DESCRIPTION
This PR adds support for using a database_url parameter (commonplace in other web frameworks, and recommended by the "12-factor app" manifest) for configuring the DB instead of using separate parameters. This is to facilitate running Invidious in PaaS environments such as Heroku or its self-hosted alternatives (Dokku in my case).

This parameter can be provided in the YAML config (and in the environment as INVIDIOUS_DATABASE_URL thanks to a separate PR that's already been merged). The existing db structure is also supported, so the change should be backwards-compatible. Note that if both are provided, then the database_url takes precedence over the db structure.

Continued from [this PR](https://github.com/iv-org/invidious/pull/1676), which was trashed due to a screwup on my part and the easiest fix was just to start on a fresh branch.