### PR TITLE
Fix Trending API

### DIFF
--- a/src/invidious/trending.cr
+++ b/src/invidious/trending.cr
@@ -6,24 +6,22 @@ def fetch_trending(trending_type, region, locale)
   plid = nil
 
   if trending_type && trending_type != "Default"
-    trending_type = trending_type.downcase.capitalize
+    if trending_type == "Music"
+      trending_type = 1
+    elsif trending_type == "Gaming"
+      trending_type = 2
+    elsif trending_type == "Movies"
+      trending_type = 3
+    end
 
     response = YT_POOL.client &.get("/feed/trending?gl=#{region}&hl=en").body
 
     initial_data = extract_initial_data(response)
+    url = initial_data["contents"]["twoColumnBrowseResultsRenderer"]["tabs"][trending_type]["tabRenderer"]["endpoint"]["commandMetadata"]["webCommandMetadata"]["url"]
+    url = "#{url}&gl=#{region}&hl=en"
 
-    tabs = initial_data["contents"]["twoColumnBrowseResultsRenderer"]["tabs"][0]["tabRenderer"]["content"]["sectionListRenderer"]["subMenu"]["channelListSubMenuRenderer"]["contents"].as_a
-    url = tabs.select { |tab| tab["channelListSubMenuAvatarRenderer"]["title"]["simpleText"] == trending_type }[0]?
-
-    if url
-      url["channelListSubMenuAvatarRenderer"]["navigationEndpoint"]["commandMetadata"]["webCommandMetadata"]["url"]
-      url = url["channelListSubMenuAvatarRenderer"]["navigationEndpoint"]["commandMetadata"]["webCommandMetadata"]["url"].as_s
-      url = "#{url}&gl=#{region}&hl=en"
-      trending = YT_POOL.client &.get(url).body
-      plid = extract_plid(url)
-    else
-      trending = YT_POOL.client &.get("/feed/trending?gl=#{region}&hl=en").body
-    end
+    trending = YT_POOL.client &.get(url).body
+    plid = extract_plid(url)
   else
     trending = YT_POOL.client &.get("/feed/trending?gl=#{region}&hl=en").body
   end

--- a/src/invidious/views/trending.ecr
+++ b/src/invidious/views/trending.ecr
@@ -21,7 +21,7 @@
     </div>
     <div class="pure-u-1-3">
         <div class="pure-g" style="text-align:right">
-            <% {"Default", "Music", "Gaming", "News", "Movies"}.each do |option| %>
+            <% {"Default", "Music", "Gaming", "Movies"}.each do |option| %>
                 <div class="pure-u-1 pure-md-1-3">
                     <% if trending_type == option %>
                         <b><%= translate(locale, option) %></b>


### PR DESCRIPTION
Fixes #1755.

<details>
    <summary>
Music
    </summary>

![trending-1](https://user-images.githubusercontent.com/70992037/112746723-4e87e400-8fa0-11eb-83e3-dceaf79d24b1.png)
</details>

<details>
    <summary>
Gaming
    </summary>

![trending-2](https://user-images.githubusercontent.com/70992037/112746725-4fb91100-8fa0-11eb-95df-3466db568751.png)
</details>

<details>
    <summary>
Movies
    </summary>

![trending-3](https://user-images.githubusercontent.com/70992037/112746726-5051a780-8fa0-11eb-8476-085b2aeb19a4.png)
</details>

All trending pages are now accessible. I've also removed the news page since it looks like YouTube has removed it on their end. 

`View as playlist` feature is still broken though.
