### PR TITLE
Multiple search fixes

### DIFF
--- a/src/invidious/helpers/youtube_api.cr
+++ b/src/invidious/helpers/youtube_api.cr
@@ -79,7 +79,7 @@ end
 def request_youtube_api_search(search_query : String, params : String, region = nil)
   # JSON Request data, required by the API
   data = {
-    "query"   => URI.encode_www_form(search_query),
+    "query"   => search_query,
     "context" => make_youtube_api_context(region),
     "params"  => params,
   }

--- a/src/invidious/views/search_homepage.ecr
+++ b/src/invidious/views/search_homepage.ecr
@@ -1,7 +1,7 @@
 <% content_for "header" do %>
 <meta name="description" content="<%= translate(locale, "An alternative front-end to YouTube") %>">
 <title>
-    Invidious
+    Invidious - <%= translate(locale, "search") %>
 </title>
 <link rel="stylesheet" href="/css/empty.css?v=<%= ASSET_COMMIT %>">
 <% end %>


### PR DESCRIPTION
Fixes #2140 

Other fixes:
* Empty search redirects to /search, not /
* Show the fullscreen search "home page" (from #1977) at /search
* Allow 'region=' parameter to be passed to /search
* Add "search" to fullscreen search page's `<title>`
