### PR TITLE
Use alternate instance button vs watch on YouTube

### DIFF
--- a/src/invidious/views/components/item.ecr
+++ b/src/invidious/views/components/item.ecr
@@ -141,7 +141,7 @@
                 <b style="flex: 1;">
                     <a style="width:100%" href="/channel/<%= item.ucid %>"><%= item.author %></a>
                 </b>
-                <a title="<%=translate(locale, "Watch on YouTube")%>" href="https://www.youtube.com/watch?v=<%= item.id %>" style="margin-right: 5px;">
+                <a title="<%=translate(locale, "Use Alternate Instance")%>" href="https://redirect.invidious.io/watch?v=<%= item.id %>" style="margin-right: 5px;">
                     <i class="icon ion-logo-youtube"></i>
                 </a>
                 <a title="<%=translate(locale, "Audio mode")%>" href="/watch?v=<%= item.id %>&amp;listen=1">


### PR DESCRIPTION
Encourages people to use the redirect.invidious.io site other than using YouTube when an instance is broken/ratelimited.