### PR TITLE
Playlist starts at the offset (fixes: #1952) 

### DIFF
--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -437,17 +437,38 @@ def get_playlist_videos(db, playlist, offset, locale = nil, continuation = nil)
     db.query_all("SELECT * FROM playlist_videos WHERE plid = $1 ORDER BY array_position($2, index) LIMIT 100 OFFSET $3",
       playlist.id, playlist.index, offset, as: PlaylistVideo)
   else
-    if offset >= 100
-      # Normalize offset to match youtube's behavior (100 videos chunck per request)
-      offset = (offset / 100).to_i64 * 100_i64
+    videos = [] of PlaylistVideo
 
-      ctoken = produce_playlist_continuation(playlist.id, offset)
-      initial_data = request_youtube_api_browse(ctoken)
-    else
-      initial_data = request_youtube_api_browse("VL" + playlist.id, params: "")
+    until videos.size >= 50 || videos.size == playlist.video_count 
+      if offset >= 100
+        # Normalize offset to match youtube's behavior (100 videos chunck per request)
+        normalized_offset = (offset / 100).to_i64 * 100_i64
+        ctoken = produce_playlist_continuation(playlist.id, normalized_offset)
+        initial_data = request_youtube_api_browse(ctoken)
+      else
+        initial_data = request_youtube_api_browse("VL" + playlist.id, params: "")
+      end
+
+      videos += extract_playlist_videos(initial_data)
+
+      if continuation
+        until videos[0].id == continuation
+          videos.shift
+        end
+      elsif
+        until videos[0].index == offset
+          videos.shift
+        end
+      end
+
+      if offset == 0
+        offset = videos[0].index
+      end
+
+      offset += 50
     end
 
-    return extract_playlist_videos(initial_data)
+    return videos
   end
 end
 


### PR DESCRIPTION
Fixes: #1952 
I want to be awarded the bounty associated to the issue this PR is fixing.

I'm not familiar with the code base, but I really wanted a working playlist! 

I noticed that the ```nextVideo``` that the frontend receives was always the ID from the second video of the playlist. I looked at how the mixer is handled at  ```fetch_mix```, and saw that the list is shifted until it reaches the offset. 

It was not happening on ```def get_playlist_videos(db, playlist, offset, locale = nil, continuation = nil)``` even though we pass the offset. So I applied it. I don't know if that's the intended behavior.

Also made sure that the playlist is always filled with videos if possible. The first time a playlist is executed, it might not have an offset, that's why it takes the one from the ```continuation.video_count```