### PR TITLE
Add the ability to listen on UNIX sockets

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -3917,6 +3917,15 @@ add_context_storage_type(Preferences)
 add_context_storage_type(User)
 
 Kemal.config.logger = LOGGER
-Kemal.config.host_binding = Kemal.config.host_binding != "0.0.0.0" ? Kemal.config.host_binding : CONFIG.host_binding
-Kemal.config.port = Kemal.config.port != 3000 ? Kemal.config.port : CONFIG.port
-Kemal.run
+
+Kemal.run do |config|
+  if CONFIG.bind_unix
+    if File.exists?(CONFIG.bind_unix.not_nil!)
+      File.delete(CONFIG.bind_unix.not_nil!)
+    end
+    config.server.not_nil!.bind_unix CONFIG.bind_unix.not_nil!
+  else
+    config.host_binding = config.host_binding != "0.0.0.0" ? config.host_binding : CONFIG.host_binding
+    config.port = config.port != 3000 ? config.port : CONFIG.port
+  end
+end

--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -98,6 +98,7 @@ class Config
   property force_resolve : Socket::Family = Socket::Family::UNSPEC # Connect to YouTube over 'ipv6', 'ipv4'. Will sometimes resolve fix issues with rate-limiting (see https://github.com/ytdl-org/youtube-dl/issues/21729)
   property port : Int32 = 3000                                     # Port to listen for connections (overrided by command line argument)
   property host_binding : String = "0.0.0.0"                       # Host to bind (overrided by command line argument)
+  property bind_unix : String? = nil                               # Make Invidious listening on UNIX sockets - Example: /tmp/invidious.sock
   property pool_size : Int32 = 100                                 # Pool size for HTTP requests to youtube.com and ytimg.com (each domain has a separate pool of `pool_size`)
   property use_quic : Bool = true                                  # Use quic transport for youtube api
 


### PR DESCRIPTION
Kemal allows native ability to listen on UNIX sockets: https://kemalcr.com/cookbook/unix_domain_socket/. This pull request add the ability to configure the UNIX sockets on Invidious.

On some environments, especially Docker, this can improve the requests throughput up to 40%: https://blog.myhro.info/2017/01/benchmarking-ip-and-unix-domain-sockets-for-real! A very small Invidious instance won't notice this gain of performance but on a high demand instance with a lot of requests this can improve the latency and the amount of requests that an instance can serve.

On a bonus note: This improves the privacy because UNIX sockets are technically not forwarded on the network, so tools like tcpdump won't work in order to silently log any HTTP requests between invidious and the reverse proxy.