### PR TITLE
Unrequire `logger`

### DIFF
--- a/src/invidious/helpers/logger.cr
+++ b/src/invidious/helpers/logger.cr
@@ -1,5 +1,3 @@
-require "logger"
-
 enum LogLevel
   All   = 0
   Trace = 1


### PR DESCRIPTION
Crystal's `Logger` was required but never used in Invidious. Crystal 0.36.0
removed `Logger` in favor of `Log`.

Closes #1719.