### PR TITLE
Set correct permissions in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,12 +18,12 @@ RUN apk add --no-cache librsvg ttf-opensans
 WORKDIR /invidious
 RUN addgroup -g 1000 -S invidious && \
     adduser -u 1000 -S invidious -G invidious
-COPY ./assets/ ./assets/
+COPY --chown=invidious ./assets/ ./assets/
 COPY --chown=invidious ./config/config.* ./config/
 RUN mv -n config/config.example.yml config/config.yml
 RUN sed -i 's/host: \(127.0.0.1\|localhost\)/host: postgres/' config/config.yml
-COPY ./config/sql/ ./config/sql/
-COPY ./locales/ ./locales/
+COPY --chown=invidious ./config/sql/ ./config/sql/
+COPY --chown=invidious ./locales/ ./locales/
 COPY --from=builder /invidious/invidious .
 
 EXPOSE 3000


### PR DESCRIPTION
When having a `umask` of `xx7` (e.g. `027`) on the host machine then the directories `assets`, `config` and `locales` don't become readable to the `invidious` user inside the Docker container since the `COPY` commands result in files owned by `root` with the same file permissions like on the host (`640` in my case).

By adding `--chown=invidious` to the `COPY` command we ensure the `invidious` user can read these files.