### PR TITLE
Unregister captcha job

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -153,10 +153,6 @@ if CONFIG.popular_enabled
   Invidious::Jobs.register Invidious::Jobs::PullPopularVideosJob.new(PG_DB)
 end
 
-if CONFIG.captcha_key
-  Invidious::Jobs.register Invidious::Jobs::BypassCaptchaJob.new
-end
-
 connection_channel = Channel({Bool, Channel(PQ::Notification)}).new(32)
 Invidious::Jobs.register Invidious::Jobs::NotificationJob.new(connection_channel, CONFIG.database_url)
 


### PR DESCRIPTION
Invidious now fully uses InnerTube which lacks captchas*. There's no reason to have the captcha job constantly run in the background anymore. However, in case YouTube does add captchas into InnerTube, the source code of the job hasn't been removed. All this PR does is remove the job from the compiled binary.

\* To a certain degree — reports do indicate that there is some sort of block/rate-limiting but the tolerance is much higher than what YouTube typically has.