### PR TITLE
Change <input value="..."> encoding to HTML.escape

### DIFF
--- a/src/invidious/views/authorize_token.ecr
+++ b/src/invidious/views/authorize_token.ecr
@@ -72,7 +72,7 @@
                 <input type="hidden" name="expire" value="<%= expire %>">
             <% end %>
 
-            <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(csrf_token) %>">
+            <input type="hidden" name="csrf_token" value="<%= HTML.escape(csrf_token) %>">
         </form>
     </div>
 <% end %>

--- a/src/invidious/views/change_password.ecr
+++ b/src/invidious/views/change_password.ecr
@@ -23,7 +23,7 @@
                         <%= translate(locale, "Change password") %>
                     </button>
 
-                    <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(csrf_token) %>">
+                    <input type="hidden" name="csrf_token" value="<%= HTML.escape(csrf_token) %>">
                 </fieldset>
             </form>
         </div>

--- a/src/invidious/views/clear_watch_history.ecr
+++ b/src/invidious/views/clear_watch_history.ecr
@@ -19,6 +19,6 @@
             </div>
         </div>
 
-        <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(csrf_token) %>">
+        <input type="hidden" name="csrf_token" value="<%= HTML.escape(csrf_token) %>">
     </form>
 </div>

--- a/src/invidious/views/components/item.ecr
+++ b/src/invidious/views/components/item.ecr
@@ -54,7 +54,7 @@
                         <img loading="lazy" class="thumbnail" src="/vi/<%= item.id %>/mqdefault.jpg"/>
                         <% if plid = env.get?("remove_playlist_items") %>
                             <form data-onsubmit="return_false" action="/playlist_ajax?action_remove_video=1&set_video_id=<%= item.index %>&playlist_id=<%= plid %>&referer=<%= env.get("current_page") %>" method="post">
-                                <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(env.get?("csrf_token").try &.as(String) || "") %>">
+                                <input type="hidden" name="csrf_token" value="<%= HTML.escape(env.get?("csrf_token").try &.as(String) || "") %>">
                                 <p class="watched">
                                     <a data-onclick="remove_playlist_item" data-index="<%= item.index %>" data-plid="<%= plid %>" href="javascript:void(0)">
                                         <button type="submit" style="all:unset">
@@ -106,7 +106,7 @@
                         <img loading="lazy" class="thumbnail" src="/vi/<%= item.id %>/mqdefault.jpg"/>
                         <% if env.get? "show_watched" %>
                             <form data-onsubmit="return_false" action="/watch_ajax?action_mark_watched=1&id=<%= item.id %>&referer=<%= env.get("current_page") %>" method="post">
-                                <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(env.get?("csrf_token").try &.as(String) || "") %>">
+                                <input type="hidden" name="csrf_token" value="<%= HTML.escape(env.get?("csrf_token").try &.as(String) || "") %>">
                                 <p class="watched">
                                     <a data-onclick="mark_watched" data-id="<%= item.id %>" href="javascript:void(0)">
                                         <button type="submit" style="all:unset">
@@ -119,7 +119,7 @@
                             </form>
                         <% elsif plid = env.get? "add_playlist_items" %>
                             <form data-onsubmit="return_false" action="/playlist_ajax?action_add_video=1&video_id=<%= item.id %>&playlist_id=<%= plid %>&referer=<%= env.get("current_page") %>" method="post">
-                                <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(env.get?("csrf_token").try &.as(String) || "") %>">
+                                <input type="hidden" name="csrf_token" value="<%= HTML.escape(env.get?("csrf_token").try &.as(String) || "") %>">
                                 <p class="watched">
                                     <a data-onclick="add_playlist_item" data-id="<%= item.id %>" data-plid="<%= plid %>" href="javascript:void(0)">
                                         <button type="submit" style="all:unset">

--- a/src/invidious/views/components/subscribe_widget.ecr
+++ b/src/invidious/views/components/subscribe_widget.ecr
@@ -2,7 +2,7 @@
     <% if subscriptions.includes? ucid %>
         <p>
             <form action="/subscription_ajax?action_remove_subscriptions=1&c=<%= ucid %>&referer=<%= env.get("current_page") %>" method="post">
-                <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(env.get?("csrf_token").try &.as(String) || "") %>">
+                <input type="hidden" name="csrf_token" value="<%= HTML.escape(env.get?("csrf_token").try &.as(String) || "") %>">
                 <button data-type="unsubscribe" id="subscribe" class="pure-button pure-button-primary">
                     <b><input style="all:unset" type="submit" value="<%= translate(locale, "Unsubscribe") %> | <%= sub_count_text %>"></b>
                 </button>
@@ -11,7 +11,7 @@
     <% else %>
         <p>
             <form action="/subscription_ajax?action_create_subscription_to_channel=1&c=<%= ucid %>&referer=<%= env.get("current_page") %>" method="post">
-                <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(env.get?("csrf_token").try &.as(String) || "") %>">
+                <input type="hidden" name="csrf_token" value="<%= HTML.escape(env.get?("csrf_token").try &.as(String) || "") %>">
                 <button data-type="subscribe" id="subscribe" class="pure-button pure-button-primary">
                     <b><input style="all:unset" type="submit" value="<%= translate(locale, "Subscribe") %> | <%= sub_count_text %>"></b>
                 </button>

--- a/src/invidious/views/create_playlist.ecr
+++ b/src/invidious/views/create_playlist.ecr
@@ -30,7 +30,7 @@
                         </button>
                     </div>
 
-                    <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(csrf_token) %>">
+                    <input type="hidden" name="csrf_token" value="<%= HTML.escape(csrf_token) %>">
                 </fieldset>
             </form>
         </div>

--- a/src/invidious/views/delete_account.ecr
+++ b/src/invidious/views/delete_account.ecr
@@ -19,6 +19,6 @@
             </div>
         </div>
 
-        <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(csrf_token) %>">
+        <input type="hidden" name="csrf_token" value="<%= HTML.escape(csrf_token) %>">
     </form>
 </div>

--- a/src/invidious/views/delete_playlist.ecr
+++ b/src/invidious/views/delete_playlist.ecr
@@ -19,6 +19,6 @@
             </div>
         </div>
 
-        <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(csrf_token) %>">
+        <input type="hidden" name="csrf_token" value="<%= HTML.escape(csrf_token) %>">
     </form>
 </div>

--- a/src/invidious/views/edit_playlist.ecr
+++ b/src/invidious/views/edit_playlist.ecr
@@ -41,7 +41,7 @@
     <div class="h-box">
         <textarea maxlength="5000" name="description" style="margin-top:10px;max-width:100%;height:20vh" class="pure-input-1"><%= playlist.description %></textarea>
     </div>
-    <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(csrf_token) %>">
+    <input type="hidden" name="csrf_token" value="<%= HTML.escape(csrf_token) %>">
 </form>
 
 <% if playlist.is_a?(InvidiousPlaylist) && playlist.author == user.try &.email %>

--- a/src/invidious/views/login.ecr
+++ b/src/invidious/views/login.ecr
@@ -66,7 +66,7 @@
                                 <% captcha = captcha.not_nil! %>
                                 <img style="width:50%" src='<%= captcha[:question] %>'/>
                                 <% captcha[:tokens].each_with_index do |token, i| %>
-                                    <input type="hidden" name="token[<%= i %>]" value="<%= URI.encode_www_form(token) %>">
+                                    <input type="hidden" name="token[<%= i %>]" value="<%= HTML.escape(token) %>">
                                 <% end %>
                                 <input type="hidden" name="captcha_type" value="image">
                                 <label for="answer"><%= translate(locale, "Time (h:mm:ss):") %></label>
@@ -74,7 +74,7 @@
                             <% else # "text" %>
                                 <% captcha = captcha.not_nil! %>
                                 <% captcha[:tokens].each_with_index do |token, i| %>
-                                    <input type="hidden" name="token[<%= i %>]" value="<%= URI.encode_www_form(token) %>">
+                                    <input type="hidden" name="token[<%= i %>]" value="<%= HTML.escape(token) %>">
                                 <% end %>
                                 <input type="hidden" name="captcha_type" value="text">
                                 <label for="answer"><%= captcha[:question] %></label>

--- a/src/invidious/views/subscription_manager.ecr
+++ b/src/invidious/views/subscription_manager.ecr
@@ -38,7 +38,7 @@
             <div class="pure-u-1-5" style="text-align:right">
                 <h3 style="padding-right:0.5em">
                     <form data-onsubmit="return_false" action="/subscription_ajax?action_remove_subscriptions=1&c=<%= channel.id %>&referer=<%= env.get("current_page") %>" method="post">
-                        <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(env.get?("csrf_token").try &.as(String) || "") %>">
+                        <input type="hidden" name="csrf_token" value="<%= HTML.escape(env.get?("csrf_token").try &.as(String) || "") %>">
                         <a data-onclick="remove_subscription" data-ucid="<%= channel.id %>" href="#">
                             <input style="all:unset" type="submit" value="<%= translate(locale, "unsubscribe") %>">
                         </a>

--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -72,7 +72,7 @@
                         <% end %>
                         <div class="pure-u-1-4">
                             <form action="/signout?referer=<%= env.get?("current_page") %>" method="post">
-                                <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(env.get?("csrf_token").try &.as(String) || "") %>">
+                                <input type="hidden" name="csrf_token" value="<%= HTML.escape(env.get?("csrf_token").try &.as(String) || "") %>">
                                 <a class="pure-menu-heading" href="#">
                                     <input style="all:unset" type="submit" value="<%= translate(locale, "Log out") %>">
                                 </a>

--- a/src/invidious/views/token_manager.ecr
+++ b/src/invidious/views/token_manager.ecr
@@ -30,7 +30,7 @@
         <div class="pure-u-1-5" style="text-align:right">
             <h3 style="padding-right:0.5em">
                 <form data-onsubmit="return_false" action="/token_ajax?action_revoke_token=1&session=<%= token[:session] %>&referer=<%= env.get("current_page") %>" method="post">
-                    <input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(env.get?("csrf_token").try &.as(String) || "") %>">
+                    <input type="hidden" name="csrf_token" value="<%= HTML.escape(env.get?("csrf_token").try &.as(String) || "") %>">
                     <a data-onclick="revoke_token" data-session="<%= token[:session] %>" href="#">
                         <input style="all:unset" type="submit" value="<%= translate(locale, "revoke") %>">
                     </a>


### PR DESCRIPTION
In some places the value string of `<input>` elements is URL-encoded:

```
<input type="hidden" name="csrf_token" value="<%= URI.encode_www_form(csrf_token) %>">
```

Browsers already URL-encode these strings on submit, so the above results in double URL-encoding.

Invidious should just make sure that these values don't mess up HTML:

```
<input type="hidden" name="csrf_token" value="<%= HTML.escape(csrf_token) %>">
```

(This is the inverse of #2460 which concerned href strings.)