### PR TITLE
show how long ago stream started

### DIFF
--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -534,7 +534,8 @@ struct Video
   end
 
   def live_now
-    info["videoDetails"]["isLiveContent"]?.try &.as_bool || false
+    info["microformat"]?.try &.["playerMicroformatRenderer"]?
+      .try &.["liveBroadcastDetails"]?.try &.["isLiveNow"]?.try &.as_bool || false
   end
 
   def is_listed

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -81,6 +81,10 @@
         <h3>
             <%= video.premiere_timestamp.try { |t| translate(locale, "Premieres in `x`", recode_date((t - Time.utc).ago, locale)) } %>
         </h3>
+    <% elsif video.live_now %>
+        <h3>
+            <%= video.premiere_timestamp.try { |t| translate(locale, "Started streaming `x` ago", recode_date((Time.utc - t).ago, locale)) } %>
+        </h3>
     <% end %>
 </div>
 


### PR DESCRIPTION
## Overview
When I start watching a stream already in progress, I want to know how much I missed.  This adds the time display like youtube

![Screen Shot 2021-02-24 at 8 09 00 PM](https://user-images.githubusercontent.com/74318225/109101788-47895f80-76dc-11eb-95a8-02a41af96e42.png)

## Change
Add a display of the time elapsed since the livestream premier if the livestream is still ongoing.

The previous live_now in video was using the wrong attribute and displays true for all livestreams.  This changes it to use the appropriate live_now which indicates if the livestream is currently ongoing.

## Testing
Tested appropriate behavior:
* ongoing livestream works as expected
* completed livestream does not display any change
* non-livestreams do not display any change