### PR TITLE
Prevent filtering options from jumping above its drop down menu.

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -641,7 +641,7 @@ body.dark-theme {
 }
 
 #filters > summary {
-  display: inline-block;
+  display: block;
   margin-bottom: 15px;
 }
 


### PR DESCRIPTION
Prevents this from happening

![Zoom](https://user-images.githubusercontent.com/70992037/112691955-010f5800-8e76-11eb-9201-8a3d43be30e2.png)
