### PR TITLE
Add new YT consent cookie to every request

### DIFF
--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -9,7 +9,7 @@ def add_yt_headers(request)
   return if request.resource.starts_with? "/sorry/index"
   request.headers["x-youtube-client-name"] ||= "1"
   request.headers["x-youtube-client-version"] ||= "2.20200609"
-  request.headers["cookie"] = "CONSENT=YES+cb.20210328-17-p0.en; " # New YT consent cookie for EU servers
+  request.headers["cookie"] = "CONSENT=YES+" # New YT consent cookie for EU servers
   if !CONFIG.cookies.empty?
     request.headers["cookie"] = "#{(CONFIG.cookies.map { |c| "#{c.name}=#{c.value}" }).join("; ")}; #{request.headers["cookie"]?}"
   end

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -9,7 +9,7 @@ def add_yt_headers(request)
   return if request.resource.starts_with? "/sorry/index"
   request.headers["x-youtube-client-name"] ||= "1"
   request.headers["x-youtube-client-version"] ||= "2.20200609"
-  request.headers["cookie"] = "CONSENT=YES+cb.20210328-17-p0.en; "  # New YT consent cookie for EU servers
+  request.headers["cookie"] = "CONSENT=YES+cb.20210328-17-p0.en; " # New YT consent cookie for EU servers
   if !CONFIG.cookies.empty?
     request.headers["cookie"] = "#{(CONFIG.cookies.map { |c| "#{c.name}=#{c.value}" }).join("; ")}; #{request.headers["cookie"]?}"
   end

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -9,6 +9,7 @@ def add_yt_headers(request)
   return if request.resource.starts_with? "/sorry/index"
   request.headers["x-youtube-client-name"] ||= "1"
   request.headers["x-youtube-client-version"] ||= "2.20200609"
+  request.headers["cookie"] = "CONSENT=YES+cb.20210328-17-p0.en; "  # New YT consent cookie for EU servers
   if !CONFIG.cookies.empty?
     request.headers["cookie"] = "#{(CONFIG.cookies.map { |c| "#{c.name}=#{c.value}" }).join("; ")}; #{request.headers["cookie"]?}"
   end


### PR DESCRIPTION
Fixes #1959
Based on @unixfox's [comment](https://github.com/iv-org/invidious/issues/1959#issuecomment-811463524).

I've only done a minimal amount of testing but it seems to have worked. 

<details>
<summary>With</summary>

![test-1](https://user-images.githubusercontent.com/70992037/113219462-f89d8f80-9270-11eb-8dc6-1ad016f0e424.png)
</details>


<details>
<summary>Without</summary>

![trending-test](https://user-images.githubusercontent.com/70992037/113219467-faffe980-9270-11eb-84c4-7ffcf156251c.png)
</details>



