### PR TITLE
Fix storyboard when proxied with an external port

### DIFF
--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -298,7 +298,7 @@ def make_host_url(kemal_config)
 
   # Add if non-standard port
   if port != 80 && port != 443
-    port = ":#{kemal_config.port}"
+    port = ":#{port}"
   else
     port = ""
   end


### PR DESCRIPTION
Say if it's `http://host:port` internally and proxied to
`https://domain:external_port`, the storyboard URL was rendered as
`https://domain:port`.