### PR TITLE
Remove login with Google button from frontend

### DIFF
--- a/src/invidious/views/login.ecr
+++ b/src/invidious/views/login.ecr
@@ -6,21 +6,6 @@
     <div class="pure-u-1 pure-u-lg-1-5"></div>
     <div class="pure-u-1 pure-u-lg-3-5">
         <div class="h-box">
-            <div class="pure-g">
-                <div class="pure-u-1-2">
-                    <a class="pure-button <% if account_type == "invidious" %>pure-button-disabled<% end %>" href="/login?type=invidious">
-                        <%= translate(locale, "Log in/register") %>
-                    </a>
-                </div>
-                <div class="pure-u-1-2">
-                    <a class="pure-button <% if account_type == "google" %>pure-button-disabled<% end %>" href="/login?type=google">
-                        <%= translate(locale, "Log in with Google") %>
-                    </a>
-                </div>
-            </div>
-
-            <hr>
-
             <% case account_type when %>
             <% when "google" %>
                 <form class="pure-form pure-form-stacked" action="/login?referer=<%= URI.encode_www_form(referer) %>&type=google" method="post">


### PR DESCRIPTION
This PR removes the frontend button to login with Google. However if a user wishes to do so, they can manually add the url parameter to access that part of the UI again.

Haven't tested this yet since Crystal isn't on termux