### PR TITLE
Add link[rel="alternate"] pointing to YouTube version

### DIFF
--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -22,6 +22,7 @@
 <meta name="twitter:player" content="<%= HOST_URL %>/embed/<%= video.id %>">
 <meta name="twitter:player:width" content="1280">
 <meta name="twitter:player:height" content="720">
+<link rel="alternate" href="https://www.youtube.com/watch?v=<%= video.id %>">
 <%= rendered "components/player_sources" %>
 <title><%= HTML.escape(video.title) %> - Invidious</title>
 <% end %>


### PR DESCRIPTION
I propose adding a `<link>` element (or a `Link` HTTP header, maybe) pointing to YouTube version of a video.

Right now, automated user agents (like youtube-dl) have to keep [a list of known Invidious instances][1], which gets out of date sometimes and needs to be kept in sync manually. This PR would allow them to know that this is a YouTube video and they can directly download it from there (youtube-dl doesn't do that yet, but I'm working on implementing this).

[1]: https://github.com/ytdl-org/youtube-dl/blob/8bf9591a70757c624a8ea5bf686040ed752246e0/youtube_dl/extractor/youtube.py#L353-L388