### PR TITLE
Revert "Bump dependencies"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,8 @@ RUN apk add --no-cache curl sqlite-static
 WORKDIR /invidious
 COPY ./shard.yml ./shard.yml
 COPY ./shard.lock ./shard.lock
-RUN shards install
+RUN shards install && \
+    curl -Lo ./lib/lsquic/src/lsquic/ext/liblsquic.a https://github.com/iv-org/lsquic-static-alpine/releases/download/v2.18.1/liblsquic.a
 COPY ./src/ ./src/
 # TODO: .git folder is required for building – this is destructive.
 # See definition of CURRENT_BRANCH, CURRENT_COMMIT and CURRENT_VERSION.

--- a/shard.lock
+++ b/shard.lock
@@ -18,7 +18,7 @@ shards:
 
   lsquic:
     git: https://github.com/iv-org/lsquic.cr.git
-    version: 2.23.1
+    version: 2.18.1-1
 
   pg:
     git: https://github.com/will/crystal-pg.git

--- a/shard.yml
+++ b/shard.yml
@@ -27,7 +27,7 @@ dependencies:
     version: ~> 0.1.3
   lsquic:
     github: iv-org/lsquic.cr
-    version: ~> 2.23.1
+    version: ~> 2.18.1-1
 
 crystal: 0.36.1
 


### PR DESCRIPTION
Fixes #1888 

After running Invidious for 30 minutes with the old lsquic version in Docker I'm unable to replicate the issue described in #1888 anymore. So something is probably off with the newest version of lsquic and Docker.

This PR downgrade the lsquic to a "stable" version in order to at least for the time being fix the invalid memory access until we find what's wrong with the new lsquic version.