### PR TITLE
Replace lsquic.cr

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -16,10 +16,6 @@ shards:
     git: https://github.com/jeromegn/kilt.git
     version: 0.4.0
 
-  lsquic:
-    git: https://github.com/iv-org/lsquic.cr.git
-    version: 2.18.1-1
-
   pg:
     git: https://github.com/will/crystal-pg.git
     version: 0.23.1

--- a/shard.yml
+++ b/shard.yml
@@ -25,9 +25,6 @@ dependencies:
   protodec:
     github: iv-org/protodec
     version: ~> 0.1.3
-  lsquic:
-    github: iv-org/lsquic.cr
-    version: ~> 2.18.1-1
 
 crystal: 0.36.1
 

--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -101,8 +101,8 @@ class Config
   property host_binding : String = "0.0.0.0"                       # Host to bind (overrided by command line argument)
   property pool_size : Int32 = 100                                 # Pool size for HTTP requests to youtube.com and ytimg.com (each domain has a separate pool of `pool_size`)
   property use_quic : Bool = true                                  # Use quic transport for youtube api
-  property quic_proxy_address : String = "0.0.0.0"                      # Address for the QUIC proxy
-  property quic_proxy_port : Int32 = 7192                       # Port for the Quic Proxy
+  property quic_proxy_address : String = "0.0.0.0"                 # Address for the QUIC proxy
+  property quic_proxy_port : Int32 = 7192                          # Port for the Quic Proxy
 
   @[YAML::Field(converter: Preferences::StringToCookies)]
   property cookies : HTTP::Cookies = HTTP::Cookies.new               # Saved cookies in "name1=value1; name2=value2..." format

--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -101,6 +101,8 @@ class Config
   property host_binding : String = "0.0.0.0"                       # Host to bind (overrided by command line argument)
   property pool_size : Int32 = 100                                 # Pool size for HTTP requests to youtube.com and ytimg.com (each domain has a separate pool of `pool_size`)
   property use_quic : Bool = true                                  # Use quic transport for youtube api
+  property quic_proxy_address : String = "0.0.0.0"                      # Address for the QUIC proxy
+  property quic_proxy_port : Int32 = 7192                       # Port for the Quic Proxy
 
   @[YAML::Field(converter: Preferences::StringToCookies)]
   property cookies : HTTP::Cookies = HTTP::Cookies.new               # Saved cookies in "name1=value1; name2=value2..." format

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -61,7 +61,7 @@ struct YoutubeConnectionPool
 end
 
 class QuicProxyWrapper
-  property yt_headers : Hash(String, String) 
+  property yt_headers : Hash(String, String)
   property family : Socket::Family
 
   def initialize(url : URI)
@@ -72,13 +72,12 @@ class QuicProxyWrapper
 
     @yt_headers = header_retreival.headers
     # Scans through yt_headers and makes sure that all values are strings.
-    @yt_headers.each do |k,v|
+    @yt_headers.each do |k, v|
       if v.is_a? Array
         @yt_headers[k] = v[0]
       end
     end
   end
-    
 
   def family=(value)
     @conn.family = value
@@ -150,12 +149,12 @@ class QuicProxyWrapper
     end
   
   {% end %}
-  
+
   def post(url, headers, form)
     headers = convert_headers(headers)
     headers.merge!(@yt_headers)
     data = {"method" => "POST", "url" => "#{YT_URL.to_s}#{url}",
-    "headers"=>headers.to_h, "data" => form}.to_json
+            "headers" => headers.to_h, "data" => form}.to_json
 
     return @conn.post("/", body: data)
   end
@@ -175,15 +174,15 @@ end
 
 # We're just using this to retreive the headers from add_yt_headers
 class HackyHeaderRetrevialClass
-  def initialize()
+  def initialize
     @headers_dict = {} of String => String
   end
 
-  def headers()
+  def headers
     return @headers_dict
   end
 
-  def resource()
+  def resource
     return ""
   end
 end

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -62,9 +62,11 @@ end
 
 class QuicProxyWrapper
   property yt_headers : Hash(String, String) 
-  def initialize(url : URI, family : Socket::Family = Socket::Family::UNSPEC)
+  property family : Socket::Family
+
+  def initialize(url : URI)
     @conn = HTTP::Client.new(url)
-    @family = family
+    @family = Socket::Family::INET
     header_retreival = HackyHeaderRetrevialClass.new
     add_yt_headers(header_retreival)
 
@@ -78,11 +80,12 @@ class QuicProxyWrapper
   end
     
 
-  def family=(value)0
+  def family=(value)
+    @conn.family = value
   end
 
   def family
-    return @family
+    return @conn.family
   end
 
   def close

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -1,4 +1,3 @@
-require "lsquic"
 require "pool/connection"
 
 def add_yt_headers(request)
@@ -20,7 +19,7 @@ struct YoutubeConnectionPool
   property! url : URI
   property! capacity : Int32
   property! timeout : Float64
-  property pool : ConnectionPool(QuicProxyWrapper | HTTP::Client | QUIC::Client)
+  property pool : ConnectionPool(QuicProxyWrapper | HTTP::Client)
 
   def initialize(url : URI, @capacity = 5, @timeout = 5.0, use_quic = true)
     @url = url
@@ -47,7 +46,7 @@ struct YoutubeConnectionPool
   end
 
   private def build_pool(use_quic)
-    ConnectionPool(QuicProxyWrapper | HTTP::Client | QUIC::Client).new(capacity: capacity, timeout: timeout) do
+    ConnectionPool(QuicProxyWrapper | HTTP::Client).new(capacity: capacity, timeout: timeout) do
       if use_quic
         conn = QuicProxyWrapper.new(URI.parse("http://#{CONFIG.quic_proxy_address}:#{CONFIG.quic_proxy_port}"))
       else

--- a/src/invidious/routes/login.cr
+++ b/src/invidious/routes/login.cr
@@ -51,7 +51,7 @@ class Invidious::Routes::Login < Invidious::Routes::BaseRoute
 
       # See https://github.com/ytdl-org/youtube-dl/blob/2019.04.07/youtube_dl/extractor/youtube.py#L82
       begin
-        client = QUIC::Client.new(LOGIN_URL)
+        client = QuicProxyWrapper.new(LOGIN_URL)
         headers = HTTP::Headers.new
 
         login_page = client.get("/ServiceLogin")


### PR DESCRIPTION
Replaces lsquic.cr in Invidious with a interface to [invidious-quic-proxy](https://github.com/syeopite/Invidious-quic-proxy)

All of Invidious's features should be tested with this before merging. The dockerfile also needs to be changed for this but I'm not knowledgeable enough to do so.