### PR TITLE
Fix missing last page in playlists

### DIFF
--- a/src/invidious/routes/playlists.cr
+++ b/src/invidious/routes/playlists.cr
@@ -434,7 +434,7 @@ class Invidious::Routes::Playlists < Invidious::Routes::BaseRoute
     end
 
     page_count = (playlist.video_count / 100).to_i
-    page_count = 1 if page_count == 0
+    page_count += 1 if (playlist.video_count % 100) > 0
 
     if page > page_count
       return env.redirect "/playlist?list=#{plid}&page=#{page_count}"


### PR DESCRIPTION
Bug introduced by #1911: Playlists with a video count is not a perfect multiple of 100 were missing their last page.
This is due to not taking into account the remainder when counting pages.

Thanks to Baobab on IRC for catching this one (They don't have a github account)!