### PR TITLE
Add CSV Subscriptions Import

### DIFF
--- a/spec/invidious/user/imports_spec.cr
+++ b/spec/invidious/user/imports_spec.cr
@@ -32,18 +32,20 @@ Spectator.describe "Invidious::User::Imports" do
     expect(subscriptions).to be_an(Array(String))
     expect(subscriptions.size).to eq(13)
 
-    expect(subscriptions).to contain("UC0hHW5Y08ggq-9kbrGgWj0A")
-    expect(subscriptions).to contain("UC0vBXGSyV14uvJ4hECDOl0Q")
-    expect(subscriptions).to contain("UC1sELGmy5jp5fQUugmuYlXQ")
-    expect(subscriptions).to contain("UC9kFnwdCRrX7oTjqKd6-tiQ")
-    expect(subscriptions).to contain("UCBa659QWEk1AI4Tg--mrJ2A")
-    expect(subscriptions).to contain("UCGu6_XQ64rXPR6nuitMQE_A")
-    expect(subscriptions).to contain("UCGwu0nbY2wSkW8N-cghnLpA")
-    expect(subscriptions).to contain("UCQ0OvZ54pCFZwsKxbltg_tg")
-    expect(subscriptions).to contain("UCRE6itj4Jte4manQEu3Y7OA")
-    expect(subscriptions).to contain("UCRLc6zsv_d0OEBO8OOkz-DA")
-    expect(subscriptions).to contain("UCSl5Uxu2LyaoAoMMGp6oTJA")
-    expect(subscriptions).to contain("UCXuqSBlHAE6Xw-yeJA0Tunw")
-    expect(subscriptions).to contain("UCZ5XnGb-3t7jCkXdawN2tkA")
+    expect(subscriptions).to contain_exactly(
+      "UC0hHW5Y08ggq-9kbrGgWj0A",
+      "UC0vBXGSyV14uvJ4hECDOl0Q",
+      "UC1sELGmy5jp5fQUugmuYlXQ",
+      "UC9kFnwdCRrX7oTjqKd6-tiQ",
+      "UCBa659QWEk1AI4Tg--mrJ2A",
+      "UCGu6_XQ64rXPR6nuitMQE_A",
+      "UCGwu0nbY2wSkW8N-cghnLpA",
+      "UCQ0OvZ54pCFZwsKxbltg_tg",
+      "UCRE6itj4Jte4manQEu3Y7OA",
+      "UCRLc6zsv_d0OEBO8OOkz-DA",
+      "UCSl5Uxu2LyaoAoMMGp6oTJA",
+      "UCXuqSBlHAE6Xw-yeJA0Tunw",
+      "UCZ5XnGb-3t7jCkXdawN2tkA",
+    ).in_order
   end
 end

--- a/spec/invidious/user/imports_spec.cr
+++ b/spec/invidious/user/imports_spec.cr
@@ -1,0 +1,49 @@
+require "spectator"
+require "../../../src/invidious/user/imports"
+
+Spectator.configure do |config|
+  config.fail_blank
+  config.randomize
+end
+
+def csv_sample
+  return <<-CSV
+  Kanal-ID,Kanal-URL,Kanaltitel
+  UC0hHW5Y08ggq-9kbrGgWj0A,http://www.youtube.com/channel/UC0hHW5Y08ggq-9kbrGgWj0A,Matias Marolla
+  UC0vBXGSyV14uvJ4hECDOl0Q,http://www.youtube.com/channel/UC0vBXGSyV14uvJ4hECDOl0Q,Techquickie
+  UC1sELGmy5jp5fQUugmuYlXQ,http://www.youtube.com/channel/UC1sELGmy5jp5fQUugmuYlXQ,Minecraft
+  UC9kFnwdCRrX7oTjqKd6-tiQ,http://www.youtube.com/channel/UC9kFnwdCRrX7oTjqKd6-tiQ,LUMOX - Topic
+  UCBa659QWEk1AI4Tg--mrJ2A,http://www.youtube.com/channel/UCBa659QWEk1AI4Tg--mrJ2A,Tom Scott
+  UCGu6_XQ64rXPR6nuitMQE_A,http://www.youtube.com/channel/UCGu6_XQ64rXPR6nuitMQE_A,Callcenter Fun
+  UCGwu0nbY2wSkW8N-cghnLpA,http://www.youtube.com/channel/UCGwu0nbY2wSkW8N-cghnLpA,Jaiden Animations
+  UCQ0OvZ54pCFZwsKxbltg_tg,http://www.youtube.com/channel/UCQ0OvZ54pCFZwsKxbltg_tg,Methos
+  UCRE6itj4Jte4manQEu3Y7OA,http://www.youtube.com/channel/UCRE6itj4Jte4manQEu3Y7OA,Chipflake
+  UCRLc6zsv_d0OEBO8OOkz-DA,http://www.youtube.com/channel/UCRLc6zsv_d0OEBO8OOkz-DA,Kegy
+  UCSl5Uxu2LyaoAoMMGp6oTJA,http://www.youtube.com/channel/UCSl5Uxu2LyaoAoMMGp6oTJA,Atomic Shrimp
+  UCXuqSBlHAE6Xw-yeJA0Tunw,http://www.youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw,Linus Tech Tips
+  UCZ5XnGb-3t7jCkXdawN2tkA,http://www.youtube.com/channel/UCZ5XnGb-3t7jCkXdawN2tkA,Discord
+  CSV
+end
+
+Spectator.describe "Invidious::User::Imports" do
+  it "imports CSV" do
+    subscriptions = parse_subscription_export_csv(csv_sample)
+
+    expect(subscriptions).to be_an(Array(String))
+    expect(subscriptions.size).to eq(13)
+
+    expect(subscriptions).to contain("UC0hHW5Y08ggq-9kbrGgWj0A")
+    expect(subscriptions).to contain("UC0vBXGSyV14uvJ4hECDOl0Q")
+    expect(subscriptions).to contain("UC1sELGmy5jp5fQUugmuYlXQ")
+    expect(subscriptions).to contain("UC9kFnwdCRrX7oTjqKd6-tiQ")
+    expect(subscriptions).to contain("UCBa659QWEk1AI4Tg--mrJ2A")
+    expect(subscriptions).to contain("UCGu6_XQ64rXPR6nuitMQE_A")
+    expect(subscriptions).to contain("UCGwu0nbY2wSkW8N-cghnLpA")
+    expect(subscriptions).to contain("UCQ0OvZ54pCFZwsKxbltg_tg")
+    expect(subscriptions).to contain("UCRE6itj4Jte4manQEu3Y7OA")
+    expect(subscriptions).to contain("UCRLc6zsv_d0OEBO8OOkz-DA")
+    expect(subscriptions).to contain("UCSl5Uxu2LyaoAoMMGp6oTJA")
+    expect(subscriptions).to contain("UCXuqSBlHAE6Xw-yeJA0Tunw")
+    expect(subscriptions).to contain("UCZ5XnGb-3t7jCkXdawN2tkA")
+  end
+end

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -821,11 +821,14 @@ post "/data_control" do |env|
           user.subscriptions += subscriptions.xpath_nodes(%q(//outline[@type="rss"])).map do |channel|
             channel["xmlUrl"].match(/UC[a-zA-Z0-9_-]{22}/).not_nil![0]
           end
-        else
+        elsif body[0] == '['
           subscriptions = JSON.parse(body)
           user.subscriptions += subscriptions.as_a.compact_map do |entry|
             entry["snippet"]["resourceId"]["channelId"].as_s
           end
+        else
+          subscriptions = parse_subscription_export_csv(body)
+          user.subscriptions += subscriptions
         end
         user.subscriptions.uniq!
 

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -746,6 +746,8 @@ post "/data_control" do |env|
 
     HTTP::FormData.parse(env.request) do |part|
       body = part.body.gets_to_end
+      type = part.headers["Content-Type"]
+
       next if body.empty?
 
       # TODO: Unify into single import based on content-type
@@ -816,12 +818,12 @@ post "/data_control" do |env|
           end
         end
       when "import_youtube"
-        if body[0..4] == "<opml"
+        if type == "application/xml"
           subscriptions = XML.parse(body)
           user.subscriptions += subscriptions.xpath_nodes(%q(//outline[@type="rss"])).map do |channel|
             channel["xmlUrl"].match(/UC[a-zA-Z0-9_-]{22}/).not_nil![0]
           end
-        elsif body[0] == '['
+        elsif type == "application/json"
           subscriptions = JSON.parse(body)
           user.subscriptions += subscriptions.as_a.compact_map do |entry|
             entry["snippet"]["resourceId"]["channelId"].as_s

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -818,7 +818,7 @@ post "/data_control" do |env|
           end
         end
       when "import_youtube"
-        if type == "application/xml"
+        if type == "application/xml" || type == "text/xml"
           subscriptions = XML.parse(body)
           user.subscriptions += subscriptions.xpath_nodes(%q(//outline[@type="rss"])).map do |channel|
             channel["xmlUrl"].match(/UC[a-zA-Z0-9_-]{22}/).not_nil![0]

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -1,5 +1,3 @@
-require "csv"
-
 # See http://www.evanmiller.org/how-not-to-sort-by-average-rating.html
 def ci_lower_bound(pos, n)
   if n == 0

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -369,23 +369,3 @@ def fetch_random_instance
 
   return filtered_instance_list.sample(1)[0]
 end
-
-def parse_subscription_export_csv(csv_content : String)
-  rows = CSV.new(csv_content, headers: true)
-  subscriptions = Array(String).new
-
-  rows.each do |row|
-    # Channel ID is the first column in the csv export we can't use the header
-    # name, because I believe the header name is localized depending on the
-    # language the user has set on their account
-    channel_id = row[0].strip
-
-    if channel_id.empty?
-      next
-    end
-
-    subscriptions << channel_id
-  end
-
-  subscriptions
-end

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -1,3 +1,5 @@
+require "csv"
+
 # See http://www.evanmiller.org/how-not-to-sort-by-average-rating.html
 def ci_lower_bound(pos, n)
   if n == 0
@@ -366,4 +368,24 @@ def fetch_random_instance
   end
 
   return filtered_instance_list.sample(1)[0]
+end
+
+def parse_subscription_export_csv(csv_content : String)
+  rows = CSV.new(csv_content, headers: true)
+  subscriptions = Array(String).new
+
+  rows.each do |row|
+    # Channel ID is the first column in the csv export we can't use the header
+    # name, because I believe the header name is localized depending on the
+    # language the user has set on their account
+    channel_id = row[0].strip
+
+    if channel_id.empty?
+      next
+    end
+
+    subscriptions << channel_id
+  end
+
+  subscriptions
 end

--- a/src/invidious/user/imports.cr
+++ b/src/invidious/user/imports.cr
@@ -1,0 +1,17 @@
+def parse_subscription_export_csv(csv_content : String)
+  rows = CSV.new(csv_content, headers: true)
+  subscriptions = Array(String).new
+
+  rows.each do |row|
+    # Channel ID is the first column in the csv export we can't use the header
+    # name, because the header name is localized depending on the
+    # language the user has set on their account
+    channel_id = row[0].strip
+
+    next if channel_id.empty?
+
+    subscriptions << channel_id
+  end
+
+  subscriptions
+end

--- a/src/invidious/user/imports.cr
+++ b/src/invidious/user/imports.cr
@@ -15,5 +15,5 @@ def parse_subscription_export_csv(csv_content : String)
     subscriptions << channel_id
   end
 
-  subscriptions
+  return subscriptions
 end

--- a/src/invidious/user/imports.cr
+++ b/src/invidious/user/imports.cr
@@ -4,7 +4,15 @@ def parse_subscription_export_csv(csv_content : String)
   rows = CSV.new(csv_content, headers: true)
   subscriptions = Array(String).new
 
+  # Counter to limit the amount of imports.
+  # This is intended to prevent DoS.
+  row_counter = 0
+
   rows.each do |row|
+    # Limit to 1200
+    row_counter += 1
+    break if row_counter > 1_200
+
     # Channel ID is the first column in the csv export we can't use the header
     # name, because the header name is localized depending on the
     # language the user has set on their account

--- a/src/invidious/user/imports.cr
+++ b/src/invidious/user/imports.cr
@@ -1,3 +1,5 @@
+require "csv"
+
 def parse_subscription_export_csv(csv_content : String)
   rows = CSV.new(csv_content, headers: true)
   subscriptions = Array(String).new


### PR DESCRIPTION
Closes #2319 

1. Add a helper function `parse_subscription_export_csv()` to `helpers/utils.cr`, this function reads the body as CSV content, and parses the channel id column from the rows. 
2. Modify `invidious.cr` to perform a check on the body to determine if it is likely JSON (if so, the continue to use the current code for importing subscriptions). Otherwise, default to assuming it is in CSV format and parse the subscription export dump with the new helper function.

In the helper function, I used column index (in this case 0 corresponds to the `"Channel Id"` column), because I believe, based off of the bug report, that the header names are localized depending on the users language in this case "Kanal" = "Channel"