### PR TITLE
Get all videos when sorted by oldest

### DIFF
--- a/config/sql/channel_continuations.sql
+++ b/config/sql/channel_continuations.sql
@@ -5,8 +5,8 @@
 CREATE TABLE IF NOT EXISTS public.channel_continuations
 (
   id text NOT NULL,
-  page integer,
-  sort_by text,
+  page integer NOT NULL,
+  sort_by text NOT NULL,
   continuation text,
   CONSTRAINT channel_continuations_id_page_sort_by_key UNIQUE (id, page, sort_by)
 );

--- a/config/sql/channel_continuations.sql
+++ b/config/sql/channel_continuations.sql
@@ -1,0 +1,23 @@
+-- Table: public.channel_continuations
+
+-- DROP TABLE public.channel_continuations;
+
+CREATE TABLE IF NOT EXISTS public.channel_continuations
+(
+  id text NOT NULL,
+  page integer,
+  sort_by text,
+  continuation text,
+  CONSTRAINT channel_continuations_id_page_sort_by_key UNIQUE (id, page, sort_by)
+);
+
+GRANT ALL ON TABLE public.channel_continuations TO default_user;
+
+-- Index: public.channel_continuations_id_idx
+
+-- DROP INDEX public.channel_continuations_id_idx;
+
+CREATE INDEX IF NOT EXISTS channel_continuations_id_idx
+  ON public.channel_continuations
+  USING btree
+  (id COLLATE pg_catalog."default");

--- a/docker/init-invidious-db.sh
+++ b/docker/init-invidious-db.sh
@@ -3,6 +3,7 @@ set -eou pipefail
 
 psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/channels.sql
 psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/videos.sql
+psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/channel_continuations.sql
 psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/channel_videos.sql
 psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/users.sql
 psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < config/sql/session_ids.sql

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -115,6 +115,7 @@ if CONFIG.check_tables
   check_enum(PG_DB, "privacy", PlaylistPrivacy)
 
   check_table(PG_DB, "channels", InvidiousChannel)
+  check_table(PG_DB, "channel_continuations", ChannelContinuation)
   check_table(PG_DB, "channel_videos", ChannelVideo)
   check_table(PG_DB, "playlists", InvidiousPlaylist)
   check_table(PG_DB, "playlist_videos", PlaylistVideo)

--- a/src/invidious/channels/channels.cr
+++ b/src/invidious/channels/channels.cr
@@ -12,8 +12,8 @@ struct ChannelContinuation
   include DB::Serializable
 
   property id : String
-  property page : Int32 = 0
-  property sort_by : String = "newest"
+  property page : Int32
+  property sort_by : String
   property continuation : String
 
   def to_tuple

--- a/src/invidious/channels/channels.cr
+++ b/src/invidious/channels/channels.cr
@@ -8,6 +8,23 @@ struct InvidiousChannel
   property subscribed : Time?
 end
 
+struct ChannelContinuation
+  include DB::Serializable
+
+  property id : String
+  property page : Int32 = 0
+  property sort_by : String = "newest"
+  property continuation : String
+
+  def to_tuple
+    {% begin %}
+      {
+        {{*@type.instance_vars.map(&.name)}}
+      }
+    {% end %}
+  end
+end
+
 struct ChannelVideo
   include DB::Serializable
 
@@ -199,6 +216,18 @@ def fetch_channel(ucid, db, pull_all_videos = true, locale = nil)
 
   page = 1
 
+  channel_continuation = ChannelContinuation.new({
+    id: ucid,
+    page: page,
+    sort_by: "newest",
+    continuation: produce_channel_videos_continuation(ucid, auto_generated: auto_generated, v2: true)
+  })
+  
+  LOGGER.trace("fetch_channel: #{ucid} : page #{page} : Updating or inserting continuation")
+
+  db.exec("INSERT INTO channel_continuations VALUES ($1, $2, $3, $4) \
+   ON CONFLICT (id, page, sort_by) DO UPDATE SET continuation = $4", *channel_continuation.to_tuple)
+
   LOGGER.trace("fetch_channel: #{ucid} : Downloading channel videos page")
   initial_data = get_channel_videos_response(ucid, page, auto_generated: auto_generated)
   videos = extract_videos(initial_data, author, ucid)
@@ -263,6 +292,15 @@ def fetch_channel(ucid, db, pull_all_videos = true, locale = nil)
     loop do
       initial_data = get_channel_videos_response(ucid, page, auto_generated: auto_generated)
       videos = extract_videos(initial_data, author, ucid)
+
+      channel_continuation = ChannelContinuation.new({
+        id: ucid,
+        page: page,
+        sort_by: "newest",
+        continuation: fetch_continuation_token(initial_data) || ""
+      })
+      db.exec("INSERT INTO channel_continuations VALUES ($1, $2, $3, $4) \
+       ON CONFLICT (id, page, sort_by) DO UPDATE SET continuation = $4", *channel_continuation.to_tuple)
 
       count = videos.size
       videos = videos.map { |video| ChannelVideo.new({

--- a/src/invidious/channels/videos.cr
+++ b/src/invidious/channels/videos.cr
@@ -95,10 +95,10 @@ def get_channel_videos_response(ucid, page = 1, auto_generated = nil, sort_by = 
       break if continuation.nil? || continuation.empty?
 
       channel_continuation = ChannelContinuation.new({
-        id: ucid,
-        page: i,
-        sort_by: sort_by,
-        continuation: continuation
+        id:           ucid,
+        page:         i,
+        sort_by:      sort_by,
+        continuation: continuation,
       })
       PG_DB.exec("INSERT INTO channel_continuations VALUES ($1, $2, $3, $4) \
         ON CONFLICT (id, page, sort_by) DO UPDATE SET continuation = $4", *channel_continuation.to_tuple)
@@ -119,10 +119,10 @@ def get_channel_videos_response(ucid, page = 1, auto_generated = nil, sort_by = 
 
       if !continuation.nil? && !continuation.empty?
         channel_continuation = ChannelContinuation.new({
-          id: ucid,
-          page: page + 1,
-          sort_by: sort_by,
-          continuation: continuation
+          id:           ucid,
+          page:         page + 1,
+          sort_by:      sort_by,
+          continuation: continuation,
         })
         PG_DB.exec("INSERT INTO channel_continuations VALUES ($1, $2, $3, $4) \
          ON CONFLICT (id, page, sort_by) DO UPDATE SET continuation = $4", *channel_continuation.to_tuple)

--- a/src/invidious/yt_backend/extractors_utils.cr
+++ b/src/invidious/yt_backend/extractors_utils.cr
@@ -58,10 +58,16 @@ def fetch_continuation_token(initial_data : Hash(String, JSON::Any))
   # Fetches the continuation token from initial data
   if initial_data["onResponseReceivedActions"]?
     continuation_items = initial_data["onResponseReceivedActions"][0]["appendContinuationItemsAction"]["continuationItems"]
-  else
+  elsif initial_data["contents"]?
     tab = extract_selected_tab(initial_data["contents"]["twoColumnBrowseResultsRenderer"]["tabs"])
     continuation_items = tab["content"]["sectionListRenderer"]["contents"][0]["itemSectionRenderer"]["contents"][0]["gridRenderer"]["items"]
+  else
+    continuation = initial_data["continuationContents"]["gridContinuation"]["continuations"][0]["nextContinuationData"]["continuation"].as_s
   end
 
-  return fetch_continuation_token(continuation_items.as_a)
+  if continuation_items.nil?
+    return continuation
+  else
+    return fetch_continuation_token(continuation_items.as_a)
+  end
 end

--- a/src/invidious/yt_backend/extractors_utils.cr
+++ b/src/invidious/yt_backend/extractors_utils.cr
@@ -55,19 +55,20 @@ def fetch_continuation_token(items : Array(JSON::Any))
 end
 
 def fetch_continuation_token(initial_data : Hash(String, JSON::Any))
+  continuation = ""
   # Fetches the continuation token from initial data
   if initial_data["onResponseReceivedActions"]?
     continuation_items = initial_data["onResponseReceivedActions"][0]["appendContinuationItemsAction"]["continuationItems"]
   elsif initial_data["contents"]?
     tab = extract_selected_tab(initial_data["contents"]["twoColumnBrowseResultsRenderer"]["tabs"])
     continuation_items = tab["content"]["sectionListRenderer"]["contents"][0]["itemSectionRenderer"]["contents"][0]["gridRenderer"]["items"]
-  else
+  elsif initial_data["continuationContents"]["gridContinuation"]["continuations"]?
     continuation = initial_data["continuationContents"]["gridContinuation"]["continuations"][0]["nextContinuationData"]["continuation"].as_s
   end
 
-  if continuation_items.nil?
-    return continuation
-  else
-    return fetch_continuation_token(continuation_items.as_a)
+  if !continuation_items.nil?
+    continuation = fetch_continuation_token(continuation_items.as_a)
   end
+
+  return continuation
 end


### PR DESCRIPTION
I had originally implemented a partially working solution where the continuation was passed in the request headers, similiar to how this issue was fixed [here](https://git.gir.st/subscriptionfeed.git/commit/7ddb60edbec29e4d88bb4b2f8f427869acea8220). However after doing that I found [this comment](https://github.com/iv-org/invidious/issues/1599#issuecomment-814372849) which stated that using the page number rather than passing around the continuation was a design decision.

This pull request adds a new database table which keeps track of the continuation for each page on a channel. The new db store/lookup logic is only used where the current implementation doesn't work, so getting videos sorted by newest and popular still uses the existing continuation generation logic. This reduces the amount of entries that will be written to the database, and the amount of time looking up continuations in the database, as we only really need to store the continuations when sorting by oldest.

In normal operation (using the next page button) the continuation for the following page will be stored after the data for the current page is returned from the API call. However if a user manually goes to a page where we don't have the continuation (e.g. by modifying the page request header) we find the 'latest' continuation we have then iterate from there to get the continuation for the wanted page. During this iteration we store the returned continuation so that it can be easily looked up next time that page is requested.

Fixes: #2436
I want to be awarded the bounty associated to the issue this PR is fixing.