### PR TITLE
Decrease channel refresh frequency (1 min -> 1 h)

### DIFF
--- a/src/invidious/jobs/refresh_channels_job.cr
+++ b/src/invidious/jobs/refresh_channels_job.cr
@@ -58,8 +58,9 @@ class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
         end
       end
 
-      LOGGER.debug("RefreshChannelsJob: Done, sleeping for one minute")
-      sleep 1.minute
+      # TODO: make this configurable
+      LOGGER.debug("RefreshChannelsJob: Done, sleeping for one hour")
+      sleep 1.hour
       Fiber.yield
     end
   end


### PR DESCRIPTION
This is a temporary fix to reduce load on instances with many channels and avoid IP being flagged by Google.