### PR TITLE
Allow user preferences to effect extend_desc

### DIFF
--- a/src/invidious/routes/preferences.cr
+++ b/src/invidious/routes/preferences.cr
@@ -60,6 +60,10 @@ class Invidious::Routes::PreferencesRoute < Invidious::Routes::BaseRoute
     volume = env.params.body["volume"]?.try &.as(String).to_i?
     volume ||= CONFIG.default_user_preferences.volume
 
+    extend_desc = env.params.body["extend_desc"]?.try &.as(String)
+    extend_desc ||= "off"
+    extend_desc = extend_desc == "on"
+
     vr_mode = env.params.body["vr_mode"]?.try &.as(String)
     vr_mode ||= "off"
     vr_mode = vr_mode == "on"
@@ -144,6 +148,7 @@ class Invidious::Routes::PreferencesRoute < Invidious::Routes::BaseRoute
       unseen_only:            unseen_only,
       video_loop:             video_loop,
       volume:                 volume,
+      extend_desc:            extend_desc,
       vr_mode:                vr_mode,
     }.to_json).to_json
 


### PR DESCRIPTION
An oversight on my part meant that the extend_desc option can't actually be changed by the end user in preferences. This PR fixes that