### PR TITLE
integrate legacy yt xml subscription import with new json sub import

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -760,7 +760,7 @@ post "/data_control" do |env|
           end
         end
       when "import_youtube"
-        if body[0..4] == "<opml" 
+        if body[0..4] == "<opml"
           subscriptions = XML.parse(body)
           user.subscriptions += subscriptions.xpath_nodes(%q(//outline[@type="rss"])).map do |channel|
             channel["xmlUrl"].match(/UC[a-zA-Z0-9_-]{22}/).not_nil![0]
@@ -1563,12 +1563,12 @@ post "/feed/webhook/:token" do |env|
         views:              video.views,
       })
 
-      was_insert = PG_DB.query_one("INSERT INTO channel_videos VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) \
-        ON CONFLICT (id) DO UPDATE SET title = $2, published = $3, \
-        updated = $4, ucid = $5, author = $6, length_seconds = $7, \
+      was_insert = PG_DB.query_one("INSERT INTO channel_videos VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        ON CONFLICT (id) DO UPDATE SET title = $2, published = $3,
+        updated = $4, ucid = $5, author = $6, length_seconds = $7,
         live_now = $8, premiere_timestamp = $9, views = $10 returning (xmax=0) as was_insert", *video.to_tuple, as: Bool)
 
-      PG_DB.exec("UPDATE users SET notifications = array_append(notifications, $1), \
+      PG_DB.exec("UPDATE users SET notifications = array_append(notifications, $1),
         feed_needs_update = true WHERE $2 = ANY(subscriptions)", video.id, video.ucid) if was_insert
     end
   end

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -769,7 +769,7 @@ post "/data_control" do |env|
           subscriptions = JSON.parse(body)
           user.subscriptions += subscriptions.as_a.compact_map do |entry|
             entry["snippet"]["resourceId"]["channelId"].as_s
-        end
+          end
         end
         user.subscriptions.uniq!
 


### PR DESCRIPTION
after @schwukas changed the youtube sub importer to support youtubes new way of exporting subs as json in this [commit]( https://github.com/iv-org/invidious/commit/62e8c091831ce2d2db7e928dd25cb55330d72323) , it wasn't possible to import old youtube sub exports (which were exported as  xml files).

i simply added an if conditional which checks the to be imported file format. if the file starts with "<opml" it'll use the legacy import if not then the new way of importing json files.

i did this because i deleted my google acc after my degooglefication process, as i only had my subs backed up as xml files i wasn't able to import these after the change. maybe there are many more out there such as myself that will benefit from this pr :)