### PR TITLE
Fix channel search API

### DIFF
--- a/spec/helpers_spec.cr
+++ b/spec/helpers_spec.cr
@@ -29,9 +29,9 @@ describe "Helper" do
 
   describe "#produce_channel_search_continuation" do
     it "correctly produces token for searching a specific channel" do
-      produce_channel_search_url("UCXuqSBlHAE6Xw-yeJA0Tunw", "", 100).should eq("4qmFsgJqEhhVQ1h1cVNCbEhBRTZYdy15ZUpBMFR1bncaIEVnWnpaV0Z5WTJnd0FUZ0JZQUY2QkVkS2IxaTRBUUE9WgCaAilicm93c2UtZmVlZFVDWHVxU0JsSEFFNlh3LXllSkEwVHVud3NlYXJjaA%3D%3D")
+      produce_channel_search_continuation("UCXuqSBlHAE6Xw-yeJA0Tunw", "", 100).should eq("4qmFsgJqEhhVQ1h1cVNCbEhBRTZYdy15ZUpBMFR1bncaIEVnWnpaV0Z5WTJnd0FUZ0JZQUY2QkVkS2IxaTRBUUE9WgCaAilicm93c2UtZmVlZFVDWHVxU0JsSEFFNlh3LXllSkEwVHVud3NlYXJjaA%3D%3D")
 
-      produce_channel_search_url("UCXuqSBlHAE6Xw-yeJA0Tunw", "По ожиशुपतिरपि子而時ஸ்றீனி", 0).should eq("4qmFsgKoARIYVUNYdXFTQmxIQUU2WHcteWVKQTBUdW53GiBFZ1p6WldGeVkyZ3dBVGdCWUFGNkJFZEJRVDI0QVFBPVo-0J_QviDQvtC20LjgpLbgpYHgpKrgpKTgpL_gpLDgpKrgpL_lrZDogIzmmYLgrrjgr43grrHgr4Dgrqngrr-aAilicm93c2UtZmVlZFVDWHVxU0JsSEFFNlh3LXllSkEwVHVud3NlYXJjaA%3D%3D")
+      produce_channel_search_continuation("UCXuqSBlHAE6Xw-yeJA0Tunw", "По ожиशुपतिरपि子而時ஸ்றீனி", 0).should eq("4qmFsgKoARIYVUNYdXFTQmxIQUU2WHcteWVKQTBUdW53GiBFZ1p6WldGeVkyZ3dBVGdCWUFGNkJFZEJRVDI0QVFBPVo-0J_QviDQvtC20LjgpLbgpYHgpKrgpKTgpL_gpLDgpKrgpL_lrZDogIzmmYLgrrjgr43grrHgr4Dgrqngrr-aAilicm93c2UtZmVlZFVDWHVxU0JsSEFFNlh3LXllSkEwVHVud3NlYXJjaA%3D%3D")
     end
   end
 

--- a/spec/helpers_spec.cr
+++ b/spec/helpers_spec.cr
@@ -41,12 +41,6 @@ describe "Helper" do
     end
   end
 
-  describe "#extract_channel_playlists_cursor" do
-    it "correctly extracts a playlists cursor from the given URL" do
-      extract_channel_playlists_cursor("4qmFsgLRARIYVUNDajk1NklGNjJGYlQ3R291c3phajl3GrQBRWdsd2JHRjViR2x6ZEhNWUF5QUJNQUk0QVdBQmFnQjZabEZWYkZCaE1XczFVbFpHZDJGV09XNWxWelI0V0RGR2VWSnVWbUZOV0Vwc1ZHcG5lRmd3TVU1aVZXdDRWMWN4YzFGdFNuTmtlbWh4VGpCd1NWTllVa1pTYTJNeFlVUmtlRmt3Y0ZWVWJWRXdWbnBzTkU1V1JqRmhNVGxFVm14dmQwMXFhRzVXZDdnQkFBJTNEJTNE", false).should eq("AIOkY9EQpi_gyn1_QrFuZ1reN81_MMmI1YmlBblw8j7JHItEFG5h7qcJTNd4W9x5Quk_CVZ028gW")
-    end
-  end
-
   describe "#produce_playlist_continuation" do
     it "correctly produces ctoken for requesting index `x` of a playlist" do
       produce_playlist_continuation("UUCla9fZca4I7KagBtgRGnOw", 100).should eq("4qmFsgJNEhpWTFVVQ2xhOWZaY2E0STdLYWdCdGdSR25PdxoUQ0FGNkJsQlVPa05IVVElM0QlM0SaAhhVVUNsYTlmWmNhNEk3S2FnQnRnUkduT3c%3D")

--- a/spec/helpers_spec.cr
+++ b/spec/helpers_spec.cr
@@ -27,11 +27,11 @@ describe "Helper" do
     end
   end
 
-  describe "#produce_channel_search_url" do
+  describe "#produce_channel_search_continuation" do
     it "correctly produces token for searching a specific channel" do
-      produce_channel_search_url("UCXuqSBlHAE6Xw-yeJA0Tunw", "", 100).should eq("/browse_ajax?continuation=4qmFsgI2EhhVQ1h1cVNCbEhBRTZYdy15ZUpBMFR1bncaGEVnWnpaV0Z5WTJnNEFYb0RNVEF3dUFFQVoA&gl=US&hl=en")
+      produce_channel_search_url("UCXuqSBlHAE6Xw-yeJA0Tunw", "", 100).should eq("4qmFsgJqEhhVQ1h1cVNCbEhBRTZYdy15ZUpBMFR1bncaIEVnWnpaV0Z5WTJnd0FUZ0JZQUY2QkVkS2IxaTRBUUE9WgCaAilicm93c2UtZmVlZFVDWHVxU0JsSEFFNlh3LXllSkEwVHVud3NlYXJjaA%3D%3D")
 
-      produce_channel_search_url("UCXuqSBlHAE6Xw-yeJA0Tunw", "По ожиशुपतिरपि子而時ஸ்றீனி", 0).should eq("/browse_ajax?continuation=4qmFsgJ0EhhVQ1h1cVNCbEhBRTZYdy15ZUpBMFR1bncaGEVnWnpaV0Z5WTJnNEFYb0JNTGdCQUE9PVo-0J_QviDQvtC20LjgpLbgpYHgpKrgpKTgpL_gpLDgpKrgpL_lrZDogIzmmYLgrrjgr43grrHgr4Dgrqngrr8%3D&gl=US&hl=en")
+      produce_channel_search_url("UCXuqSBlHAE6Xw-yeJA0Tunw", "По ожиशुपतिरपि子而時ஸ்றீனி", 0).should eq("4qmFsgKoARIYVUNYdXFTQmxIQUU2WHcteWVKQTBUdW53GiBFZ1p6WldGeVkyZ3dBVGdCWUFGNkJFZEJRVDI0QVFBPVo-0J_QviDQvtC20LjgpLbgpYHgpKrgpKTgpL_gpLDgpKrgpL_lrZDogIzmmYLgrrjgr43grrHgr4Dgrqngrr-aAilicm93c2UtZmVlZFVDWHVxU0JsSEFFNlh3LXllSkEwVHVud3NlYXJjaA%3D%3D")
     end
   end
 

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -2521,7 +2521,7 @@ get "/api/v1/channels/search/:ucid" do |env|
   query ||= ""
 
   page = env.params.query["page"]?.try &.to_i?
-  page ||= 1
+  page = 1 if !page || page <= 0
 
   count, search_results = channel_search(query, page, ucid)
   JSON.build do |json|

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -2521,7 +2521,7 @@ get "/api/v1/channels/search/:ucid" do |env|
   query ||= ""
 
   page = env.params.query["page"]?.try &.to_i?
-  page = 1 if !page || page <= 0
+  page ||= 1
 
   count, search_results = channel_search(query, page, ucid)
   JSON.build do |json|

--- a/src/invidious/search.cr
+++ b/src/invidious/search.cr
@@ -369,6 +369,12 @@ def produce_search_params(page = 1, sort : String = "relevance", date : String =
 end
 
 def produce_channel_search_continuation(ucid, query, page)
+  if page <= 1
+    idx = 0_i64
+  else
+    idx = 30_i64 * (page - 1)
+  end
+
   object = {
     "80226972:embedded" => {
       "2:string" => ucid,
@@ -378,7 +384,7 @@ def produce_channel_search_continuation(ucid, query, page)
         "7:varint" => 1_i64,
         "12:varint" => 1_i64,
         "15:base64" => {
-          "3:varint" => 30_i64 * (page - 1),
+          "3:varint" => idx,
         },
         "23:varint" => 0_i64
       },

--- a/src/invidious/search.cr
+++ b/src/invidious/search.cr
@@ -231,20 +231,27 @@ end
 alias SearchItem = SearchVideo | SearchChannel | SearchPlaylist
 
 def channel_search(query, page, channel)
-  response = YT_POOL.client &.get("/channel/#{channel}?hl=en&gl=US")
-  response = YT_POOL.client &.get("/user/#{channel}?hl=en&gl=US") if response.headers["location"]?
-  response = YT_POOL.client &.get("/c/#{channel}?hl=en&gl=US") if response.headers["location"]?
+  response = YT_POOL.client &.get("/channel/#{channel}")
 
-  ucid = response.body.match(/\\"channelId\\":\\"(?<ucid>[^\\]+)\\"/).try &.["ucid"]?
+  if response.status_code == 404
+    response = YT_POOL.client &.get("/user/#{channel}")
+    response = YT_POOL.client &.get("/c/#{channel}") if response.status_code == 404
+    ucid = response.body.match(/HeaderRenderer":\{"channelId":"(?<ucid>[^\\"]+)"/).try &.["ucid"]?
+  else
+    ucid = channel
+  end
 
-  return 0, [] of SearchItem if !ucid
+  continuation = produce_channel_search_continuation(ucid, query, page)
+  response_json = request_youtube_api_browse(continuation)
 
-  url = produce_channel_search_url(ucid, query, page)
-  response = YT_POOL.client &.get(url)
-  initial_data = JSON.parse(response.body).as_a.find &.["response"]?
-  return 0, [] of SearchItem if !initial_data
-  author = initial_data["response"]?.try &.["metadata"]?.try &.["channelMetadataRenderer"]?.try &.["title"]?.try &.as_s
-  items = extract_items(initial_data.as_h, author, ucid)
+  result = JSON.parse(response_json.match(/"continuationItems": (?<items>\[.*\]),/m).try &.["items"] || "{}")
+  return 0, [] of SearchItem if result.size == 0
+
+  items = [] of SearchItem
+  result.as_a.select(&.as_h.has_key?("itemSectionRenderer")).each { |item|
+    extract_item(item["itemSectionRenderer"]["contents"].as_a[0])
+      .try { |t| items << t }
+  }
 
   return items.size, items
 end
@@ -361,18 +368,23 @@ def produce_search_params(page = 1, sort : String = "relevance", date : String =
   return params
 end
 
-def produce_channel_search_url(ucid, query, page)
+def produce_channel_search_continuation(ucid, query, page)
   object = {
     "80226972:embedded" => {
       "2:string" => ucid,
       "3:base64" => {
-        "2:string"  => "search",
-        "7:varint"  => 1_i64,
-        "15:string" => "#{page}",
-        "23:varint" => 0_i64,
+        "2:string" => "search",
+        "6:varint" => 1_i64,
+        "7:varint" => 1_i64,
+        "12:varint" => 1_i64,
+        "15:base64" => {
+          "3:varint" => 30_i64 * (page - 1),
+        },
+        "23:varint" => 0_i64
       },
       "11:string" => query,
-    },
+      "35:string" => "browse-feed#{ucid}search"
+    }
   }
 
   continuation = object.try { |i| Protodec::Any.cast_json(object) }
@@ -380,7 +392,7 @@ def produce_channel_search_url(ucid, query, page)
     .try { |i| Base64.urlsafe_encode(i) }
     .try { |i| URI.encode_www_form(i) }
 
-  return "/browse_ajax?continuation=#{continuation}&gl=US&hl=en"
+  return continuation
 end
 
 def process_search_query(query, page, user, region)

--- a/src/invidious/search.cr
+++ b/src/invidious/search.cr
@@ -379,18 +379,18 @@ def produce_channel_search_continuation(ucid, query, page)
     "80226972:embedded" => {
       "2:string" => ucid,
       "3:base64" => {
-        "2:string" => "search",
-        "6:varint" => 1_i64,
-        "7:varint" => 1_i64,
+        "2:string"  => "search",
+        "6:varint"  => 1_i64,
+        "7:varint"  => 1_i64,
         "12:varint" => 1_i64,
         "15:base64" => {
           "3:varint" => idx,
         },
-        "23:varint" => 0_i64
+        "23:varint" => 0_i64,
       },
       "11:string" => query,
-      "35:string" => "browse-feed#{ucid}search"
-    }
+      "35:string" => "browse-feed#{ucid}search",
+    },
   }
 
   continuation = object.try { |i| Protodec::Any.cast_json(object) }


### PR DESCRIPTION
This PR fixes the functionality of the channels' search API
NOTE: `/browse_ajax` is deprecated and return 410s (Gone)