### PR TITLE
Partial (and temporary) fix for age restricted videos

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -1961,9 +1961,9 @@ get "/api/v1/captions/:id" do |env|
           json.array do
             captions.each do |caption|
               json.object do
-                json.field "label", caption.name.simpleText
+                json.field "label", caption.name
                 json.field "languageCode", caption.languageCode
-                json.field "url", "/api/v1/captions/#{id}?label=#{URI.encode_www_form(caption.name.simpleText)}"
+                json.field "url", "/api/v1/captions/#{id}?label=#{URI.encode_www_form(caption.name)}"
               end
             end
           end
@@ -1979,7 +1979,7 @@ get "/api/v1/captions/:id" do |env|
   if lang
     caption = captions.select { |caption| caption.languageCode == lang }
   else
-    caption = captions.select { |caption| caption.name.simpleText == label }
+    caption = captions.select { |caption| caption.name == label }
   end
 
   if caption.empty?
@@ -1993,7 +1993,7 @@ get "/api/v1/captions/:id" do |env|
 
   # Auto-generated captions often have cues that aren't aligned properly with the video,
   # as well as some other markup that makes it cumbersome, so we try to fix that here
-  if caption.name.simpleText.includes? "auto-generated"
+  if caption.name.includes? "auto-generated"
     caption_xml = YT_POOL.client &.get(url).body
     caption_xml = XML.parse(caption_xml)
 

--- a/src/invidious/routes/embed.cr
+++ b/src/invidious/routes/embed.cr
@@ -165,11 +165,11 @@ class Invidious::Routes::Embed < Invidious::Routes::BaseRoute
     captions = video.captions
 
     preferred_captions = captions.select { |caption|
-      params.preferred_captions.includes?(caption.name.simpleText) ||
+      params.preferred_captions.includes?(caption.name) ||
         params.preferred_captions.includes?(caption.languageCode.split("-")[0])
     }
     preferred_captions.sort_by! { |caption|
-      (params.preferred_captions.index(caption.name.simpleText) ||
+      (params.preferred_captions.index(caption.name) ||
         params.preferred_captions.index(caption.languageCode.split("-")[0])).not_nil!
     }
     captions = captions - preferred_captions

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -150,11 +150,11 @@ class Invidious::Routes::Watch < Invidious::Routes::BaseRoute
     captions = video.captions
 
     preferred_captions = captions.select { |caption|
-      params.preferred_captions.includes?(caption.name.simpleText) ||
+      params.preferred_captions.includes?(caption.name) ||
         params.preferred_captions.includes?(caption.languageCode.split("-")[0])
     }
     preferred_captions.sort_by! { |caption|
-      (params.preferred_captions.index(caption.name.simpleText) ||
+      (params.preferred_captions.index(caption.name) ||
         params.preferred_captions.index(caption.languageCode.split("-")[0])).not_nil!
     }
     captions = captions - preferred_captions

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -786,7 +786,7 @@ struct Video
   end
 end
 
-class Caption
+struct Caption
   property name
   property languageCode
   property baseUrl

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -989,9 +989,15 @@ def fetch_video(id, region)
 
   # Try to pull streams from embed URL
   if info["reason"]?
-    embed_page = YT_POOL.client &.get("/embed/#{id}").body
-    sts = embed_page.match(/"sts"\s*:\s*(?<sts>\d+)/).try &.["sts"]? || ""
-    embed_info = HTTP::Params.parse(YT_POOL.client &.get("/get_video_info?html5=1&video_id=#{id}&eurl=https://youtube.googleapis.com/v/#{id}&gl=US&hl=en&sts=#{sts}").body)
+    required_parameters = URI::Params.new({
+      "video_id" => [id],
+      "eurl"     => ["https://youtube.googleapis.com/v/#{id}"],
+      "html5"    => ["1"],
+      "c"        => ["TVHTML5"],
+      "cver"     => ["6.20180913"],
+    })
+
+    embed_info = HTTP::Params.parse(YT_POOL.client &.get("/get_video_info?#{required_parameters}", headers: HTTP::Headers{"x-youtube-client-version" => "6.20180913"}).body)
 
     if embed_info["player_response"]?
       player_response = JSON.parse(embed_info["player_response"])

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -425,9 +425,9 @@ struct Video
         json.array do
           self.captions.each do |caption|
             json.object do
-              json.field "label", caption.name.simpleText
+              json.field "label", caption.name
               json.field "languageCode", caption.languageCode
-              json.field "url", "/api/v1/captions/#{id}?label=#{URI.encode_www_form(caption.name.simpleText)}"
+              json.field "url", "/api/v1/captions/#{id}?label=#{URI.encode_www_form(caption.name)}"
             end
           end
         end
@@ -706,8 +706,12 @@ struct Video
   def captions : Array(Caption)
     return @captions.as(Array(Caption)) if @captions
     captions = info["captions"]?.try &.["playerCaptionsTracklistRenderer"]?.try &.["captionTracks"]?.try &.as_a.map do |caption|
-      caption = Caption.from_json(caption.to_json)
-      caption.name.simpleText = caption.name.simpleText.split(" - ")[0]
+      name = caption["name"]["simpleText"]? || caption["name"]["runs"][0]["text"]
+      languageCode = caption["languageCode"].to_s
+      baseUrl = caption["baseUrl"].to_s
+
+      caption = Caption.new(name.to_s, languageCode, baseUrl)
+      caption.name = caption.name.split(" - ")[0]
       caption
     end
     captions ||= [] of Caption
@@ -782,18 +786,19 @@ struct Video
   end
 end
 
-struct CaptionName
-  include JSON::Serializable
+class Caption
+  property name
+  property languageCode
+  property baseUrl
 
-  property simpleText : String
-end
+  getter name : String
+  getter languageCode : String
+  getter baseUrl : String
 
-struct Caption
-  include JSON::Serializable
+  setter name
 
-  property name : CaptionName
-  property baseUrl : String
-  property languageCode : String
+  def initialize(@name, @languageCode, @baseUrl)
+  end
 end
 
 class VideoRedirect < Exception

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -999,7 +999,8 @@ def fetch_video(id, region)
       "cver"     => "6.20180913",
     })
 
-    # In order to actually extract video info without error, the `x-youtube-client-version` has to be set to the same version as `cver` above.
+    # In order to actually extract video info without error, the `x-youtube-client-version`
+    # has to be set to the same version as `cver` above.
     embed_info = HTTP::Params.parse(YT_POOL.client &.get("/get_video_info?#{required_parameters}",
       headers: HTTP::Headers{
         "x-youtube-client-version" => "6.20180913",

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -25,13 +25,13 @@
         <% end %>
 
         <% preferred_captions.each do |caption| %>
-            <track kind="captions" src="/api/v1/captions/<%= video.id %>?label=<%= caption.name.simpleText %>&hl=<%= env.get("preferences").as(Preferences).locale %>"
-                label="<%= caption.name.simpleText %>">
+            <track kind="captions" src="/api/v1/captions/<%= video.id %>?label=<%= caption.name %>&hl=<%= env.get("preferences").as(Preferences).locale %>"
+                label="<%= caption.name %>">
         <% end %>
 
         <% captions.each do |caption| %>
-            <track kind="captions" src="/api/v1/captions/<%= video.id %>?label=<%= caption.name.simpleText %>&hl=<%= env.get("preferences").as(Preferences).locale %>"
-                label="<%= caption.name.simpleText %>">
+            <track kind="captions" src="/api/v1/captions/<%= video.id %>?label=<%= caption.name %>&hl=<%= env.get("preferences").as(Preferences).locale %>"
+                label="<%= caption.name %>">
         <% end %>
     <% end %>
 </video>

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -178,8 +178,8 @@ we're going to need to do it here in order to allow for translations.
                                 </option>
                             <% end %>
                             <% captions.each do |caption| %>
-                                <option value='{"id":"<%= video.id %>","label":"<%= caption.name.simpleText %>","title":"<%= URI.encode_www_form(video.title) %>-<%= video.id %>.<%= caption.languageCode %>.vtt"}'>
-                                    <%= translate(locale, "Subtitles - `x` (.vtt)", caption.name.simpleText) %>
+                                <option value='{"id":"<%= video.id %>","label":"<%= caption.name %>","title":"<%= URI.encode_www_form(video.title) %>-<%= video.id %>.<%= caption.languageCode %>.vtt"}'>
+                                    <%= translate(locale, "Subtitles - `x` (.vtt)", caption.name) %>
                                 </option>
                             <% end %>
                         </select>


### PR DESCRIPTION
Fixes #2189

This is a temporarily fix for age restricted videos based on what many other projects such as yt-dlp have implemented. However, this only fixes a large portion of age restricted videos but not all of them. Furthermore, it seems like this fix also either exposes or creates issues regarding  captions on a subset of age gated videos. 

If this PR is still compatible with the bounty, I'll like to claim it. Please don't use my previous address though.