### PR TITLE
add icon-buttons to playlist items

### DIFF
--- a/src/invidious/views/components/item.ecr
+++ b/src/invidious/views/components/item.ecr
@@ -79,6 +79,19 @@
                 <div class="flex-left"><a href="/channel/<%= item.ucid %>">
                     <p class="channel-name" dir="auto"><%= HTML.escape(item.author) %></p>
                 </a></div>
+                <div class="flex-right">
+                    <div class="icon-buttons">
+                        <a title="<%=translate(locale, "Watch on YouTube")%>" href="https://www.youtube.com/watch?v=<%= item.id %>&list=<%= item.plid %>">
+                            <i class="icon ion-logo-youtube"></i>
+                        </a>
+                        <a title="<%=translate(locale, "Audio mode")%>" href="/watch?v=<%= item.id %>&list=<%= item.plid %>&amp;listen=1">
+                            <i class="icon ion-md-headset"></i>
+                        </a>
+                        <a title="<%=translate(locale, "Switch Invidious Instance")%>" href="/redirect?referer=<%=HTML.escape("watch?v=#{item.id}&list=#{item.plid}")%>">
+                            <i class="icon ion-md-jet"></i>
+                        </a>
+                    </div>
+                </div>
             </div>
 
             <div class="video-card-row flexible">


### PR DESCRIPTION
This adds icon-buttons ("Watch on YouTube", "Audio mode", "Switch Invidious Instance") to playlist items.

It uses the existing icon-buttons template, with the addition of list=item.plid URL parameters.