### PR TITLE
fix typo in the template file

### DIFF
--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -26,7 +26,7 @@
     <span style="display:none" id="dark_mode_pref"><%= env.get("preferences").as(Preferences).dark_mode %></span>
     <div class="pure-g">
         <div class="pure-u-1 pure-u-md-2-24"></div>
-        <div class="pure-u-1 pure-u-md-20-24", id="contents">
+        <div class="pure-u-1 pure-u-md-20-24" id="contents">
             <div class="pure-g navbar h-box">
                 <% if navbar_search %>
                     <div class="pure-u-1 pure-u-md-4-24">


### PR DESCRIPTION
In the template file there is a typo that makes the rendered HTML code invalid.
The browser doesn't really care, but it's still invalid HTML code.