### PR TITLE
Remove the decrypt function job

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -136,11 +136,6 @@ if CONFIG.feed_threads > 0
   Invidious::Jobs.register Invidious::Jobs::RefreshFeedsJob.new(PG_DB)
 end
 
-DECRYPT_FUNCTION = DecryptFunction.new(CONFIG.decrypt_polling)
-if CONFIG.decrypt_polling
-  Invidious::Jobs.register Invidious::Jobs::UpdateDecryptFunctionJob.new
-end
-
 if CONFIG.statistics_enabled
   Invidious::Jobs.register Invidious::Jobs::StatisticsRefreshJob.new(PG_DB, SOFTWARE)
 end


### PR DESCRIPTION
Closes #1762

As this feature is currently broken, remove the job so it doesn't make periodic requests to YT.

Depending on the decision made in #2354, the rest of the code will be either removed or updated.