### PR TITLE
Update regex expressions to handle unexpected '};'

### DIFF
--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -678,7 +678,7 @@ def create_notification_stream(env, topics, connection_channel)
 end
 
 def extract_initial_data(body) : Hash(String, JSON::Any)
-  return JSON.parse(body.match(/(window\["ytInitialData"\]|var\s*ytInitialData)\s*=\s*(?<info>\{.*?\});/mx).try &.["info"] || "{}").as_h
+  return JSON.parse(body.match(/(window\["ytInitialData"\]|var\s*ytInitialData)\s*=\s*(?<info>{.*?});<\/script>/mx).try &.["info"] || "{}").as_h
 end
 
 def proxy_file(response, env)

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -818,7 +818,7 @@ end
 
 def extract_polymer_config(body)
   params = {} of String => JSON::Any
-  player_response = body.match(/(window\["ytInitialPlayerResponse"\]|var\sytInitialPlayerResponse)\s*=\s*(?<info>{.*?});/m)
+  player_response = body.match(/(window\["ytInitialPlayerResponse"\]|var\sytInitialPlayerResponse)\s*=\s*(?<info>{.*?});\s*var\s*meta/m)
     .try { |r| JSON.parse(r["info"]).as_h }
 
   if body.includes?("To continue with your YouTube experience, please fill out the form below.") ||


### PR DESCRIPTION
Fixes: #1673
I want to be awarded the bounty associated to the issue this PR is fixing.

Tested with the following ids:
<details>

O4r9D2jI0_w

VQOdmckqNro

3AF3sYnvj5o

BFlF9gGnyro 

BUU7WFd8XLU

channel/UCRZY6MGMG1Fmzt50rYalTwQ

</details>

I wasn't able to reproduce the error in any of the videos linked in duplicate issues. However, this does fix the error in the original video and any other content with "};".