### PR TITLE
do not preload captions

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -21,6 +21,7 @@ var options = {
         ]
     },
     html5: {
+        preloadTextTracks: false,
         hls: {
             overrideNative: true
         }
@@ -546,4 +547,11 @@ window.addEventListener('keydown', e => {
 // Since videojs-share can sometimes be blocked, we defer it until last
 if (player.share) {
     player.share(shareOptions);
+}
+
+// show the preferred caption by default
+if (player_data.preferred_caption_found) {
+    player.ready(() => {
+        player.textTracks()[1].mode = 'showing';
+    });
 }

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -24,9 +24,9 @@
             <% end %>
         <% end %>
 
-        <% preferred_captions.each_with_index do |caption, i| %>
+        <% preferred_captions.each do |caption| %>
             <track kind="captions" src="/api/v1/captions/<%= video.id %>?label=<%= caption.name.simpleText %>&hl=<%= env.get("preferences").as(Preferences).locale %>"
-                label="<%= caption.name.simpleText %>" <% if i == 0 %>default<% end %>>
+                label="<%= caption.name.simpleText %>">
         <% end %>
 
         <% captions.each do |caption| %>
@@ -42,7 +42,8 @@
     "aspect_ratio" => aspect_ratio,
     "title" => video.title,
     "description" => HTML.escape(video.short_description),
-    "thumbnail" => thumbnail
+    "thumbnail" => thumbnail,
+    "preferred_caption_found" => !preferred_captions.empty?
 }.to_pretty_json
 %>
 </script>


### PR DESCRIPTION
## Overview
It seems like preloading all of the captions for all of the languages is running into some bot detection or rate limit.  This adds the videojs option not to preload the captions.

There is a videojs bug that makes the default caption have an issue when this option is enabled.  https://github.com/videojs/video.js/issues/7019  In order to mitigate this, I removed the default and simply show the default caption using js.

## Testing
* Tested with no preferred caption, and able to select captions during the video
* Tested with a preferred caption, which works fine
* tested with a preferred caption which doesn't exist on the video, then a second-preferred which does. This works as expected.

Fixes #1703, fixes #1707 (hopefully)