### PR TITLE
Add 10px margin to top and bottom of hr element

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -488,7 +488,7 @@ body.dark-theme {
 the hr element is rendered improperly within one.
 See https://stackoverflow.com/a/34372979 for more info */
 hr {
-  margin: auto 0 auto 0;
+  margin: 10px 0 10px 0;
 }
 
 /* Description Expansion Styling*/


### PR DESCRIPTION
Hello! This is a really minor change, but it's something that's been irking me slightly for a while. After Invidious switched to flexboxes a while back, the ``hr`` element seems to have lost its top/bottom margins. You can see how it used to look in [this screenshot](https://github.com/iv-org/invidious/blob/master/screenshots/04_description.png?raw=true) on the README, versus how it looks at the moment:
![1623695176](https://user-images.githubusercontent.com/47785671/121941665-cc8c9900-cd0c-11eb-9b7c-e7d69000195d.png)
This PR just adds a 10px margin to the top and bottom of the hr element so it looks a little more like it did prior.
![1623695222](https://user-images.githubusercontent.com/47785671/121941788-f04fdf00-cd0c-11eb-9ebb-62b16a91dc69.png)
This also makes the Subscriptions page look a little nicer than it does currently! I did a little testing and it doesn't seem to affect the website's ability to scale to different screen sizes.