### PR TITLE
Use UTC for published date

### DIFF
--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -517,7 +517,7 @@ struct Video
   end
 
   def published : Time
-    info["microformat"]?.try &.["playerMicroformatRenderer"]?.try &.["publishDate"]?.try { |t| Time.parse(t.as_s, "%Y-%m-%d", Time::Location.local) } || Time.local
+    info["microformat"]?.try &.["playerMicroformatRenderer"]?.try &.["publishDate"]?.try { |t| Time.parse(t.as_s, "%Y-%m-%d", Time::Location::UTC) } || Time.utc
   end
 
   def published=(other : Time)


### PR DESCRIPTION
Fixes #1796

Could someone test that if not based in CET timezone?
http://localhost:3000/api/v1/videos/MQNMWCJ1Tjg?fields=published should be 1593129600