### PR TITLE
Remove 3gp only from the player

### DIFF
--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -16,6 +16,8 @@
             <% end %>
 
             <%
+            fmt_stream.reject! { |f| f["itag"] == 17 }
+            fmt_stream.sort_by! {|f| params.quality == f["quality"] ? 0 : 1 }
             fmt_stream.each_with_index do |fmt, i|
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local


### PR DESCRIPTION
and video quality precedence on default player when JavaScript is not enabled

This fixes #2359, this fixes #2361 and this help with #2236.

Why does this help with #2236? If hd720 quality is set but not dash then the safari browser on iOS will load a 720p video which is the maximum video quality that safari on iOS can load due to not supporting dash, that's what youtube is doing too.

--------------

In testing on https://yewtu.be