### PR TITLE
Configuration fixes for Docker and docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,10 @@ services:
     restart: unless-stopped
     volumes:
       - postgresdata:/var/lib/postgresql/data
-      - ./config/sql:/config/sql
-      - ./docker/init-invidious-db.sh:/docker-entrypoint-initdb.d/init-invidious-db.sh
     environment:
-      POSTGRES_DB: invidious
-      POSTGRES_PASSWORD: kemal
-      POSTGRES_USER: kemal
+      POSTGRES_DB: invidiousdb
+      POSTGRES_PASSWORD: R3p1aceW1thStr0ngPa33word
+      POSTGRES_USER: invidious
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres"]
   invidious:
@@ -21,20 +19,19 @@ services:
     ports:
       - "127.0.0.1:3000:3000"
     environment:
-      # Adapted from ./config/config.yml
-      INVIDIOUS_CONFIG: |
-        channel_threads: 1
-        check_tables: true
-        feed_threads: 1
-        db:
-          user: kemal
-          password: kemal
-          host: postgres
-          port: 5432
-          dbname: invidious
-        full_refresh: false
-        https_only: false
-        domain:
+      POSTGRES_USER: invidious
+      POSTGRES_PASS: R3p1aceW1thStr0ngPa33word
+      POSTGRES_HOST: postgres
+      POSTGRES_DB: invidiousdb
+      POSTGRES_PORT: 5432
+      INVIDIOUS_DOMAIN: localhost
+      INVIDIOUS_REGISTRATION_ENABLED: "true"
+      INVIDIOUS_DISABLE_PROXY: "false"
+      INVIDIOUS_HTTPS_ONLY: "false"
+      INVIDIOUS_FULL_REFRESH: "false"
+      INVIDIOUS_CHECK_TABLES: "true"
+      INVIDIOUS_CHANNEL_THREADS: 1
+      INVIDIOUS_FEED_THREADS: 1
     depends_on:
       - postgres
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,8 +20,7 @@ RUN addgroup -g 1000 -S invidious && \
     adduser -u 1000 -S invidious -G invidious
 COPY ./assets/ ./assets/
 COPY --chown=invidious ./config/config.* ./config/
-RUN mv -n config/config.example.yml config/config.yml
-RUN sed -i 's/host: \(127.0.0.1\|localhost\)/host: postgres/' config/config.yml
+
 COPY ./config/sql/ ./config/sql/
 COPY ./locales/ ./locales/
 COPY --from=builder /invidious/invidious .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,26 @@ COPY ./config/sql/ ./config/sql/
 COPY ./locales/ ./locales/
 COPY --from=builder /invidious/invidious .
 
+ENV POSTGRES_USER kemal
+ENV POSTGRES_PASS kemal
+ENV POSTGRES_HOST postgres
+ENV POSTGRES_DB invidious
+ENV POSTGRES_PORT 5432
+
+ENV INVIDIOUS_DOMAIN localhost
+ENV INVIDIOUS_REGISTRATION_ENABLED true
+ENV INVIDIOUS_DISABLE_PROXY false
+ENV INVIDIOUS_HTTPS_ONLY false
+ENV INVIDIOUS_FULL_REFRESH false
+ENV INVIDIOUS_CHECK_TABLES true
+ENV INVIDIOUS_CHANNEL_THREADS 1
+ENV INVIDIOUS_FEED_THREADS 1
+
+COPY docker/startup /startup
+RUN chown invidious:invidious /startup
+RUN chmod 700 /startup
+RUN chown -R invidious:invidious /invidious/config/sql
+
 EXPOSE 3000
 USER invidious
-CMD [ "/invidious/invidious" ]
+CMD [ "/startup" ]

--- a/docker/init-invidious-db.sh
+++ b/docker/init-invidious-db.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -eou pipefail
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-  CREATE USER postgres;
-EOSQL
-
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/channels.sql
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/videos.sql
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/channel_videos.sql

--- a/docker/startup
+++ b/docker/startup
@@ -1,23 +1,29 @@
 #!/bin/sh
 
-echo "Configuring Invidious"
+CONF_FILE="/invidious/config/config.yml"
 
-cat <<EOF > /invidious/config/config.yml
-channel_threads: $INVIDIOUS_CHANNEL_THREADS
-check_tables: $INVIDIOUS_CHECK_TABLES
-feed_threads: $INVIDIOUS_FEED_THREADS
-db:
-  user: $POSTGRES_USER
-  password: $POSTGRES_PASS
-  host: $POSTGRES_HOST
-  port: $POSTGRES_PORT
-  dbname: $POSTGRES_DB
-full_refresh: $INVIDIOUS_FULL_REFRESH
-https_only: $INVIDIOUS_HTTPS_ONLY
-domain:  $INVIDIOUS_DOMAIN
-registration_enabled: $INVIDIOUS_REGISTRATION_ENABLED
-disable_proxy: $INVIDIOUS_DISABLE_PROXY
+if [ -f "$CONF_FILE" ]; then
+  echo "Existing configuration found. Skipping environment variable based conifg..."
+else
+  echo "Configuring Invidious"
+
+  cat <<EOF > /invidious/config/config.yml
+  channel_threads: $INVIDIOUS_CHANNEL_THREADS
+  check_tables: $INVIDIOUS_CHECK_TABLES
+  feed_threads: $INVIDIOUS_FEED_THREADS
+  db:
+    user: $POSTGRES_USER
+    password: $POSTGRES_PASS
+    host: $POSTGRES_HOST
+    port: $POSTGRES_PORT
+    dbname: $POSTGRES_DB
+  full_refresh: $INVIDIOUS_FULL_REFRESH
+  https_only: $INVIDIOUS_HTTPS_ONLY
+  domain:  $INVIDIOUS_DOMAIN
+  registration_enabled: $INVIDIOUS_REGISTRATION_ENABLED
+  disable_proxy: $INVIDIOUS_DISABLE_PROXY
 EOF
+fi
 
 # kemal is the hardcoded postgres username
 for i in /invidious/config/sql/*.sql; do sed -i s/kemal/$POSTGRES_USER/g $i; done

--- a/docker/startup
+++ b/docker/startup
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+echo "Configuring Invidious"
+
+cat <<EOF > /invidious/config/config.yml
+channel_threads: $INVIDIOUS_CHANNEL_THREADS
+check_tables: $INVIDIOUS_CHECK_TABLES
+feed_threads: $INVIDIOUS_FEED_THREADS
+db:
+  user: $POSTGRES_USER
+  password: $POSTGRES_PASS
+  host: $POSTGRES_HOST
+  port: $POSTGRES_PORT
+  dbname: $POSTGRES_DB
+full_refresh: $INVIDIOUS_FULL_REFRESH
+https_only: $INVIDIOUS_HTTPS_ONLY
+domain:  $INVIDIOUS_DOMAIN
+registration_enabled: $INVIDIOUS_REGISTRATION_ENABLED
+disable_proxy: $INVIDIOUS_DISABLE_PROXY
+EOF
+
+# kemal is the hardcoded postgres username
+for i in /invidious/config/sql/*.sql; do sed -i s/kemal/$POSTGRES_USER/g $i; done
+
+echo "Starting Invidious"
+exec /invidious/invidious


### PR DESCRIPTION
The current docker-compose file indicates the entire configuration for invidious can be placed inside a single environment variable, but I couldn't get configuration changes to take effect. Unless I'm missing something, it seems like the program's entrypoint and crystal configuration loading does support pulling in the entire configuration from an environment variable (maybe it did at one time?)

I've adjusted the docker-compose file to define individual configuration variables and allow for custom usernames and password for the database initialization. I currently use a `sed` command in startup to adjust the SQL files, which is kinda hackey, and it seems like this might be addressed in #1678.

The configmap via Kubernetes seems to correctly support injecting a configuration file, but might break if this PR's startup replaces that configuration file on startup.