### PR TITLE
Fix: functional hl / dark_mode / thin_mode params

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -289,6 +289,7 @@ before_all do |env|
   preferences.dark_mode = dark_mode
   preferences.thin_mode = thin_mode
   preferences.locale = locale
+  env.set "preferences", preferences
 
   current_page = env.request.path
   if env.request.query


### PR DESCRIPTION
The `hl`, `dark_mode` and `thin_mode` URL query parameters should be overriding the preferences' options (or, in the case of direct use of the API, the `hl` parameter should be localizing some strings) but this isn't currently happening.

This PR fixes that behavior.