### PR TITLE
Add config option to display source code URL in footer

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -314,6 +314,11 @@ footer a {
   text-decoration: underline;
 }
 
+footer span {
+  margin: 4px 0;
+  display: block;
+}
+
 /* keyframes */
 
 @keyframes spin {

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -432,6 +432,15 @@ feed_threads: 1
 ##
 #cache_annotations: false
 
+##
+## Source code URL. If your instance is running a modfied source
+## code, you MUST publish it somewhere and set this option.
+##
+## Accepted values: a string
+## Default: <none>
+##
+#source_code_url: ""
+
 
 
 #########################################

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -423,5 +423,10 @@
     "Current version: ": "Current version: ",
     "next_steps_error_message": "After which you should try to: ",
     "next_steps_error_message_refresh": "Refresh",
-    "next_steps_error_message_go_to_youtube": "Go to YouTube"
+    "next_steps_error_message_go_to_youtube": "Go to YouTube",
+    "footer_donate": "Donate: ",
+    "footer_documentation": "Documentation",
+    "footer_source_code": "Source code",
+    "footer_original_source_code": "Original source code",
+    "footer_modfied_source_code": "Modified Source code"
 }

--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -97,6 +97,10 @@ class Config
   property hsts : Bool? = true                            # Enables 'Strict-Transport-Security'. Ensure that `domain` and all subdomains are served securely
   property disable_proxy : Bool? | Array(String)? = false # Disable proxying server-wide: options: 'dash', 'livestreams', 'downloads', 'local'
 
+  # URL to the modified source code to be easily AGPL compliant
+  # Will display in the footer, next to the main source code link
+  property source_code_url : String? = nil
+
   @[YAML::Field(converter: Preferences::FamilyConverter)]
   property force_resolve : Socket::Family = Socket::Family::UNSPEC # Connect to YouTube over 'ipv6', 'ipv4'. Will sometimes resolve fix issues with rate-limiting (see https://github.com/ytdl-org/youtube-dl/issues/21729)
   property port : Int32 = 3000                                     # Port to listen for connections (overrided by command line argument)

--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -117,38 +117,47 @@
             <footer>
                 <div class="pure-g">
                     <div class="pure-u-1 pure-u-md-1-3">
-                        <a href="https://github.com/iv-org/invidious">
-                            <%= translate(locale, "Released under the AGPLv3 on Github.") %>
-                        </a>
+                        <span>
+                            <i class="icon ion-logo-github"></i>
+                        <% if CONFIG.source_code_url %>
+                            <a href="https://github.com/iv-org/invidious"><%= translate(locale, "footer_original_source_code") %></a>&nbsp;/
+                            <a href="<%= CONFIG.source_code_url %>"><%= translate(locale, "footer_modfied_source_code") %></a>
+                        <% else %>
+                            <a href="https://github.com/iv-org/invidious"><%= translate(locale, "footer_source_code") %></a>
+                        <% end %>
+                        </span>
+                        <span>
+                            <i class="icon ion-ios-paper"></i>
+                            <a href="https://github.com/iv-org/documentation"><%= translate(locale, "footer_documentation") %></a>
+                        </span>
                     </div>
+
                     <div class="pure-u-1 pure-u-md-1-3">
-                        <i class="icon ion-ios-wallet"></i>
-                        BTC: <a href="bitcoin:bc1qfhe7rq3lqzuayzjxzyt9waz9ytrs09kla3tsgr">bc1qfhe7rq3lqzuayzjxzyt9waz9ytrs09kla3tsgr</a>
+                        <span>
+                            <a href="https://github.com/iv-org/invidious/blob/master/LICENSE"><%= translate(locale, "Released under the AGPLv3 on Github.") %></a>
+                        </span>
+                        <span>
+                            <i class="icon ion-logo-javascript"></i>
+                            <a rel="jslicense" href="/licenses"><%= translate(locale, "View JavaScript license information.") %></a>
+                        </span>
+                        <span>
+                            <i class="icon ion-ios-paper"></i>
+                            <a href="/privacy"><%= translate(locale, "View privacy policy.") %></a>
+                        </span>
                     </div>
+
                     <div class="pure-u-1 pure-u-md-1-3">
-                        <i class="icon ion-ios-wallet"></i>
-                        XMR: <a href="monero:41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3LXqkEJBrCZBgPTwJrDp1FrZJfycGPR">Click here</a>
-                    </div>
-                    <div class="pure-u-1 pure-u-md-1-3">
-                        <a href="https://github.com/iv-org/documentation">Documentation</a>
-                    </div>
-                    <div class="pure-u-1 pure-u-md-1-3">
-                        <i class="icon ion-logo-javascript"></i>
-                        <a rel="jslicense" href="/licenses">
-                            <%= translate(locale, "View JavaScript license information.") %>
-                        </a>
-                        /
-                        <i class="icon ion-ios-paper"></i>
-                        <a href="/privacy">
-                            <%= translate(locale, "View privacy policy.") %>
-                        </a>
-                    </div>
-                    <div class="pure-u-1 pure-u-md-1-3">
-                        <i class="icon ion-logo-github"></i>
-                        <%= translate(locale, "Current version: ") %> <%= CURRENT_VERSION %>-<%= CURRENT_COMMIT %> @ <%= CURRENT_BRANCH %>
+                        <span>
+                            <i class="icon ion-ios-wallet"></i>
+                            <%= translate(locale, "footer_donate") %>
+                            <a href="bitcoin:bc1qfhe7rq3lqzuayzjxzyt9waz9ytrs09kla3tsgr">BTC</a>&nbsp;/
+                            <a href="monero:41nMCtek197boJtiUvGnTFYMatrLEpnpkQDmUECqx5Es2uX3sTKKWVhSL76suXsG3LXqkEJBrCZBgPTwJrDp1FrZJfycGPR">XMR</a>
+                        </span>
+                        <span><%= translate(locale, "Current version: ") %> <%= CURRENT_VERSION %>-<%= CURRENT_COMMIT %> @ <%= CURRENT_BRANCH %></span>
                     </div>
                 </div>
             </footer>
+
         </div>
         <div class="pure-u-1 pure-u-md-2-24"></div>
     </div>


### PR DESCRIPTION
This is not the greatest fix, but it provides an easy way for instance maintainers to put a link to the modified source code in order to comply with the AGPL.

Response to the feedback received in iv-org/documentation#148 and iv-org/documentation#149