### PR TITLE
Use the new youtube api for comments

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -2066,9 +2066,6 @@ get "/api/v1/comments/:id" do |env|
   format = env.params.query["format"]?
   format ||= "json"
 
-  action = env.params.query["action"]?
-  action ||= "action_get_comments"
-
   continuation = env.params.query["continuation"]?
   sort_by = env.params.query["sort_by"]?.try &.downcase
 
@@ -2076,7 +2073,7 @@ get "/api/v1/comments/:id" do |env|
     sort_by ||= "top"
 
     begin
-      comments = fetch_youtube_comments(id, PG_DB, continuation, format, locale, thin_mode, region, sort_by: sort_by, action: action)
+      comments = fetch_youtube_comments(id, continuation, format, locale, thin_mode, region, sort_by: sort_by)
     rescue ex
       next error_json(500, ex)
     end

--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -57,8 +57,6 @@ class RedditListing
 end
 
 def fetch_youtube_comments(id, db, cursor, format, locale, thin_mode, region, sort_by = "top", action = "action_get_comments")
-  video = get_video(id, db, region: region)
-
   case cursor
   when nil, ""
     ctoken = produce_comment_continuation(id, cursor: "", sort_by: sort_by)

--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -56,7 +56,7 @@ class RedditListing
   property modhash : String
 end
 
-def fetch_youtube_comments(id, db, cursor, format, locale, thin_mode, region, sort_by = "top", action = "action_get_comments")
+def fetch_youtube_comments(id, cursor, format, locale, thin_mode, region, sort_by = "top")
   case cursor
   when nil, ""
     ctoken = produce_comment_continuation(id, cursor: "", sort_by: sort_by)
@@ -68,7 +68,8 @@ def fetch_youtube_comments(id, db, cursor, format, locale, thin_mode, region, so
     ctoken = cursor
   end
 
-  response = YoutubeAPI.next(continuation: ctoken)
+  client_config = YoutubeAPI::ClientConfig.new(region: region)
+  response = YoutubeAPI.next(continuation: ctoken, client_config: client_config)
 
   if !response["continuationContents"]?
     raise InfoException.new("Could not fetch comments")
@@ -209,7 +210,7 @@ def fetch_youtube_comments(id, db, cursor, format, locale, thin_mode, region, so
 
   if format == "html"
     response = JSON.parse(response)
-    content_html = template_youtube_comments(response, locale, thin_mode, action == "action_get_comment_replies")
+    content_html = template_youtube_comments(response, locale, thin_mode)
 
     response = JSON.build do |json|
       json.object do

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -92,7 +92,7 @@ class Invidious::Routes::Watch < Invidious::Routes::BaseRoute
 
         if source == "youtube"
           begin
-            comment_html = JSON.parse(fetch_youtube_comments(id, PG_DB, nil, "html", locale, preferences.thin_mode, region))["contentHtml"]
+            comment_html = JSON.parse(fetch_youtube_comments(id, nil, "html", locale, preferences.thin_mode, region))["contentHtml"]
           rescue ex
             if preferences.comments[1] == "reddit"
               comments, reddit_thread = fetch_reddit_comments(id)
@@ -111,12 +111,12 @@ class Invidious::Routes::Watch < Invidious::Routes::BaseRoute
             comment_html = replace_links(comment_html)
           rescue ex
             if preferences.comments[1] == "youtube"
-              comment_html = JSON.parse(fetch_youtube_comments(id, PG_DB, nil, "html", locale, preferences.thin_mode, region))["contentHtml"]
+              comment_html = JSON.parse(fetch_youtube_comments(id, nil, "html", locale, preferences.thin_mode, region))["contentHtml"]
             end
           end
         end
       else
-        comment_html = JSON.parse(fetch_youtube_comments(id, PG_DB, nil, "html", locale, preferences.thin_mode, region))["contentHtml"]
+        comment_html = JSON.parse(fetch_youtube_comments(id, nil, "html", locale, preferences.thin_mode, region))["contentHtml"]
       end
 
       comment_html ||= ""


### PR DESCRIPTION
This PR is related to #1981.

This PR switch the endpoint used for fetching the comments from the old and soon deprecated `https://www.youtube.com/comment_service_ajax` to the InnerTube API with the endpoint `/next`.

Issue to fix:
```
invidious Invalid memory access (signal 11) at address 0xffff811a8158                                                                                                                        │
│ invidious [0x673488] print_backtrace at /usr/lib/crystal/core/exception/call_stack.cr:129:5                                                                                                  │
│ invidious [0x41ac70] __crystal_sigfault_handler at /usr/lib/crystal/core/signal.cr:347:3                                                                                                     │
│ invidious [0xf4e5f4] posix_spawn_file_actions_init at src/process/posix_spawn_file_actions_init.c:7:1                                                                                        │
│ invidious [0xcbd510] ???                                                                                                                                                                     │
│ invidious [0x47f334] -> at /invidious/lib/lsquic/src/lsquic/client.cr:210:11                                                                                                                 │
│ invidious [0x71df28] run at /usr/lib/crystal/core/primitives.cr:255:3                                                                                                                        │
│ invidious [0x41a184] -> at /usr/lib/crystal/core/fiber.cr:92:34                                                                                                                              │
│ invidious [0x0] ???
```