### PR TITLE
Fix infinite recursion caused by `to_json` methods

### DIFF
--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -206,7 +206,7 @@ def create_notification_stream(env, topics, connection_channel)
 
           video = get_video(video_id, PG_DB)
           video.published = published
-          response = JSON.parse(video.to_json(locale))
+          response = JSON.parse(video.to_json(locale, nil))
 
           if fields_text = env.params.query["fields"]?
             begin
@@ -282,7 +282,7 @@ def create_notification_stream(env, topics, connection_channel)
 
         video = get_video(video_id, PG_DB)
         video.published = Time.unix(published)
-        response = JSON.parse(video.to_json(locale))
+        response = JSON.parse(video.to_json(locale, nil))
 
         if fields_text = env.params.query["fields"]?
           begin

--- a/src/invidious/helpers/serialized_yt_data.cr
+++ b/src/invidious/helpers/serialized_yt_data.cr
@@ -211,7 +211,7 @@ struct SearchChannel
     end
   end
 
-  def to_json(locale, _json : Nil)
+  def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil)
     JSON.build do |json|
       to_json(locale, json)
     end

--- a/src/invidious/helpers/serialized_yt_data.cr
+++ b/src/invidious/helpers/serialized_yt_data.cr
@@ -95,7 +95,7 @@ struct SearchVideo
     end
   end
 
-  def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil = nil)
+  def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil)
     JSON.build do |json|
       to_json(locale, json)
     end
@@ -159,7 +159,7 @@ struct SearchPlaylist
     end
   end
 
-  def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil = nil)
+  def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil)
     JSON.build do |json|
       to_json(locale, json)
     end
@@ -211,7 +211,7 @@ struct SearchChannel
     end
   end
 
-  def to_json(locale, _json : Nil = nil)
+  def to_json(locale, _json : Nil)
     JSON.build do |json|
       to_json(locale, json)
     end
@@ -245,7 +245,7 @@ class Category
     end
   end
 
-  def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil = nil)
+  def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil)
     JSON.build do |json|
       to_json(locale, json)
     end

--- a/src/invidious/helpers/serialized_yt_data.cr
+++ b/src/invidious/helpers/serialized_yt_data.cr
@@ -58,17 +58,13 @@ struct SearchVideo
     end
   end
 
-  def to_xml(auto_generated, query_params, xml : XML::Builder | Nil = nil)
-    if xml
-      to_xml(HOST_URL, auto_generated, query_params, xml)
-    else
-      XML.build do |xml|
-        to_xml(HOST_URL, auto_generated, query_params, xml)
-      end
+  def to_xml(auto_generated, query_params, _xml : Nil)
+    XML.build do |xml|
+      to_xml(auto_generated, query_params, xml)
     end
   end
 
-  def to_json(locale : Hash(String, JSON::Any), json : JSON::Builder)
+  def to_json(locale : Hash(String, JSON::Any) | Nil, json : JSON::Builder)
     json.object do
       json.field "type", "video"
       json.field "title", self.title
@@ -99,14 +95,14 @@ struct SearchVideo
     end
   end
 
-  def to_json(locale, json : JSON::Builder | Nil = nil)
-    if json
+  def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil = nil)
+    JSON.build do |json|
       to_json(locale, json)
-    else
-      JSON.build do |json|
-        to_json(locale, json)
-      end
     end
+  end
+
+  def to_json(json : JSON::Builder)
+    to_json(nil, json)
   end
 
   def is_upcoming
@@ -133,7 +129,7 @@ struct SearchPlaylist
   property videos : Array(SearchPlaylistVideo)
   property thumbnail : String?
 
-  def to_json(locale, json : JSON::Builder)
+  def to_json(locale : Hash(String, JSON::Any) | Nil, json : JSON::Builder)
     json.object do
       json.field "type", "playlist"
       json.field "title", self.title
@@ -163,14 +159,14 @@ struct SearchPlaylist
     end
   end
 
-  def to_json(locale, json : JSON::Builder | Nil = nil)
-    if json
+  def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil = nil)
+    JSON.build do |json|
       to_json(locale, json)
-    else
-      JSON.build do |json|
-        to_json(locale, json)
-      end
     end
+  end
+
+  def to_json(json : JSON::Builder)
+    to_json(nil, json)
   end
 end
 
@@ -185,7 +181,7 @@ struct SearchChannel
   property description_html : String
   property auto_generated : Bool
 
-  def to_json(locale, json : JSON::Builder)
+  def to_json(locale : Hash(String, JSON::Any) | Nil, json : JSON::Builder)
     json.object do
       json.field "type", "channel"
       json.field "author", self.author
@@ -215,14 +211,14 @@ struct SearchChannel
     end
   end
 
-  def to_json(locale, json : JSON::Builder | Nil = nil)
-    if json
+  def to_json(locale, _json : Nil = nil)
+    JSON.build do |json|
       to_json(locale, json)
-    else
-      JSON.build do |json|
-        to_json(locale, json)
-      end
     end
+  end
+
+  def to_json(json : JSON::Builder)
+    to_json(nil, json)
   end
 end
 
@@ -235,7 +231,7 @@ class Category
   property description_html : String
   property badges : Array(Tuple(String, String))?
 
-  def to_json(locale, json : JSON::Builder)
+  def to_json(locale : Hash(String, JSON::Any) | Nil, json : JSON::Builder)
     json.object do
       json.field "type", "category"
       json.field "title", self.title
@@ -249,14 +245,14 @@ class Category
     end
   end
 
-  def to_json(locale, json : JSON::Builder | Nil = nil)
-    if json
+  def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil = nil)
+    JSON.build do |json|
       to_json(locale, json)
-    else
-      JSON.build do |json|
-        to_json(locale, json)
-      end
     end
+  end
+
+  def to_json(json : JSON::Builder)
+    to_json(nil, json)
   end
 end
 

--- a/src/invidious/helpers/serialized_yt_data.cr
+++ b/src/invidious/helpers/serialized_yt_data.cr
@@ -95,6 +95,7 @@ struct SearchVideo
     end
   end
 
+  # TODO: remove the locale and follow the crystal convention
   def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil)
     JSON.build do |json|
       to_json(locale, json)
@@ -159,6 +160,7 @@ struct SearchPlaylist
     end
   end
 
+  # TODO: remove the locale and follow the crystal convention
   def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil)
     JSON.build do |json|
       to_json(locale, json)
@@ -211,6 +213,7 @@ struct SearchChannel
     end
   end
 
+  # TODO: remove the locale and follow the crystal convention
   def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil)
     JSON.build do |json|
       to_json(locale, json)
@@ -245,6 +248,7 @@ class Category
     end
   end
 
+  # TODO: remove the locale and follow the crystal convention
   def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil)
     JSON.build do |json|
       to_json(locale, json)

--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -11,7 +11,7 @@ struct PlaylistVideo
   property index : Int64
   property live_now : Bool
 
-  def to_xml(auto_generated, xml : XML::Builder)
+  def to_xml(xml : XML::Builder)
     xml.element("entry") do
       xml.element("id") { xml.text "yt:video:#{self.id}" }
       xml.element("yt:videoId") { xml.text self.id }
@@ -20,13 +20,8 @@ struct PlaylistVideo
       xml.element("link", rel: "alternate", href: "#{HOST_URL}/watch?v=#{self.id}")
 
       xml.element("author") do
-        if auto_generated
-          xml.element("name") { xml.text self.author }
-          xml.element("uri") { xml.text "#{HOST_URL}/channel/#{self.ucid}" }
-        else
-          xml.element("name") { xml.text author }
-          xml.element("uri") { xml.text "#{HOST_URL}/channel/#{ucid}" }
-        end
+        xml.element("name") { xml.text self.author }
+        xml.element("uri") { xml.text "#{HOST_URL}/channel/#{self.ucid}" }
       end
 
       xml.element("content", type: "xhtml") do
@@ -47,14 +42,8 @@ struct PlaylistVideo
     end
   end
 
-  def to_xml(auto_generated, xml : XML::Builder? = nil)
-    if xml
-      to_xml(auto_generated, xml)
-    else
-      XML.build do |xml|
-        to_xml(auto_generated, xml)
-      end
-    end
+  def to_xml(_xml : Nil = nil)
+    XML.build { |xml| to_xml(xml) }
   end
 
   def to_json(json : JSON::Builder, index : Int32? = nil)

--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -57,7 +57,7 @@ struct PlaylistVideo
     end
   end
 
-  def to_json(locale, json : JSON::Builder, index : Int32?)
+  def to_json(json : JSON::Builder, index : Int32? = nil)
     json.object do
       json.field "title", self.title
       json.field "videoId", self.id
@@ -81,14 +81,8 @@ struct PlaylistVideo
     end
   end
 
-  def to_json(locale, json : JSON::Builder? = nil, index : Int32? = nil)
-    if json
-      to_json(locale, json, index: index)
-    else
-      JSON.build do |json|
-        to_json(locale, json, index: index)
-      end
-    end
+  def to_json(_json : Nil, index : Int32? = nil)
+    JSON.build { |json| to_json(json, index: index) }
   end
 end
 
@@ -144,7 +138,7 @@ struct Playlist
         json.array do
           videos = get_playlist_videos(PG_DB, self, offset: offset, locale: locale, video_id: video_id)
           videos.each do |video|
-            video.to_json(locale, json)
+            video.to_json(json)
           end
         end
       end
@@ -224,7 +218,7 @@ struct InvidiousPlaylist
 
           videos = get_playlist_videos(PG_DB, self, offset: offset, locale: locale, video_id: video_id)
           videos.each_with_index do |video, index|
-            video.to_json(locale, json, offset + index)
+            video.to_json(json, offset + index)
           end
         end
       end

--- a/src/invidious/routes/api/v1/authenticated.cr
+++ b/src/invidious/routes/api/v1/authenticated.cr
@@ -274,7 +274,10 @@ module Invidious::Routes::API::V1::Authenticated
 
     env.response.headers["Location"] = "#{HOST_URL}/api/v1/auth/playlists/#{plid}/videos/#{playlist_video.index.to_u64.to_s(16).upcase}"
     env.response.status_code = 201
-    playlist_video.to_json(locale, index: playlist.index.size)
+
+    JSON.build do |json|
+      playlist_video.to_json(json, index: playlist.index.size)
+    end
   end
 
   def self.delete_video_in_playlist(env)

--- a/src/invidious/routes/api/v1/videos.cr
+++ b/src/invidious/routes/api/v1/videos.cr
@@ -16,7 +16,7 @@ module Invidious::Routes::API::V1::Videos
       return error_json(500, ex)
     end
 
-    video.to_json(locale)
+    video.to_json(locale, nil)
   end
 
   def self.captions(env)

--- a/src/invidious/routes/feeds.cr
+++ b/src/invidious/routes/feeds.cr
@@ -281,9 +281,7 @@ module Invidious::Routes::Feeds
               xml.element("name") { xml.text playlist.author }
             end
 
-            videos.each do |video|
-              video.to_xml(false, xml)
-            end
+            videos.each &.to_xml(xml)
           end
         end
       else

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -275,7 +275,7 @@ struct Video
     end
   end
 
-  def to_json(locale : Hash(String, JSON::Any), json : JSON::Builder)
+  def to_json(locale : Hash(String, JSON::Any) | Nil, json : JSON::Builder)
     json.object do
       json.field "type", "video"
 
@@ -474,14 +474,13 @@ struct Video
     end
   end
 
-  def to_json(locale, json : JSON::Builder | Nil = nil)
-    if json
-      to_json(locale, json)
-    else
-      JSON.build do |json|
-        to_json(locale, json)
-      end
-    end
+  # TODO: remove the locale and follow the crystal convention
+  def to_json(locale : Hash(String, JSON::Any) | Nil, _json : Nil)
+    JSON.build { |json| to_json(locale, json) }
+  end
+
+  def to_json(json : JSON::Builder | Nil = nil)
+    to_json(nil, json)
   end
 
   def title


### PR DESCRIPTION
Changes in the aforementioned PR lead to change the behavior of some old code. The data type of the parameters aren't explicit enough, which makes the compiler use the wrong method because of type infering.

Thanks to @Blacksmoke16 for the help on that one :)

---

error log:
```
Stack overflow (e.g., infinite or very deep recursion)
[0x5567bca0b670] print_backtrace at /usr/share/crystal/src/exception/call_stack.cr:129:5
[0x5567bca0b525] -> at /usr/share/crystal/src/signal.cr:152:5
[0x7f69e2c6d140] ???
[0x5567bd02dbeb] to_json at /srv/invidious/invidious.git/src/invidious/helpers/serialized_yt_data.cr:104:7
[0x5567bd02dbf0] to_json at /srv/invidious/invidious.git/src/invidious/helpers/serialized_yt_data.cr:104:7 (93900870067114 times)
[0x5567bd02dba7] to_json at /usr/share/crystal/src/json/builder.cr:61:17
[0x5567bd02d024] to_json at /usr/share/crystal/src/json/to_json.cr:96:14
[0x5567bd02cd0a] field at /usr/share/crystal/src/json/builder.cr:252:5
[0x5567bd02cca3] to_json at /usr/share/crystal/src/json/builder.cr:224:17
[0x5567bd02f3a4] search at /srv/invidious/invidious.git/src/invidious/routes/api/v1/search.cr:39:11
[0x5567bd02e57e] -> at /srv/invidious/invidious.git/src/invidious.cr:391:1
[0x5567bcce8800] -> at /usr/share/crystal/src/primitives.cr:266:3
[0x5567bd1acd2c] process_request at /srv/invidious/invidious.git/src/invidious/helpers/handlers.cr:30:5
[0x5567bd1acc98] call at /srv/invidious/invidious.git/lib/kemal/src/kemal/route_handler.cr:17:7
[0x5567bd1aea9b] call_next at /usr/share/crystal/src/http/server/handler.cr:28:7
[0x5567bd1ad370] call at /srv/invidious/invidious.git/lib/kemal/src/kemal/websocket_handler.cr:13:14
[0x5567bd1a6a20] call_next at /usr/share/crystal/src/http/server/handler.cr:28:7
[0x5567bd1a64b8] call at /srv/invidious/invidious.git/lib/kemal/src/kemal/filter_handler.cr:21:7
[0x5567bd1a80f4] call_next at /usr/share/crystal/src/http/server/handler.cr:28:7
[0x5567bd1a6b1f] call at /srv/invidious/invidious.git/src/invidious/helpers/handlers.cr:212:5
[0x5567bd1ab54d] call_next at /usr/share/crystal/src/http/server/handler.cr:28:7
[0x5567bd1a957d] call at /srv/invidious/invidious.git/src/invidious/helpers/handlers.cr:94:12
[0x5567bd1a922f] call_next at /usr/share/crystal/src/http/server/handler.cr:28:7
[0x5567bd1a846b] call at /srv/invidious/invidious.git/src/invidious/helpers/handlers.cr:158:7
[0x5567bd1abf26] call_next at /usr/share/crystal/src/http/server/handler.cr:28:7
[0x5567bd1ab83d] call at /srv/invidious/invidious.git/src/invidious/helpers/handlers.cr:70:5
[0x5567bd1a27a8] call_next at /usr/share/crystal/src/http/server/handler.cr:28:7
[0x5567bd1a0721] call at /srv/invidious/invidious.git/src/invidious/helpers/static_file_handler.cr:189:11
[0x5567bd1a5fcc] call_next at /usr/share/crystal/src/http/server/handler.cr:28:7
[0x5567bd1a5c90] call at /srv/invidious/invidious.git/lib/kemal/src/kemal/exception_handler.cr:8:7
[0x5567bd1a4bdb] call_next at /usr/share/crystal/src/http/server/handler.cr:28:7
[0x5567bd1a47ca] call at /srv/invidious/invidious.git/src/invidious/helpers/logger.cr:17:35
[0x5567bd1ac968] call_next at /usr/share/crystal/src/http/server/handler.cr:28:7
[0x5567bd1ac702] call at /srv/invidious/invidious.git/lib/kemal/src/kemal/init_handler.cr:12:7
[0x5567bd198483] process at /usr/share/crystal/src/http/server/request_processor.cr:51:11
[0x5567bd197407] handle_client at /usr/share/crystal/src/http/server.cr:515:5
[0x5567bd196cea] -> at /usr/share/crystal/src/http/server.cr:468:13
[0x5567bca0043a] run at /usr/share/crystal/src/primitives.cr:266:3
[0x5567bca04fce] -> at /usr/share/crystal/src/fiber.cr:92:34
[0x0] ???
```