### PR TITLE
Update lock inactive days

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -13,8 +13,8 @@ jobs:
       - uses: dessant/lock-threads@v2
         with:
           github-token: ${{ github.token }}
-          issue-lock-inactive-days: '30'
-          pr-lock-inactive-days: '30'
+          issue-lock-inactive-days: '240'
+          pr-lock-inactive-days: '240'
           issue-lock-reason: 'resolved'
           pr-lock-reason: 'resolved'
 


### PR DESCRIPTION
30 days is just too low, I changed that to 8 months, which is in my opinion still a timeframe where the reported issue can still be relevant and maybe opened or having feedback again on it.