### PR TITLE
Allow default_home config to be an empty string

### DIFF
--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -42,7 +42,7 @@ struct ConfigPreferences
   property player_style : String = "invidious"
   property quality : String = "hd720"
   property quality_dash : String = "auto"
-  property default_home : String = "Popular"
+  property default_home : String? = "Popular"
   property feed_menu : Array(String) = ["Popular", "Trending", "Subscriptions", "Playlists"]
   property related_videos : Bool = true
   property sort : String = "published"

--- a/src/invidious/users.cr
+++ b/src/invidious/users.cr
@@ -68,7 +68,7 @@ struct Preferences
   property quality : String = CONFIG.default_user_preferences.quality
   @[JSON::Field(converter: Preferences::ProcessString)]
   property quality_dash : String = CONFIG.default_user_preferences.quality_dash
-  property default_home : String = CONFIG.default_user_preferences.default_home
+  property default_home : String? = CONFIG.default_user_preferences.default_home
   property feed_menu : Array(String) = CONFIG.default_user_preferences.feed_menu
   property related_videos : Bool = CONFIG.default_user_preferences.related_videos
 


### PR DESCRIPTION
Fixes #1625 
This PR makes it possible to set an empty homepage through the configuration file.

Based on @saltycrys's [typing explanation here](https://github.com/iv-org/invidious/issues/1625#issuecomment-753240245). 