### PR TITLE
fix comments not loading

### DIFF
--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -185,7 +185,7 @@ def fetch_youtube_comments(id, db, cursor, format, locale, thin_mode, region, so
               json.field "published", published.to_unix
               json.field "publishedText", translate(locale, "`x` ago", recode_date(published, locale))
 
-              json.field "likeCount", node_comment["likeCount"]
+              json.field "likeCount", 0
               json.field "commentId", node_comment["commentId"]
               json.field "authorIsChannelOwner", node_comment["authorIsChannelOwner"]
 


### PR DESCRIPTION
(using a workaround: like count is always 0)

I did not use "" like https://github.com/iv-org/invidious/issues/2092#issuecomment-845753246 used, because using a string may break apps using the API until the real fix comes, whereas using an integer will provide a false value but won't break anything

fixes #2092 ,
I'll open a new issue for like count = 0 when this PR is merged