### PR TITLE
Bump Crystal version for CI and Docker to 1.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         crystal:
           - 1.0.0
           - 1.1.1
-          - 1.2.1
+          - 1.2.2
         include:
           - crystal: nightly
             stable: false

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Crystal
         uses: oprypin/install-crystal@v1.2.4
         with:
-          crystal: 1.1.1
+          crystal: 1.2.2
         
       - name: Run lint
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:1.2.1-alpine AS builder
+FROM crystallang/crystal:1.2.2-alpine AS builder
 RUN apk add --no-cache sqlite-static yaml-static
 
 ARG release


### PR DESCRIPTION
Entirely copied from https://github.com/iv-org/invidious/pull/2527