### PR TITLE
Fix channels' playlists fetching

### DIFF
--- a/spec/helpers_spec.cr
+++ b/spec/helpers_spec.cr
@@ -41,12 +41,6 @@ describe "Helper" do
     end
   end
 
-  describe "#extract_channel_playlists_cursor" do
-    it "correctly extracts a playlists cursor from the given URL" do
-      extract_channel_playlists_cursor("4qmFsgLRARIYVUNDajk1NklGNjJGYlQ3R291c3phajl3GrQBRWdsd2JHRjViR2x6ZEhNWUF5QUJNQUk0QVdBQmFnQjZabEZWYkZCaE1XczFVbFpHZDJGV09XNWxWelI0V0RGR2VWSnVWbUZOV0Vwc1ZHcG5lRmd3TVU1aVZXdDRWMWN4YzFGdFNuTmtlbWh4VGpCd1NWTllVa1pTYTJNeFlVUmtlRmt3Y0ZWVWJWRXdWbnBzTkU1V1JqRmhNVGxFVm14dmQwMXFhRzVXZDdnQkFBJTNEJTNE", false).should eq("AIOkY9EQpi_gyn1_QrFuZ1reN81_MMmI1YmlBblw8j7JHItEFG5h7qcJTNd4W9x5Quk_CVZ028gW")
-    end
-  end
-
   describe "#produce_playlist_continuation" do
     it "correctly produces ctoken for requesting index `x` of a playlist" do
       produce_playlist_continuation("UUCla9fZca4I7KagBtgRGnOw", 100).should eq("4qmFsgJNEhpWTFVVQ2xhOWZaY2E0STdLYWdCdGdSR25PdxoUQ0FGNkJsQlVPa05IVVElM0QlM0SaAhhVVUNsYTlmWmNhNEk3S2FnQnRnUkduT3c%3D")

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -1699,7 +1699,7 @@ get "/channel/:ucid" do |env|
     sort_options = {"last", "oldest", "newest"}
     sort_by ||= "last"
 
-    items, continuation = fetch_channel_playlists(channel.ucid, channel.author, channel.auto_generated, continuation, sort_by)
+    items, continuation = fetch_channel_playlists(channel.ucid, channel.author, continuation, sort_by)
     items.uniq! do |item|
       if item.responds_to?(:title)
         item.title
@@ -1766,7 +1766,7 @@ get "/channel/:ucid/playlists" do |env|
     next env.redirect "/channel/#{channel.ucid}"
   end
 
-  items, continuation = fetch_channel_playlists(channel.ucid, channel.author, channel.auto_generated, continuation, sort_by)
+  items, continuation = fetch_channel_playlists(channel.ucid, channel.author, continuation, sort_by)
   items = items.select { |item| item.is_a?(SearchPlaylist) }.map { |item| item.as(SearchPlaylist) }
   items.each { |item| item.author = "" }
 
@@ -2467,7 +2467,7 @@ end
       next error_json(500, ex)
     end
 
-    items, continuation = fetch_channel_playlists(channel.ucid, channel.author, channel.auto_generated, continuation, sort_by)
+    items, continuation = fetch_channel_playlists(channel.ucid, channel.author, continuation, sort_by)
 
     JSON.build do |json|
       json.object do

--- a/src/invidious/channels.cr
+++ b/src/invidious/channels.cr
@@ -358,7 +358,6 @@ end
 def fetch_channel_playlists(ucid, author, continuation, sort_by)
   if continuation
     response_json = request_youtube_api_browse(continuation)
-    # result = JSON.parse(response_json.match(/"continuationItems": (?<items>\[.*\]),/m).try &.["items"] || "{}")
     result = JSON.parse(response_json)
     continuationItems = result["onResponseReceivedActions"]?
       .try &.[0]["appendContinuationItemsAction"]["continuationItems"]

--- a/src/invidious/channels.cr
+++ b/src/invidious/channels.cr
@@ -512,31 +512,6 @@ def produce_channel_playlists_url(ucid, cursor, sort = "newest", auto_generated 
   return "/browse_ajax?continuation=#{continuation}&gl=US&hl=en"
 end
 
-def extract_channel_playlists_cursor(cursor, auto_generated)
-  cursor = URI.decode_www_form(cursor)
-    .try { |i| Base64.decode(i) }
-    .try { |i| IO::Memory.new(i) }
-    .try { |i| Protodec::Any.parse(i) }
-    .try { |i| i["80226972:0:embedded"]["3:1:base64"].as_h.find { |k, v| k.starts_with? "15:" } }
-    .try &.[1]
-
-  if cursor.try &.as_h?
-    cursor = cursor.try { |i| Protodec::Any.cast_json(i.as_h) }
-      .try { |i| Protodec::Any.from_json(i) }
-      .try { |i| Base64.urlsafe_encode(i) }
-      .try { |i| URI.encode_www_form(i) } || ""
-  else
-    cursor = cursor.try &.as_s || ""
-  end
-
-  if !auto_generated
-    cursor = URI.decode_www_form(cursor)
-      .try { |i| Base64.decode_string(i) }
-  end
-
-  return cursor
-end
-
 # TODO: Add "sort_by"
 def fetch_channel_community(ucid, continuation, locale, format, thin_mode)
   response = YT_POOL.client &.get("/channel/#{ucid}/community?gl=US&hl=en")

--- a/src/invidious/channels.cr
+++ b/src/invidious/channels.cr
@@ -457,6 +457,15 @@ def produce_channel_videos_url(ucid, page = 1, auto_generated = nil, sort_by = "
   return "/browse_ajax?continuation=#{continuation}&gl=US&hl=en"
 end
 
+# ## NOTE: DEPRECATED
+# Reason -> Unstable
+# The Protobuf object must be provided with an id of the last playlist from the current "page"
+# in order to fetch the next one accurately
+# (if the id isn't included, entries shift around erratically between pages,
+# leading to repetitions and skip overs)
+#
+# Since it's impossible to produce the appropriate Protobuf without an id being provided by the user,
+# it's better to stick to continuation tokens provided by the first request and onward
 def produce_channel_playlists_url(ucid, cursor, sort = "newest", auto_generated = false)
   object = {
     "80226972:embedded" => {


### PR DESCRIPTION
This PR changes how Invidious fetches a channel's playlists so that it works even for topic channels
Fixes #1637
I want to be awarded the bounty associated to the issue this PR is fixing.
(I'm not cultured enough to have a "nice" image to go along with this, so I'll wait for @tenpura-shrimp to give me a link and I'll put that up, promise)