### PR TITLE
Mute unbuffered_flush IOError exception

### DIFF
--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -700,6 +700,16 @@ def proxy_file(response, env)
   end
 end
 
+class HTTP::Server::Response
+  class Output
+    private def unbuffered_flush
+      @io.flush
+    rescue ex : IO::Error
+      unbuffered_close
+    end
+  end
+end
+
 class HTTP::Client::Response
   def pipe(io)
     HTTP.serialize_body(io, headers, @body, @body_io, @version)


### PR DESCRIPTION
Related #1416, it doesn't really fix the real error, but it mutes the `Error while flushing data to the client` exception until we come up with a fix for the error.

Like explained in #1416, this exception `Error while flushing data to the client` doesn't really do any actual harm to the communication between the client and the server. But this exception message, really continuously spam the logs and make debugging and finding other errors really difficult.

That's why I would rather mute it so that I can more easily find the real other errors in my logs and better test the pull requests.

This code override these lines: https://github.com/crystal-lang/crystal/blob/master/src/http/server/response.cr#L274-L279