### PR TITLE
Fix Trending API

### DIFF
--- a/src/invidious/trending.cr
+++ b/src/invidious/trending.cr
@@ -6,24 +6,22 @@ def fetch_trending(trending_type, region, locale)
   plid = nil
 
   if trending_type && trending_type != "Default"
-    trending_type = trending_type.downcase.capitalize
+    if trending_type == "Music"
+      trending_type = 1
+    elsif trending_type == "Gaming"
+      trending_type = 2
+    elsif trending_type == "Movies"
+      trending_type = 3
+    end
 
     response = YT_POOL.client &.get("/feed/trending?gl=#{region}&hl=en").body
 
     initial_data = extract_initial_data(response)
+    url = initial_data["contents"]["twoColumnBrowseResultsRenderer"]["tabs"][trending_type]["tabRenderer"]["endpoint"]["commandMetadata"]["webCommandMetadata"]["url"]
+    url = "#{url}&gl=#{region}&hl=en"
 
-    tabs = initial_data["contents"]["twoColumnBrowseResultsRenderer"]["tabs"][0]["tabRenderer"]["content"]["sectionListRenderer"]["subMenu"]["channelListSubMenuRenderer"]["contents"].as_a
-    url = tabs.select { |tab| tab["channelListSubMenuAvatarRenderer"]["title"]["simpleText"] == trending_type }[0]?
-
-    if url
-      url["channelListSubMenuAvatarRenderer"]["navigationEndpoint"]["commandMetadata"]["webCommandMetadata"]["url"]
-      url = url["channelListSubMenuAvatarRenderer"]["navigationEndpoint"]["commandMetadata"]["webCommandMetadata"]["url"].as_s
-      url = "#{url}&gl=#{region}&hl=en"
-      trending = YT_POOL.client &.get(url).body
-      plid = extract_plid(url)
-    else
-      trending = YT_POOL.client &.get("/feed/trending?gl=#{region}&hl=en").body
-    end
+    trending = YT_POOL.client &.get(url).body
+    plid = extract_plid(url)
   else
     trending = YT_POOL.client &.get("/feed/trending?gl=#{region}&hl=en").body
   end

--- a/src/invidious/trending.cr
+++ b/src/invidious/trending.cr
@@ -18,10 +18,10 @@ def fetch_trending(trending_type, region, locale)
 
     initial_data = extract_initial_data(response)
     url = initial_data["contents"]["twoColumnBrowseResultsRenderer"]["tabs"][trending_type]["tabRenderer"]["endpoint"]["commandMetadata"]["webCommandMetadata"]["url"]
-    url = "#{url}&gl=#{region}&hl=en"
+    bp = initial_data["contents"]["twoColumnBrowseResultsRenderer"]["tabs"][trending_type]["tabRenderer"]["endpoint"]["browseEndpoint"]["params"].to_s
 
-    trending = YT_POOL.client &.get(url).body
-    plid = extract_plid(url)
+    trending = YT_POOL.client &.get("#{url}&gl=#{region}&hl=en").body
+    plid = extract_plid(bp)
   else
     trending = YT_POOL.client &.get("/feed/trending?gl=#{region}&hl=en").body
   end
@@ -32,12 +32,10 @@ def fetch_trending(trending_type, region, locale)
   return {trending, plid}
 end
 
-def extract_plid(url)
-  return url.try { |i| URI.parse(i).query }
-    .try { |i| HTTP::Params.parse(i)["bp"] }
-    .try { |i| URI.decode_www_form(i) }
+def extract_plid(bp)
+  return bp.try { |i| URI.decode_www_form(i) }
     .try { |i| Base64.decode(i) }
     .try { |i| IO::Memory.new(i) }
     .try { |i| Protodec::Any.parse(i) }
-    .try &.["44:0:embedded"]?.try &.["2:1:string"]?.try &.as_s
+    .try &.["44:0:embedded"]?.try &.["3:0:string"]?.try &.as_s
 end

--- a/src/invidious/views/trending.ecr
+++ b/src/invidious/views/trending.ecr
@@ -21,7 +21,7 @@
     </div>
     <div class="pure-u-1-3">
         <div class="pure-g" style="text-align:right">
-            <% {"Default", "Music", "Gaming", "News", "Movies"}.each do |option| %>
+            <% {"Default", "Music", "Gaming", "Movies"}.each do |option| %>
                 <div class="pure-u-1 pure-md-1-3">
                     <% if trending_type == option %>
                         <b><%= translate(locale, option) %></b>


### PR DESCRIPTION
Fixes  #1755.

<details>
    <summary>
Music
    </summary>

![trending2](https://user-images.githubusercontent.com/70992037/112745651-97886a00-8f99-11eb-9450-992af99aabc2.png)

</details>

<details>
    <summary>
Gaming
    </summary>

![trending3](https://user-images.githubusercontent.com/70992037/112745652-98b99700-8f99-11eb-9e87-1aa32b3df193.png)

</details>

<details>
    <summary>
Movies
    </summary>

![trending4](https://user-images.githubusercontent.com/70992037/112745653-99eac400-8f99-11eb-8cf5-44a0871e75c6.png)

</details>

All trending pages are now accessible. I've also removed the news page since it looks like YouTube has removed it on their end. 

`View as playlist` is still broken though.








