### PR TITLE
hrefs: replace HTML.escape w/ URI.encode_www_form

### DIFF
--- a/src/invidious/views/add_playlist_items.ecr
+++ b/src/invidious/views/add_playlist_items.ecr
@@ -41,7 +41,7 @@
     <div class="pure-g h-box">
         <div class="pure-u-1 pure-u-lg-1-5">
             <% if page > 1 %>
-                <a href="/add_playlist_items?list=<%= plid %>&q=<%= HTML.escape(query.not_nil!) %>&page=<%= page - 1 %>">
+                <a href="/add_playlist_items?list=<%= plid %>&q=<%= URI.encode_www_form(query.not_nil!) %>&page=<%= page - 1 %>">
                     <%= translate(locale, "Previous page") %>
                 </a>
             <% end %>
@@ -49,7 +49,7 @@
         <div class="pure-u-1 pure-u-lg-3-5"></div>
         <div class="pure-u-1 pure-u-lg-1-5" style="text-align:right">
             <% if count >= 20 %>
-                <a href="/add_playlist_items?list=<%= plid %>&q=<%= HTML.escape(query.not_nil!) %>&page=<%= page + 1 %>">
+                <a href="/add_playlist_items?list=<%= plid %>&q=<%= URI.encode_www_form(query.not_nil!) %>&page=<%= page + 1 %>">
                     <%= translate(locale, "Next page") %>
                 </a>
             <% end %>

--- a/src/invidious/views/channel.ecr
+++ b/src/invidious/views/channel.ecr
@@ -96,7 +96,7 @@
 <div class="pure-g h-box">
     <div class="pure-u-1 pure-u-lg-1-5">
         <% if page > 1 %>
-            <a href="/channel/<%= ucid %>?page=<%= page - 1 %><% if sort_by != "newest" %>&sort_by=<%= HTML.escape(sort_by) %><% end %>">
+            <a href="/channel/<%= ucid %>?page=<%= page - 1 %><% if sort_by != "newest" %>&sort_by=<%= URI.encode_www_form(sort_by) %><% end %>">
                 <%= translate(locale, "Previous page") %>
             </a>
         <% end %>
@@ -104,7 +104,7 @@
     <div class="pure-u-1 pure-u-lg-3-5"></div>
     <div class="pure-u-1 pure-u-lg-1-5" style="text-align:right">
         <% if count == 60 %>
-            <a href="/channel/<%= ucid %>?page=<%= page + 1 %><% if sort_by != "newest" %>&sort_by=<%= HTML.escape(sort_by) %><% end %>">
+            <a href="/channel/<%= ucid %>?page=<%= page + 1 %><% if sort_by != "newest" %>&sort_by=<%= URI.encode_www_form(sort_by) %><% end %>">
                 <%= translate(locale, "Next page") %>
             </a>
         <% end %>

--- a/src/invidious/views/components/item.ecr
+++ b/src/invidious/views/components/item.ecr
@@ -87,7 +87,7 @@
                         <a title="<%=translate(locale, "Audio mode")%>" href="/watch?v=<%= item.id %>&list=<%= item.plid %>&amp;listen=1">
                             <i class="icon ion-md-headset"></i>
                         </a>
-                        <a title="<%=translate(locale, "Switch Invidious Instance")%>" href="/redirect?referer=<%=HTML.escape("watch?v=#{item.id}&list=#{item.plid}")%>">
+                        <a title="<%=translate(locale, "Switch Invidious Instance")%>" href="/redirect?referer=<%=URI.encode_www_form("watch?v=#{item.id}&list=#{item.plid}")%>">
                             <i class="icon ion-md-jet"></i>
                         </a>
                     </div>
@@ -163,7 +163,7 @@
                         <a title="<%=translate(locale, "Audio mode")%>" href="/watch?v=<%= item.id %>&amp;listen=1">
                             <i class="icon ion-md-headset"></i>
                         </a>
-                        <a title="<%=translate(locale, "Switch Invidious Instance")%>" href="/redirect?referer=<%=HTML.escape("watch?v=#{item.id}")%>">
+                        <a title="<%=translate(locale, "Switch Invidious Instance")%>" href="/redirect?referer=<%=URI.encode_www_form("watch?v=#{item.id}")%>">
                             <i class="icon ion-md-jet"></i>
                         </a>
                     </div>

--- a/src/invidious/views/playlists.ecr
+++ b/src/invidious/views/playlists.ecr
@@ -96,7 +96,7 @@
     <div class="pure-u-1 pure-u-md-4-5"></div>
     <div class="pure-u-1 pure-u-lg-1-5" style="text-align:right">
         <% if continuation %>
-            <a href="/channel/<%= ucid %>/playlists?continuation=<%= continuation %><% if sort_by != "last" %>&sort_by=<%= HTML.escape(sort_by) %><% end %>">
+            <a href="/channel/<%= ucid %>/playlists?continuation=<%= continuation %><% if sort_by != "last" %>&sort_by=<%= URI.encode_www_form(sort_by) %><% end %>">
                 <%= translate(locale, "Next page") %>
             </a>
         <% end %>

--- a/src/invidious/views/search.ecr
+++ b/src/invidious/views/search.ecr
@@ -23,7 +23,7 @@
                         <% if operator_hash.fetch("date", "all") == date %>
                             <b><%= translate(locale, date) %></b>
                         <% else %>
-                            <a href="/search?q=<%= HTML.escape(query.not_nil!.gsub(/ ?date:[a-z]+/, "") + " date:" + date) %>&page=<%= page %>">
+                            <a href="/search?q=<%= URI.encode_www_form(query.not_nil!.gsub(/ ?date:[a-z]+/, "") + " date:" + date) %>&page=<%= page %>">
                                 <%= translate(locale, date) %>
                             </a>
                         <% end %>
@@ -38,7 +38,7 @@
                         <% if operator_hash.fetch("content_type", "all") == content_type %>
                             <b><%= translate(locale, content_type) %></b>
                         <% else %>
-                            <a href="/search?q=<%= HTML.escape(query.not_nil!.gsub(/ ?content_type:[a-z]+/, "") + " content_type:" + content_type) %>&page=<%= page %>">
+                            <a href="/search?q=<%= URI.encode_www_form(query.not_nil!.gsub(/ ?content_type:[a-z]+/, "") + " content_type:" + content_type) %>&page=<%= page %>">
                                 <%= translate(locale, content_type) %>
                             </a>
                         <% end %>
@@ -53,7 +53,7 @@
                         <% if operator_hash.fetch("duration", "all") == duration %>
                             <b><%= translate(locale, duration) %></b>
                         <% else %>
-                            <a href="/search?q=<%= HTML.escape(query.not_nil!.gsub(/ ?duration:[a-z]+/, "") + " duration:" + duration) %>&page=<%= page %>">
+                            <a href="/search?q=<%= URI.encode_www_form(query.not_nil!.gsub(/ ?duration:[a-z]+/, "") + " duration:" + duration) %>&page=<%= page %>">
                                 <%= translate(locale, duration) %>
                             </a>
                         <% end %>
@@ -68,11 +68,11 @@
                         <% if operator_hash.fetch("features", "all").includes?(feature) %>
                             <b><%= translate(locale, feature) %></b>
                         <% elsif operator_hash.has_key?("features") %>
-                            <a href="/search?q=<%= HTML.escape(query.not_nil!.gsub(/features:/, "features:" + feature + ",")) %>&page=<%= page %>">
+                            <a href="/search?q=<%= URI.encode_www_form(query.not_nil!.gsub(/features:/, "features:" + feature + ",")) %>&page=<%= page %>">
                                 <%= translate(locale, feature) %>
                             </a>
                         <% else %>
-                            <a href="/search?q=<%= HTML.escape(query.not_nil! + " features:" + feature) %>&page=<%= page %>">
+                            <a href="/search?q=<%= URI.encode_www_form(query.not_nil! + " features:" + feature) %>&page=<%= page %>">
                                 <%= translate(locale, feature) %>
                             </a>
                         <% end %>
@@ -87,7 +87,7 @@
                         <% if operator_hash.fetch("sort", "relevance") == sort %>
                             <b><%= translate(locale, sort) %></b>
                         <% else %>
-                            <a href="/search?q=<%= HTML.escape(query.not_nil!.gsub(/ ?sort:[a-z]+/, "") + " sort:" + sort) %>&page=<%= page %>">
+                            <a href="/search?q=<%= URI.encode_www_form(query.not_nil!.gsub(/ ?sort:[a-z]+/, "") + " sort:" + sort) %>&page=<%= page %>">
                                 <%= translate(locale, sort) %>
                             </a>
                         <% end %>


### PR DESCRIPTION
Currently in some href strings URL parameter values are HTML-escaped when they should be URL-encoded instead.

An example of the issue is redirecting a playlist item to another instance. The current href string:

    /redirect?referer=watch?v=yiw6_JakZFc&list=PLFs4vir_WsTxontcYm5ctqp89cNBJKNrs

Because the "referer" value is not URL-encoded, the "list" parameter ends up being its own URL parameter alongside "referer". So the above href ends up redirecting to a URL without the "list" component:

    https://redirect.invidious.io/watch?v=yiw6_JakZFc

This patch replaces HTML.escape in such places with URI.encode_www_form, so for example the above href string ends up being:

    /redirect?referer=watch%3Fv%3Dyiw6_JakZFc%26list%3DPLFs4vir_WsTxontcYm5ctqp89cNBJKNrs

...which correctly redirects to:

    https://redirect.invidious.io/watch?v=yiw6_JakZFc&list=PLFs4vir_WsTxontcYm5ctqp89cNBJKNrs