### PR TITLE
futureproof comment avatars

### DIFF
--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -315,7 +315,7 @@ def template_youtube_comments(comments, locale, thin_mode, is_replies = false)
       html << <<-END_HTML
       <div class="pure-g" style="width:100%">
         <div class="channel-profile pure-u-4-24 pure-u-md-2-24">
-          <img style="padding-right:1em;padding-top:1em;width:90%" src="#{author_thumbnail}">
+          <img style="margin-right:1em;margin-top:1em;width:90%" src="#{author_thumbnail}">
         </div>
         <div class="pure-u-20-24 pure-u-md-22-24">
           <p>


### PR DESCRIPTION
i was injecting custom css into the site that made the avatars round, and noticed comment avatars looked a little odd

i opened dev tools and siffed through the html, and noticed that the image was being padded,
when it would look nicer if the element used margin instead of padding

with padding:
![image](https://user-images.githubusercontent.com/82222883/123371497-807cf800-d547-11eb-8ae0-f6a743e22561.png)

with proposed changes (margin instead of padding):
![image](https://user-images.githubusercontent.com/82222883/123371520-8d015080-d547-11eb-9ce5-84b4e85c5701.png)