### PR TITLE
Massively enhance the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,33 @@
 # Invidious
 
-[![Build Status](https://github.com/iv-org/invidious/workflows/Invidious%20CI/badge.svg)](https://github.com/iv-org/invidious/actions) [![Translation Status](https://hosted.weblate.org/widgets/invidious/-/translations/svg-badge.svg)](https://hosted.weblate.org/engage/invidious/)
+---
 
 ## Invidious is an alternative front-end to YouTube
 
+---
+
+[![Build Status](https://github.com/iv-org/invidious/workflows/Invidious%20CI/badge.svg)](https://github.com/iv-org/invidious/actions) [![Translation Status](https://hosted.weblate.org/widgets/invidious/-/translations/svg-badge.svg)](https://hosted.weblate.org/engage/invidious/)
+
+---
+
 ## Invidious instances:
 
-[Public Invidious instances are listed here.](https://github.com/iv-org/documentation/blob/master/Invidious-Instances.md)
+Public Invidious instances are listed on the documentation website: https://docs.invidious.io/Invidious-Instances.md
+
+---
 
 ## Invidious features:
 
 - [Copylefted libre software](https://github.com/iv-org/invidious) (AGPLv3+ licensed)
-- Audio-only mode (and no need to keep window open on mobile)
 - Lightweight (the homepage is ~4 KB compressed)
+- Javascript is 100% optional
 - Tools for managing subscriptions:
   - Only show unseen videos
   - Only show latest (or latest unseen) video from each channel
   - Delivers notifications from all subscribed channels
   - Automatically redirect homepage to feed
   - Import subscriptions from YouTube
+- Audio-only mode (and no need to keep window open on mobile)
 - Dark mode
 - Embed support
 - Set default player options (speed, quality, autoplay, loop)
@@ -26,18 +35,13 @@
 - Import/Export subscriptions, watch history, preferences
 - [Developer API](https://github.com/iv-org/documentation/blob/master/API.md)
 - Does not use any of the official YouTube APIs
-- Does not require JavaScript to play videos
 - No need to create a Google account to save subscriptions
 - No ads
-- No CoC
-- No CLA
-- [Multilingual](https://hosted.weblate.org/projects/invidious/#languages) (translated into many languages)
+- No Code of Conduct
+- No Contributor license Agreement
+- Available in many language thanks to [Weblate](https://hosted.weblate.org/projects/)invidious/
 
-## Donate:
-
-Bitcoin (BTC): [bc1qfhe7rq3lqzuayzjxzyt9waz9ytrs09kla3tsgr](bitcoin:bc1qfhe7rq3lqzuayzjxzyt9waz9ytrs09kla3tsgr)
-
-Monero (XMR): [41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3LXqkEJBrCZBgPTwJrDp1FrZJfycGPR](monero:41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3LXqkEJBrCZBgPTwJrDp1FrZJfycGPR)
+---
 
 ## Screenshots:
 
@@ -46,197 +50,27 @@ Monero (XMR): [41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3
 | [<img src="screenshots/01_player.png?raw=true" height="140" width="280">](screenshots/01_player.png?raw=true)           | [<img src="screenshots/02_preferences.png?raw=true" height="140" width="280">](screenshots/02_preferences.png?raw=true) | [<img src="screenshots/03_subscriptions.png?raw=true" height="140" width="280">](screenshots/03_subscriptions.png?raw=true) |
 | [<img src="screenshots/04_description.png?raw=true" height="140" width="280">](screenshots/04_description.png?raw=true) | [<img src="screenshots/05_preferences.png?raw=true" height="140" width="280">](screenshots/05_preferences.png?raw=true) | [<img src="screenshots/06_subscriptions.png?raw=true" height="140" width="280">](screenshots/06_subscriptions.png?raw=true) |
 
-## Installation:
+---
 
-To manually compile invidious you need at least 2GB of RAM. If you have less you can setup SWAP to have a combined amount of 2 GB or use Docker instead.
+## Donate:
 
-After installation take a look at the [Post-install steps](#post-install-configuration).
+Bitcoin (BTC): [bc1qfhe7rq3lqzuayzjxzyt9waz9ytrs09kla3tsgr](bitcoin:bc1qfhe7rq3lqzuayzjxzyt9waz9ytrs09kla3tsgr)
 
-### Automated installation:
+Monero (XMR): [41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3LXqkEJBrCZBgPTwJrDp1FrZJfycGPR](monero:41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3LXqkEJBrCZBgPTwJrDp1FrZJfycGPR)
 
-[Invidious-Updater](https://github.com/tmiland/Invidious-Updater) is a self-contained script that can automatically install and update Invidious.
-
-### Docker:
-
-#### Build and start cluster:
-
-```bash
-$ docker-compose up
-```
-
-Then visit `localhost:3000` in your browser.
-
-#### Rebuild cluster:
-
-```bash
-$ docker-compose build
-```
-
-#### Delete data and rebuild:
-
-```bash
-$ docker volume rm invidious_postgresdata
-$ docker-compose build
-```
-
-### Manual installation:
-
-### Linux:
-
-#### Install the dependencies
-
-```bash
-# Arch Linux
-$ sudo pacman -S base-devel shards crystal librsvg postgresql
-
-# Ubuntu or Debian
-# First you have to add the repository to your APT configuration. For easy setup just run in your command line:
-$ curl -fsSL https://crystal-lang.org/install.sh | sudo bash
-# That will add the signing key and the repository configuration. If you prefer to do it manually, Follow the instructions here https://crystal-lang.org/install
-$ sudo apt-get update
-$ sudo apt install crystal libssl-dev libxml2-dev libyaml-dev libgmp-dev libreadline-dev postgresql librsvg2-bin libsqlite3-dev zlib1g-dev
-```
-
-#### Add an Invidious user and clone the repository
-
-```bash
-$ useradd -m invidious
-$ sudo -i -u invidious
-$ git clone https://github.com/iv-org/invidious
-$ exit
-```
-
-#### Set up PostgresSQL
-
-```bash
-$ sudo systemctl enable --now postgresql
-$ sudo -i -u postgres
-$ psql -c "CREATE USER kemal WITH PASSWORD 'kemal';" # Change 'kemal' here to a stronger password, and update `password` in config/config.yml
-$ createdb -O kemal invidious
-$ psql invidious kemal < /home/invidious/invidious/config/sql/channels.sql
-$ psql invidious kemal < /home/invidious/invidious/config/sql/videos.sql
-$ psql invidious kemal < /home/invidious/invidious/config/sql/channel_videos.sql
-$ psql invidious kemal < /home/invidious/invidious/config/sql/users.sql
-$ psql invidious kemal < /home/invidious/invidious/config/sql/session_ids.sql
-$ psql invidious kemal < /home/invidious/invidious/config/sql/nonces.sql
-$ psql invidious kemal < /home/invidious/invidious/config/sql/annotations.sql
-$ psql invidious kemal < /home/invidious/invidious/config/sql/playlists.sql
-$ psql invidious kemal < /home/invidious/invidious/config/sql/playlist_videos.sql
-$ exit
-```
-
-#### Set up Invidious
-
-```bash
-$ sudo -i -u invidious
-$ cd invidious
-$ shards update && shards install
-$ crystal build src/invidious.cr --release
-# test compiled binary
-$ ./invidious # stop with ctrl c
-$ exit
-```
-
-#### Systemd service:
-
-```bash
-$ sudo cp /home/invidious/invidious/invidious.service /etc/systemd/system/invidious.service
-$ sudo systemctl enable --now invidious.service
-```
-
-#### Logrotate:
-
-```bash
-$ echo "/home/invidious/invidious/invidious.log {
-rotate 4
-weekly
-notifempty
-missingok
-compress
-minsize 1048576
-}" | sudo tee /etc/logrotate.d/invidious.logrotate
-$ sudo chmod 0644 /etc/logrotate.d/invidious.logrotate
-```
-
-### MacOS:
-
-```bash
-# Install dependencies
-$ brew update
-$ brew install shards crystal postgres imagemagick librsvg
-
-# Clone the repository and set up a PostgreSQL database
-$ git clone https://github.com/iv-org/invidious
-$ cd invidious
-$ brew services start postgresql
-$ psql -c "CREATE ROLE kemal WITH PASSWORD 'kemal';" # Change 'kemal' here to a stronger password, and update `password` in config/config.yml
-$ createdb -O kemal invidious
-$ psql invidious kemal < config/sql/channels.sql
-$ psql invidious kemal < config/sql/videos.sql
-$ psql invidious kemal < config/sql/channel_videos.sql
-$ psql invidious kemal < config/sql/users.sql
-$ psql invidious kemal < config/sql/session_ids.sql
-$ psql invidious kemal < config/sql/nonces.sql
-$ psql invidious kemal < config/sql/annotations.sql
-$ psql invidious kemal < config/sql/privacy.sql
-$ psql invidious kemal < config/sql/playlists.sql
-$ psql invidious kemal < config/sql/playlist_videos.sql
-
-# Set up Invidious
-$ shards update && shards install
-$ crystal build src/invidious.cr --release
-```
-
-## Post-install configuration:
-
-Detailed configuration available in the [configuration guide](https://github.com/iv-org/documentation/blob/master/Configuration.md).
-
-If you use a reverse proxy, you **must** configure invidious to properly serve request through it:
-
-`https_only: true` : if your are serving your instance via https, set it to true
-
-`domain: domain.ext`: if you are serving your instance via a domain name, set it here
-
-`external_port: 443`: if your are serving your instance via https, set it to 443
-
-## Update Invidious
-
-Instructions are available in the [updating guide](https://github.com/iv-org/documentation/blob/master/Updating.md).
-
-## Usage:
-
-```bash
-$ ./invidious -h
-Usage: invidious [arguments]
-    -b HOST, --bind HOST             Host to bind (defaults to 0.0.0.0)
-    -p PORT, --port PORT             Port to listen for connections (defaults to 3000)
-    -s, --ssl                        Enables SSL
-    --ssl-key-file FILE              SSL key file
-    --ssl-cert-file FILE             SSL certificate file
-    -h, --help                       Shows this help
-    -c THREADS, --channel-threads=THREADS
-                                     Number of threads for refreshing channels (default: 1)
-    -f THREADS, --feed-threads=THREADS
-                                     Number of threads for refreshing feeds (default: 1)
-    -o OUTPUT, --output=OUTPUT       Redirect output (default: STDOUT)
-    -v, --version                    Print version
-```
-
-Or for development:
-
-```bash
-$ curl -fsSLo- https://raw.githubusercontent.com/samueleaton/sentry/master/install.cr | crystal eval
-$ ./sentry
-🤖  Your SentryBot is vigilant. beep-boop...
-```
+---
 
 ## Documentation
 
-The [documentation](https://github.com/iv-org/documentation) can be found in its own repository.
+The complete documentation is available on https://docs.invidious.io/
+
+---
 
 ## Extensions
 
 [Extensions](https://github.com/iv-org/documentation/blob/master/Extensions.md) can be found in the wiki, as well as documentation for integrating it into other projects.
+
+---
 
 ## Made with Invidious
 
@@ -247,6 +81,8 @@ The [documentation](https://github.com/iv-org/documentation) can be found in its
 - [LapisTube](https://github.com/blubbll/lapis-tube): A fancy and advanced (experimental) YouTube front-end. Combined streams & custom YT features.
 - [HoloPlay](https://github.com/stephane-r/HoloPlay): Funny Android application connecting on Invidious API's with search, playlists and favoris.
 
+---
+
 ## Contributing
 
 1.  Fork it ( https://github.com/iv-org/invidious/fork )
@@ -255,13 +91,18 @@ The [documentation](https://github.com/iv-org/documentation) can be found in its
 4.  Push to the branch (git push origin my-new-feature)
 5.  Create a new pull request
 
-#### Translation
+### Translation
 
 - Log in with an account you have elsewhere, or register an account and start translating at [Hosted Weblate](https://hosted.weblate.org/engage/invidious/).
+
+
+---
 
 ## Contact
 
 Feel free to join our [Matrix room](https://matrix.to/#/#invidious:matrix.org), or #invidious on freenode. Both platforms are bridged together.
+
+---
 
 ## Liability
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Monero (XMR): [41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3
 
 ## Documentation:
 
-The complete documentation is available on https://docs.invidious.io/
+The complete documentation is available on https://docs.invidious.io/ (or alternatively on its own [Github repository](https://github.com/iv-org/documentation)).
 
 ---
 
@@ -70,7 +70,7 @@ The complete documentation is available on https://docs.invidious.io/
 ## Made with Invidious:
 
 - [FreeTube](https://github.com/FreeTubeApp/FreeTube): A libre software YouTube app for privacy.
-- [CloudTube](https://cadence.moe/cloudtube/subscriptions): A JavaScript-rich alternate YouTube player
+- [CloudTube](https://cadence.moe/cloudtube/subscriptions): A JavaScript-rich alternate YouTube player.
 - [PeerTubeify](https://gitlab.com/Cha_deL/peertubeify): On YouTube, displays a link to the same video on PeerTube, if it exists.
 - [MusicPiped](https://github.com/deep-gaurav/MusicPiped): A material design music player that streams music from YouTube.
 - [LapisTube](https://github.com/blubbll/lapis-tube): A fancy and advanced (experimental) YouTube front-end. Combined streams & custom YT features.
@@ -82,11 +82,11 @@ The complete documentation is available on https://docs.invidious.io/
 
 [![Build Status](https://github.com/iv-org/invidious/workflows/Invidious%20CI/badge.svg)](https://github.com/iv-org/invidious/actions) [![Translation Status](https://hosted.weblate.org/widgets/invidious/-/translations/svg-badge.svg)](https://hosted.weblate.org/engage/invidious/)
 
-1.  Fork it ( https://github.com/iv-org/invidious/fork )
-2.  Create your feature branch (git checkout -b my-new-feature)
-3.  Commit your changes (git commit -am 'Add some feature')
-4.  Push to the branch (git push origin my-new-feature)
-5.  Create a new pull request
+1.  Fork it ( https://github.com/iv-org/invidious/fork ).
+2.  Create your feature branch (git checkout -b my-new-feature).
+3.  Commit your changes (git commit -am 'Add some feature').
+4.  Push to the branch (git push origin my-new-feature).
+5.  Create a new pull request.
 
 ### Translation:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Public Invidious instances are listed on the documentation website: https://docs
 - Set default player options (speed, quality, autoplay, loop)
 - Support for Reddit comments in place of YouTube comments
 - Import/Export subscriptions, watch history, preferences
-- [Developer API](https://github.com/iv-org/documentation/blob/master/API.md)
+- [Developer API](https://docs.invidious.io/API.md)
 - Does not use any of the official YouTube APIs
 - No need to create a Google account to save subscriptions
 - No Code of Conduct
@@ -63,7 +63,7 @@ The complete documentation is available on https://docs.invidious.io/
 
 ## Extensions:
 
-[Extensions](https://github.com/iv-org/documentation/blob/master/Extensions.md) can be found in the wiki, as well as documentation for integrating it into other projects.
+[Extensions](https://docs.invidious.io/Extensions.md) can be found in the wiki, as well as documentation for integrating it into other projects.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
-# Invidious
+<h1 align="center">Invidious</h1>
 
----
-
-## Invidious is an alternative front-end to YouTube
-
----
-
-[![Build Status](https://github.com/iv-org/invidious/workflows/Invidious%20CI/badge.svg)](https://github.com/iv-org/invidious/actions) [![Translation Status](https://hosted.weblate.org/widgets/invidious/-/translations/svg-badge.svg)](https://hosted.weblate.org/engage/invidious/)
+<h2 align="center">Invidious is an alternative front-end to YouTube.</h2>
 
 ---
 
@@ -20,6 +14,8 @@ Public Invidious instances are listed on the documentation website: https://docs
 
 - [Copylefted libre software](https://github.com/iv-org/invidious) (AGPLv3+ licensed)
 - Lightweight (the homepage is ~4 KB compressed)
+- No ads
+- No tracking
 - Javascript is 100% optional
 - Tools for managing subscriptions:
   - Only show unseen videos
@@ -36,10 +32,9 @@ Public Invidious instances are listed on the documentation website: https://docs
 - [Developer API](https://github.com/iv-org/documentation/blob/master/API.md)
 - Does not use any of the official YouTube APIs
 - No need to create a Google account to save subscriptions
-- No ads
 - No Code of Conduct
 - No Contributor license Agreement
-- Available in many language thanks to [Weblate](https://hosted.weblate.org/projects/)invidious/
+- Available in many language, thanks to [Weblate](https://hosted.weblate.org/projects/invidious/)
 
 ---
 
@@ -60,19 +55,19 @@ Monero (XMR): [41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3
 
 ---
 
-## Documentation
+## Documentation:
 
 The complete documentation is available on https://docs.invidious.io/
 
 ---
 
-## Extensions
+## Extensions:
 
 [Extensions](https://github.com/iv-org/documentation/blob/master/Extensions.md) can be found in the wiki, as well as documentation for integrating it into other projects.
 
 ---
 
-## Made with Invidious
+## Made with Invidious:
 
 - [FreeTube](https://github.com/FreeTubeApp/FreeTube): A libre software YouTube app for privacy.
 - [CloudTube](https://cadence.moe/cloudtube/subscriptions): A JavaScript-rich alternate YouTube player
@@ -83,7 +78,9 @@ The complete documentation is available on https://docs.invidious.io/
 
 ---
 
-## Contributing
+## Contributing:
+
+[![Build Status](https://github.com/iv-org/invidious/workflows/Invidious%20CI/badge.svg)](https://github.com/iv-org/invidious/actions) [![Translation Status](https://hosted.weblate.org/widgets/invidious/-/translations/svg-badge.svg)](https://hosted.weblate.org/engage/invidious/)
 
 1.  Fork it ( https://github.com/iv-org/invidious/fork )
 2.  Create your feature branch (git checkout -b my-new-feature)
@@ -91,20 +88,19 @@ The complete documentation is available on https://docs.invidious.io/
 4.  Push to the branch (git push origin my-new-feature)
 5.  Create a new pull request
 
-### Translation
+### Translation:
 
 - Log in with an account you have elsewhere, or register an account and start translating at [Hosted Weblate](https://hosted.weblate.org/engage/invidious/).
 
-
 ---
 
-## Contact
+## Contact:
 
 Feel free to join our [Matrix room](https://matrix.to/#/#invidious:matrix.org), or #invidious on freenode. Both platforms are bridged together.
 
 ---
 
-## Liability
+## Liability:
 
 We take no responsibility for the use of our tool, or external instances provided by third parties. We strongly recommend you abide by the valid official regulations in your country. Furthermore, we refuse liability for any inappropriate use of Invidious, such as illegal downloading. This tool is provided to you in the spirit of free, open software.
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,9 @@ The complete documentation is available on https://docs.invidious.io/ (or altern
 ## Made with Invidious:
 
 - [FreeTube](https://github.com/FreeTubeApp/FreeTube): A libre software YouTube app for privacy.
-- [CloudTube](https://cadence.moe/cloudtube/subscriptions): A JavaScript-rich alternate YouTube player.
+- [CloudTube](https://sr.ht/~cadence/tube/): A JavaScript-rich alternate YouTube player.
 - [PeerTubeify](https://gitlab.com/Cha_deL/peertubeify): On YouTube, displays a link to the same video on PeerTube, if it exists.
 - [MusicPiped](https://github.com/deep-gaurav/MusicPiped): A material design music player that streams music from YouTube.
-- [LapisTube](https://github.com/blubbll/lapis-tube): A fancy and advanced (experimental) YouTube front-end. Combined streams & custom YT features.
 - [HoloPlay](https://github.com/stephane-r/HoloPlay): Funny Android application connecting on Invidious API's with search, playlists and favoris.
 
 ---

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Public Invidious instances are listed on the documentation website: https://docs
 - No need to create a Google account to save subscriptions
 - No Code of Conduct
 - No Contributor license Agreement
-- Available in many language, thanks to [Weblate](https://hosted.weblate.org/projects/invidious/)
+- Available in many languages, thanks to [Weblate](https://hosted.weblate.org/projects/invidious/)
 
 ---
 


### PR DESCRIPTION
Objective of this PR:

- Make the README as most user-friendly as possible
- Move the content irrelevant to end-users out of the way

What this PR does:

- Installation instruction moved to the documentation (Related PR: https://github.com/iv-org/documentation/pull/34 )
- Reword various sentence
- Separate the content in a more readable way
- Reorder some categories
- Make the README link to https://docs.invidious.io instead of the documentation repository when applicable
- Fix and enhance various things
- More

---

The end result can be seen: [Here](https://github.com/TheFrenchGhosty/invidious/tree/enhance-readme#invidious)

Note: some stuff is based on the README of one of my project: [TheFrenchGhosty's Ultimate YouTube-DL Scripts Collection](https://github.com/TheFrenchGhosty/TheFrenchGhostys-Ultimate-YouTube-DL-Scripts-Collection).


PS: I'm thinking of maybe separating the features list between "Differences with YouTube" (Lightweight, Audio-only mode... for example), "Privacy specific" (No ads, No tracking... for example), "Project specific" (Copylefted, No CoC... for example) but it's maybe weird, I don't know