### PR TITLE
Handle equirectangular projections for VR

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -151,7 +151,12 @@ player.on('error', function (event) {
 // Enable VR video support
 if (video_data.vr && video_data.params.vr_mode) {
     player.crossOrigin("anonymous")
-    player.vr({projection: "EAC"});
+    switch (video_data.projection_type) {
+        case "EQUIRECTANGULAR":
+            player.vr({projection: "equirectangular"});
+        default: // Should only be "MESH". But We'll use this as a fallback.
+            player.vr({projection: "EAC"});
+    }
 }
 
 // Add markers

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -154,7 +154,7 @@ if (video_data.vr && video_data.params.vr_mode) {
     switch (video_data.projection_type) {
         case "EQUIRECTANGULAR":
             player.vr({projection: "equirectangular"});
-        default: // Should only be "MESH". But We'll use this as a fallback.
+        default: // Should only be "MESH" but we'll use this as a fallback.
             player.vr({projection: "EAC"});
     }
 }

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -762,7 +762,12 @@ struct Video
   end
 
   def is_vr : Bool?
-    info.dig?("streamingData", "adaptiveFormats", 0, "projectionType").try &.as_s == "MESH"
+    projection_type = info.dig?("streamingData", "adaptiveFormats", 0, "projectionType").try &.as_s
+    return {"EQUIRECTANGULAR", "MESH"}.includes? projection_type
+  end
+
+  def projection_type : String?
+    return info.dig?("streamingData", "adaptiveFormats", 0, "projectionType").try &.as_s
   end
 
   def wilson_score : Float64

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -63,7 +63,8 @@ we're going to need to do it here in order to allow for translations.
     "params" => params,
     "preferences" => preferences,
     "premiere_timestamp" => video.premiere_timestamp.try &.to_unix,
-    "vr" => video.is_vr
+    "vr" => video.is_vr,
+    "projection_type" => video.projection_type
 }.to_pretty_json
 %>
 </script>


### PR DESCRIPTION
Some VR videos on YouTube uses the equirectangular projection type. For example: https://www.youtube.com/watch?v=i6j5pPD2jnY