### PR TITLE
Disallow /watch path for bots again

### DIFF
--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Disallow: /search
 Disallow: /login
+Disallow: /watch


### PR DESCRIPTION
Allowing the /watch path in the robots.txt enables google to index a lot of videos on an invidious instance. This merge request disables that behavior but not allowing bots and crawlers to index videos.