### PR TITLE
Fix "fatal role postgres doesn't exist"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       POSTGRES_PASSWORD: kemal
       POSTGRES_USER: kemal
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER"]
   invidious:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       POSTGRES_PASSWORD: kemal
       POSTGRES_USER: kemal
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
   invidious:
     build:
       context: .


### PR DESCRIPTION
Fix a frequent error with recent postgres docker images:
`FATAL:  role "postgres" does not exist`