### PR TITLE
Fix the parsing of likes in the comments

### DIFF
--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -185,12 +185,14 @@ def fetch_youtube_comments(id, db, cursor, format, locale, thin_mode, region, so
               json.field "published", published.to_unix
               json.field "publishedText", translate(locale, "`x` ago", recode_date(published, locale))
 
-              json.field "likeCount", node_comment["likeCount"]
+              comment_action_buttons_renderer = node_comment["actionButtons"]["commentActionButtonsRenderer"]
+
+              json.field "likeCount", comment_action_buttons_renderer["likeButton"]["toggleButtonRenderer"]["accessibilityData"]["accessibilityData"]["label"].as_s.scan(/\d/).map(&.[0]).join.to_i
               json.field "commentId", node_comment["commentId"]
               json.field "authorIsChannelOwner", node_comment["authorIsChannelOwner"]
 
-              if node_comment["actionButtons"]["commentActionButtonsRenderer"]["creatorHeart"]?
-                hearth_data = node_comment["actionButtons"]["commentActionButtonsRenderer"]["creatorHeart"]["creatorHeartRenderer"]["creatorThumbnail"]
+              if comment_action_buttons_renderer["creatorHeart"]?
+                hearth_data = comment_action_buttons_renderer["creatorHeart"]["creatorHeartRenderer"]["creatorThumbnail"]
                 json.field "creatorHeart" do
                   json.object do
                     json.field "creatorThumbnail", hearth_data["thumbnails"][-1]["url"]


### PR DESCRIPTION
Fixes #2092

Based on the idea of @SamantazFox, I parse the label of the `accessibilityData` object in order to retrieve the number of likes:
```json
"accessibilityData":{
    "accessibilityData":{
        "label":"Like this comment along with 8,510 other people"
    }
}
```

I'm using a regex to find every digit in the string then combining every match, in this case `8` and `510` into one string (this is needed because [the regex function doesn't support the global match](https://github.com/crystal-lang/crystal/issues/2223)).
This is in my opinion pretty reliable because I don't see YouTube later adding numbers into the sentence.

I could add a fallback in case this break and instead parse the data from `voteCount`:
```json
"voteCount":{
    "accessibility":{
        "accessibilityData":{
        "label":"8.5K likes"
        }
    },
    "simpleText":"8.5K"
},
```
This would be acceptable for the HTML results but not for results from the API in JSON. So that's why I don't really see the point of doing that.