### PR TITLE
Retain video time position in video player

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -38,7 +38,7 @@ embed_url.searchParams.delete('v');
 short_url = location.origin + '/' + video_data.id + embed_url.search;
 embed_url = location.origin + '/embed/' + video_data.id + embed_url.search;
 
-var remember_position_key = "remember_position";
+var save_player_pos_key = "save_player_pos";
 
 var shareOptions = {
     socials: ['fbFeed', 'tw', 'reddit', 'email'],
@@ -201,7 +201,7 @@ if (video_data.premiere_timestamp && Math.round(new Date() / 1000) < video_data.
     player.getChild('bigPlayButton').hide();
 }
 
-if (video_data.params.remember_position) {
+if (video_data.params.save_player_pos) {
     const remeberedTime = get_video_time();
     let lastUpdated = 0;
 
@@ -384,12 +384,12 @@ function get_video_time() {
 function set_all_video_times(times) {
     const json = JSON.stringify(times);
 
-    localStorage.setItem(remember_position_key, json);
+    localStorage.setItem(save_player_pos_key, json);
 }
 
 function get_all_video_times() {
     try {
-        const raw = localStorage.getItem(remember_position_key);
+        const raw = localStorage.getItem(save_player_pos_key);
         const times = JSON.parse(raw);
 
         return times || {};
@@ -400,7 +400,7 @@ function get_all_video_times() {
 }
 
 function remove_all_video_times() {
-    localStorage.removeItem(remember_position_key);
+    localStorage.removeItem(save_player_pos_key);
 }
 
 function set_time_percent(percent) {

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -207,7 +207,7 @@ if (video_data.params.remember_position) {
 
     set_seconds_after_start(remeberedTime);
 
-    player.on("timeupdate", e => {
+    const updateTime = () => {
         const raw = player.currentTime();
         const time = Math.floor(raw);
 
@@ -215,7 +215,9 @@ if (video_data.params.remember_position) {
             save_video_time(time);
             lastUpdated = time;
         }
-    });
+    };
+
+    player.on("timeupdate", updateTime);
 }
 else {
     remove_all_video_times();
@@ -372,7 +374,7 @@ function get_video_time() {
         const all_video_times = get_all_video_times();
         const timestamp = all_video_times[videoId];
 
-        return timestamp;
+        return timestamp || 0;
     }
     catch {
         return 0;

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -202,10 +202,14 @@ if (video_data.premiere_timestamp && Math.round(new Date() / 1000) < video_data.
 }
 
 if (video_data.params.save_player_pos) {
+    const url = new URL(location);
+    const hasTimeParam = url.searchParams.has("t");
     const remeberedTime = get_video_time();
     let lastUpdated = 0;
 
-    set_seconds_after_start(remeberedTime);
+    if(!hasTimeParam) {
+        set_seconds_after_start(remeberedTime);
+    }
 
     const updateTime = () => {
         const raw = player.currentTime();

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -218,7 +218,6 @@ if (video_data.params.remember_position) {
     });
 }
 else {
-    console.log("Removing data for remebered positions");
     remove_all_video_times();
 }
 

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -461,5 +461,6 @@
     "download_subtitles": "Subtitles - `x` (.vtt)",
     "user_created_playlists": "`x` created playlists",
     "user_saved_playlists": "`x` saved playlists",
-    "Video unavailable": "Video unavailable"
+    "Video unavailable": "Video unavailable",
+    "preferences_save_player_pos_label": "Save the current video time: "
 }

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -42,7 +42,7 @@ struct ConfigPreferences
   property volume : Int32 = 100
   property vr_mode : Bool = true
   property show_nick : Bool = true
-  property remember_position : Bool = false
+  property save_player_pos : Bool = false
 
   def to_tuple
     {% begin %}

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -42,6 +42,7 @@ struct ConfigPreferences
   property volume : Int32 = 100
   property vr_mode : Bool = true
   property show_nick : Bool = true
+  property remember_position : Bool = false
 
   def to_tuple
     {% begin %}

--- a/src/invidious/routes/preferences.cr
+++ b/src/invidious/routes/preferences.cr
@@ -70,9 +70,9 @@ module Invidious::Routes::PreferencesRoute
     vr_mode ||= "off"
     vr_mode = vr_mode == "on"
 
-    remember_position = env.params.body["remember_position"]?.try &.as(String)
-    remember_position ||= "off"
-    remember_position = remember_position == "on"
+    save_player_pos = env.params.body["save_player_pos"]?.try &.as(String)
+    save_player_pos ||= "off"
+    save_player_pos = save_player_pos == "on"
 
     show_nick = env.params.body["show_nick"]?.try &.as(String)
     show_nick ||= "off"
@@ -169,7 +169,7 @@ module Invidious::Routes::PreferencesRoute
       extend_desc:                 extend_desc,
       vr_mode:                     vr_mode,
       show_nick:                   show_nick,
-      remember_position:           remember_position,
+      save_player_pos:           save_player_pos,
     }.to_json).to_json
 
     if user = env.get? "user"

--- a/src/invidious/routes/preferences.cr
+++ b/src/invidious/routes/preferences.cr
@@ -70,6 +70,10 @@ module Invidious::Routes::PreferencesRoute
     vr_mode ||= "off"
     vr_mode = vr_mode == "on"
 
+    remember_position = env.params.body["remember_position"]?.try &.as(String)
+    remember_position ||= "off"
+    remember_position = remember_position == "on"
+
     show_nick = env.params.body["show_nick"]?.try &.as(String)
     show_nick ||= "off"
     show_nick = show_nick == "on"
@@ -165,6 +169,7 @@ module Invidious::Routes::PreferencesRoute
       extend_desc:                 extend_desc,
       vr_mode:                     vr_mode,
       show_nick:                   show_nick,
+      remember_position:           remember_position,
     }.to_json).to_json
 
     if user = env.get? "user"

--- a/src/invidious/routes/preferences.cr
+++ b/src/invidious/routes/preferences.cr
@@ -169,7 +169,7 @@ module Invidious::Routes::PreferencesRoute
       extend_desc:                 extend_desc,
       vr_mode:                     vr_mode,
       show_nick:                   show_nick,
-      save_player_pos:           save_player_pos,
+      save_player_pos:             save_player_pos,
     }.to_json).to_json
 
     if user = env.get? "user"

--- a/src/invidious/user/preferences.cr
+++ b/src/invidious/user/preferences.cr
@@ -53,6 +53,7 @@ struct Preferences
   property video_loop : Bool = CONFIG.default_user_preferences.video_loop
   property extend_desc : Bool = CONFIG.default_user_preferences.extend_desc
   property volume : Int32 = CONFIG.default_user_preferences.volume
+  property remember_position : Bool = CONFIG.default_user_preferences.remember_position
 
   module BoolToString
     def self.to_json(value : String, json : JSON::Builder)

--- a/src/invidious/user/preferences.cr
+++ b/src/invidious/user/preferences.cr
@@ -53,7 +53,7 @@ struct Preferences
   property video_loop : Bool = CONFIG.default_user_preferences.video_loop
   property extend_desc : Bool = CONFIG.default_user_preferences.extend_desc
   property volume : Int32 = CONFIG.default_user_preferences.volume
-  property remember_position : Bool = CONFIG.default_user_preferences.remember_position
+  property save_player_pos : Bool = CONFIG.default_user_preferences.save_player_pos
 
   module BoolToString
     def self.to_json(value : String, json : JSON::Builder)

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -1195,7 +1195,7 @@ def process_video_params(query, preferences)
     video_start:        video_start,
     volume:             volume,
     vr_mode:            vr_mode,
-    save_player_pos:  save_player_pos,
+    save_player_pos:    save_player_pos,
   })
 
   return params

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -246,6 +246,7 @@ struct VideoPreferences
   property video_start : Float64 | Int32
   property volume : Int32
   property vr_mode : Bool
+  property remember_position : Bool
 end
 
 struct Video
@@ -1090,6 +1091,7 @@ def process_video_params(query, preferences)
   extend_desc = query["extend_desc"]?.try { |q| (q == "true" || q == "1").to_unsafe }
   volume = query["volume"]?.try &.to_i?
   vr_mode = query["vr_mode"]?.try { |q| (q == "true" || q == "1").to_unsafe }
+  remember_position = query["remember_position"]?.try { |q| (q == "true" || q == "1").to_unsafe }
 
   if preferences
     # region ||= preferences.region
@@ -1110,6 +1112,7 @@ def process_video_params(query, preferences)
     extend_desc ||= preferences.extend_desc.to_unsafe
     volume ||= preferences.volume
     vr_mode ||= preferences.vr_mode.to_unsafe
+    remember_position ||= preferences.remember_position.to_unsafe
   end
 
   annotations ||= CONFIG.default_user_preferences.annotations.to_unsafe
@@ -1129,6 +1132,7 @@ def process_video_params(query, preferences)
   extend_desc ||= CONFIG.default_user_preferences.extend_desc.to_unsafe
   volume ||= CONFIG.default_user_preferences.volume
   vr_mode ||= CONFIG.default_user_preferences.vr_mode.to_unsafe
+  remember_position ||= CONFIG.default_user_preferences.remember_position.to_unsafe
 
   annotations = annotations == 1
   autoplay = autoplay == 1
@@ -1140,6 +1144,7 @@ def process_video_params(query, preferences)
   video_loop = video_loop == 1
   extend_desc = extend_desc == 1
   vr_mode = vr_mode == 1
+  remember_position = remember_position == 1
 
   if CONFIG.disabled?("dash") && quality == "dash"
     quality = "high"
@@ -1190,6 +1195,7 @@ def process_video_params(query, preferences)
     video_start:        video_start,
     volume:             volume,
     vr_mode:            vr_mode,
+    remember_position:  remember_position,
   })
 
   return params

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -246,7 +246,7 @@ struct VideoPreferences
   property video_start : Float64 | Int32
   property volume : Int32
   property vr_mode : Bool
-  property remember_position : Bool
+  property save_player_pos : Bool
 end
 
 struct Video
@@ -1091,7 +1091,7 @@ def process_video_params(query, preferences)
   extend_desc = query["extend_desc"]?.try { |q| (q == "true" || q == "1").to_unsafe }
   volume = query["volume"]?.try &.to_i?
   vr_mode = query["vr_mode"]?.try { |q| (q == "true" || q == "1").to_unsafe }
-  remember_position = query["remember_position"]?.try { |q| (q == "true" || q == "1").to_unsafe }
+  save_player_pos = query["save_player_pos"]?.try { |q| (q == "true" || q == "1").to_unsafe }
 
   if preferences
     # region ||= preferences.region
@@ -1112,7 +1112,7 @@ def process_video_params(query, preferences)
     extend_desc ||= preferences.extend_desc.to_unsafe
     volume ||= preferences.volume
     vr_mode ||= preferences.vr_mode.to_unsafe
-    remember_position ||= preferences.remember_position.to_unsafe
+    save_player_pos ||= preferences.save_player_pos.to_unsafe
   end
 
   annotations ||= CONFIG.default_user_preferences.annotations.to_unsafe
@@ -1132,7 +1132,7 @@ def process_video_params(query, preferences)
   extend_desc ||= CONFIG.default_user_preferences.extend_desc.to_unsafe
   volume ||= CONFIG.default_user_preferences.volume
   vr_mode ||= CONFIG.default_user_preferences.vr_mode.to_unsafe
-  remember_position ||= CONFIG.default_user_preferences.remember_position.to_unsafe
+  save_player_pos ||= CONFIG.default_user_preferences.save_player_pos.to_unsafe
 
   annotations = annotations == 1
   autoplay = autoplay == 1
@@ -1144,7 +1144,7 @@ def process_video_params(query, preferences)
   video_loop = video_loop == 1
   extend_desc = extend_desc == 1
   vr_mode = vr_mode == 1
-  remember_position = remember_position == 1
+  save_player_pos = save_player_pos == 1
 
   if CONFIG.disabled?("dash") && quality == "dash"
     quality = "high"
@@ -1195,7 +1195,7 @@ def process_video_params(query, preferences)
     video_start:        video_start,
     volume:             volume,
     vr_mode:            vr_mode,
-    remember_position:  remember_position,
+    save_player_pos:  save_player_pos,
   })
 
   return params

--- a/src/invidious/views/preferences.ecr
+++ b/src/invidious/views/preferences.ecr
@@ -116,6 +116,11 @@
                 <input name="vr_mode" id="vr_mode" type="checkbox" <% if preferences.vr_mode %>checked<% end %>>
             </div>
 
+            <div class="pure-control-group">
+                <label for="remember_position">Remember the current video time:</label>
+                <input name="remember_position" id="remember_position" type="checkbox" <% if preferences.remember_position %>checked<% end %>>
+            </div>
+
             <legend><%= translate(locale, "preferences_category_visual") %></legend>
 
             <div class="pure-control-group">

--- a/src/invidious/views/preferences.ecr
+++ b/src/invidious/views/preferences.ecr
@@ -117,8 +117,8 @@
             </div>
 
             <div class="pure-control-group">
-                <label for="remember_position">Remember the current video time:</label>
-                <input name="remember_position" id="remember_position" type="checkbox" <% if preferences.remember_position %>checked<% end %>>
+                <label for="save_player_pos">Remember the current video time:</label>
+                <input name="save_player_pos" id="save_player_pos" type="checkbox" <% if preferences.save_player_pos %>checked<% end %>>
             </div>
 
             <legend><%= translate(locale, "preferences_category_visual") %></legend>

--- a/src/invidious/views/preferences.ecr
+++ b/src/invidious/views/preferences.ecr
@@ -117,7 +117,7 @@
             </div>
 
             <div class="pure-control-group">
-                <label for="save_player_pos">Remember the current video time:</label>
+                <label for="save_player_pos"><%= translate(locale, "preferences_save_player_pos_label") %></label>
                 <input name="save_player_pos" id="save_player_pos" type="checkbox" <% if preferences.save_player_pos %>checked<% end %>>
             </div>
 


### PR DESCRIPTION
Closes #2024 

1. Add a checkbox toggle in the preferences page
2. Add `remember_position` field to `Preferences` and `VideoPreferences` structs
2. Modify player.js to save and load the current time stamp to an object in local storage to maintain the video time in a long term location

User preferences page checkbox for this new setting:
<img width="354" alt="Screen Shot 2021-10-25 at 9 04 12 PM" src="https://user-images.githubusercontent.com/9137314/138791429-9f4779d4-2858-4799-a605-2cb9930a07f7.png">

Users video times are stored in a JSON object in local storage, the object has this structure:
```javascript
{
  "<video_id>": seconds,
  "jNQXAC9IVRw": 3
}
```
<img width="447" alt="Screen Shot 2021-10-25 at 9 11 26 PM" src="https://user-images.githubusercontent.com/9137314/138791855-fbcbe732-b072-48b9-992c-864c2c553a84.png">


The time stamp is only updated once per second while the video is playing, to reduce unnecessary IO.