### PR TITLE
Fix video/playlist descriptions

### DIFF
--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -488,8 +488,12 @@ def replace_links(html)
         length_seconds = decode_time(anchor.content)
       end
 
-      anchor["href"] = "javascript:void(0)"
-      anchor["onclick"] = "player.currentTime(#{length_seconds})"
+      if length_seconds > 0
+        anchor["href"] = "javascript:void(0)"
+        anchor["onclick"] = "player.currentTime(#{length_seconds})"
+      else
+        anchor["href"] = url.request_target
+      end
     end
   end
 
@@ -528,11 +532,7 @@ end
 
 def content_to_comment_html(content)
   comment_html = content.map do |run|
-    text = HTML.escape(run["text"].as_s)
-
-    if run["text"] == "\n"
-      text = "<br>"
-    end
+    text = HTML.escape(run["text"].as_s).gsub("\n", "<br>")
 
     if run["bold"]?
       text = "<b>#{text}</b>"
@@ -559,7 +559,7 @@ def content_to_comment_html(content)
         length_seconds = watch_endpoint["startTimeSeconds"]?
         video_id = watch_endpoint["videoId"].as_s
 
-        if length_seconds
+        if length_seconds && length_seconds.as_i > 0
           text = %(<a href="javascript:void(0)" data-onclick="jump_to_time" data-jump-time="#{length_seconds}">#{text}</a>)
         else
           text = %(<a href="/watch?v=#{video_id}">#{text}</a>)

--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -101,6 +101,7 @@ struct Playlist
   property author_thumbnail : String
   property ucid : String
   property description : String
+  property description_html : String
   property video_count : Int32
   property views : Int64
   property updated : Time
@@ -162,10 +163,6 @@ struct Playlist
 
   def privacy
     PlaylistPrivacy::Public
-  end
-
-  def description_html
-    HTML.escape(self.description).gsub("\n", "<br>")
   end
 end
 
@@ -374,8 +371,15 @@ def fetch_playlist(plid, locale)
 
   title = playlist_info["title"]?.try &.["runs"][0]?.try &.["text"]?.try &.as_s || ""
 
+
   desc_item = playlist_info["description"]?
-  description = desc_item.try &.["runs"]?.try &.as_a.map(&.["text"].as_s).join("") || desc_item.try &.["simpleText"]?.try &.as_s || ""
+
+  description_txt = desc_item.try &.["runs"]?.try &.as_a
+    .map(&.["text"].as_s).join("") || desc_item.try &.["simpleText"]?.try &.as_s || ""
+
+  description_html = desc_item.try &.["runs"]?.try &.as_a
+    .try { |run| content_to_comment_html(run).try &.to_s } || "<p></p>"
+
 
   thumbnail = playlist_info["thumbnailRenderer"]?.try &.["playlistVideoThumbnailRenderer"]?
     .try &.["thumbnail"]["thumbnails"][0]["url"]?.try &.as_s
@@ -415,7 +419,8 @@ def fetch_playlist(plid, locale)
     author:           author,
     author_thumbnail: author_thumbnail,
     ucid:             ucid,
-    description:      description,
+    description:      description_txt,
+    description_html: description_html,
     video_count:      video_count,
     views:            views,
     updated:          updated,


### PR DESCRIPTION
This pull request fixes the links in the descriptions of both videos and playlists.

What's been fixed:

1. The `*/watch?v={id}` links in video description were creating `<a href="javascript:void(0)" ...>` elements, meant to change the "start time" of the video, even when they did not contain a "start time" info (this applies to links to other videos, too). This should be fixed now, but still requires testing (e.g when a comment contains a link to another video with a "start time").

2. Playlist descriptions were on plain text, making links unreachable due to link shortening (see #1767). They're now properly parsed, using the same function as video descriptions (1).

-------

(1) The function in question is `content_to_comment_html`. Given that it's now used by more things than just the comments, It'd be maybe interesting to rename it and move it to a more appropriate place, probably in `src/invidious/helpers/`.