### PR TITLE
Remove workaround for kemalcr/kemal/issues/575

### DIFF
--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -700,26 +700,6 @@ def proxy_file(response, env)
   end
 end
 
-# See https://github.com/kemalcr/kemal/pull/576
-class HTTP::Server::Response::Output
-  def close
-    return if closed?
-
-    unless response.wrote_headers?
-      response.content_length = @out_count
-    end
-
-    ensure_headers_written
-
-    super
-
-    if @chunked
-      @io << "0\r\n\r\n"
-      @io.flush
-    end
-  end
-end
-
 class HTTP::Client::Response
   def pipe(io)
     HTTP.serialize_body(io, headers, @body, @body_io, @version)


### PR DESCRIPTION
Removing the workaround for a bug described in https://github.com/kemalcr/kemal/issues/575 and fixed in https://github.com/kemalcr/kemal/pull/576.

The workaround was introduced by @omarroth in https://github.com/iv-org/invidious/commit/d30a972a#diff-06fc4c84acaa6461d7a42730dcb5d21997eb524bb17fcb14f9d82c32035fa4a2R918.