### PR TITLE
Pick a random video for bypass captcha

### DIFF
--- a/src/invidious/jobs/bypass_captcha_job.cr
+++ b/src/invidious/jobs/bypass_captcha_job.cr
@@ -2,7 +2,11 @@ class Invidious::Jobs::BypassCaptchaJob < Invidious::Jobs::BaseJob
   def begin
     loop do
       begin
-        {"/watch?v=zj82_v2R6ts&gl=US&hl=en&has_verified=1&bpctr=9999999999", produce_channel_videos_url(ucid: "UCK87Lox575O_HCHBWaBSyGA")}.each do |path|
+        random_video = PG_DB.query_one?("select id, ucid from (select id, ucid from channel_videos limit 1000) as s ORDER BY RANDOM() LIMIT 1", as: {id: String, ucid: String})
+        if !random_video
+          random_video = {id: "zj82_v2R6ts", ucid: "UCK87Lox575O_HCHBWaBSyGA"}
+        end
+        {"/watch?v=#{random_video["id"]}&gl=US&hl=en&has_verified=1&bpctr=9999999999", produce_channel_videos_url(ucid: random_video["ucid"])}.each do |path|
           response = YT_POOL.client &.get(path)
           if response.body.includes?("To continue with your YouTube experience, please fill out the form below.")
             html = XML.parse_html(response.body)


### PR DESCRIPTION
Fixes #2131 #2181

I choose only the 1000 first rows because it is still faster than picking a random row when there are 7 000 000 rows in the database.

Cost of computing a random row from 1000 rows:
````
Limit  (cost=55.18..55.18 rows=1 width=45) (actual time=1.337..1.338 rows=1 loops=1)
  ->  Sort  (cost=55.18..57.68 rows=1000 width=45) (actual time=1.336..1.337 rows=1 loops=1)
        Sort Key: (random())
        Sort Method: top-N heapsort  Memory: 25kB
        ->  Subquery Scan on s  (cost=0.00..50.18 rows=1000 width=45) (actual time=0.017..1.081 rows=1000 loops=1)
              ->  Limit  (cost=0.00..37.68 rows=1000 width=37) (actual time=0.015..0.918 rows=1000 loops=1)
                    ->  Seq Scan on channel_videos  (cost=0.00..284610.53 rows=7552953 width=37) (actual time=0.015..0.827 rows=1000 loops=1)
Planning time: 0.103 ms
Execution time: 1.374 ms
````

We don't want to add more strain on the database. Also, the 1000 first rows will vary A LOT by Invidious installations, so I expect we don't need later to pick a random row from a bigger dataset of rows.

Obviously, this code works even if the table has one row or if the table is empty.