### PR TITLE
Prevent YouTube throttling

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -4,6 +4,10 @@ shards:
     git: https://github.com/crystal-lang/crystal-db.git
     version: 0.10.1
 
+  duktape:
+    git: https://github.com/jessedoyle/duktape.cr.git
+    version: 1.0.0
+
   exception_page:
     git: https://github.com/crystal-loot/exception_page.git
     version: 0.1.5

--- a/shard.yml
+++ b/shard.yml
@@ -25,6 +25,9 @@ dependencies:
   lsquic:
     github: iv-org/lsquic.cr
     version: ~> 2.18.1-2
+  duktape:
+    github: jessedoyle/duktape.cr
+    version: ~> 1.0.0
 
 crystal: 1.0.0
 

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -586,6 +586,7 @@ struct Video
         fmt["url"] = JSON::Any.new("#{fmt["url"]}#{DECRYPT_FUNCTION.decrypt_signature(fmt)}")
       end
 
+      fmt["url"] = JSON::Any.new(DECRYPT_FUNCTION.overwrite_n(self.id, fmt))
       fmt["url"] = JSON::Any.new("#{fmt["url"]}&host=#{URI.parse(fmt["url"].as_s).host}")
       fmt["url"] = JSON::Any.new("#{fmt["url"]}&region=#{self.info["region"]}") if self.info["region"]?
     end
@@ -605,6 +606,7 @@ struct Video
         fmt["url"] = JSON::Any.new("#{fmt["url"]}#{DECRYPT_FUNCTION.decrypt_signature(fmt)}")
       end
 
+      fmt["url"] = JSON::Any.new(DECRYPT_FUNCTION.overwrite_n(self.id, fmt))
       fmt["url"] = JSON::Any.new("#{fmt["url"]}&host=#{URI.parse(fmt["url"].as_s).host}")
       fmt["url"] = JSON::Any.new("#{fmt["url"]}&region=#{self.info["region"]}") if self.info["region"]?
     end


### PR DESCRIPTION
Hi there, I'm trying to fix #2194.

Though this is unfinished and a bit unstable, the parch seems working on PC/RPI4.
(I'm testing on a docker instance. #2147 needs `RUN apk add --no-cache make` to build this patch.)

Unfortunately it now requires a real JS interpreter (duktape) because the decryption code was too complicated without it.

ytdl-org/youtube-dl#29326 says
> This does change with different player versions, so youtube-dl will need to extract this for every video that it fetches and then modify the n parameter as such.

but it's not changed so often, and fetching it for every video is pretty expensive. This needs more investigating.

Anyway, I implemented two level caches to prevent refetching it for every video. The decryption function is called dozens times on page load. (you can see `cache #1` and `cache #2` in the debug log)

```
invidious_1  | 2021-06-28 05:54:47 UTC [debug] decrypt_n: 1LaKH5etJoE fn = cha n = RFcl_9VK-CZhPMH89IYrX -> Fcw3Gl6gxDsX_A
invidious_1  | 2021-06-28 05:54:47 UTC [debug] decrypt_n: 1LaKH5etJoE fn = (cache #1) n = RFcl_9VK-CZhPMH89IYrX -> Fcw3Gl6gxDsX_A
invidious_1  | 2021-06-28 05:54:48 UTC [debug] decrypt_n: 1LaKH5etJoE fn = (cache #2) n = Fbc5fFBLqpj0fJOfAj4Gr -> 48_sUCeKYn_LHg
invidious_1  | 2021-06-28 05:54:48 UTC [debug] decrypt_n: 1LaKH5etJoE fn = (cache #1) n = Fbc5fFBLqpj0fJOfAj4Gr -> 48_sUCeKYn_LHg
invidious_1  | 2021-06-28 05:54:48 UTC [debug] decrypt_n: 1LaKH5etJoE fn = (cache #1) n = Fbc5fFBLqpj0fJOfAj4Gr -> 48_sUCeKYn_LHg
invidious_1  | 2021-06-28 05:54:48 UTC [debug] decrypt_n: 1LaKH5etJoE fn = (cache #1) n = Fbc5fFBLqpj0fJOfAj4Gr -> 48_sUCeKYn_LHg
   :
```