### PR TITLE
Add override to mute IO::Error in HTTP::Server::Response::Output

### DIFF
--- a/src/invidious/helpers/crystal_class_overrides.cr
+++ b/src/invidious/helpers/crystal_class_overrides.cr
@@ -53,38 +53,23 @@ end
 #
 class HTTP::Server::Response
   class Output
-    # Copy-paste of https://github.com/crystal-lang/crystal/blob/1.2.2/src/http/server/response.cr#L205-L228
-    # but without the "raise" statement in `rescue ex`
+    # Run unbuffered_write() from stdlib but catch IO::Error
+    # HTTP::Server::ClientError exceptions.
     private def unbuffered_write(slice : Bytes)
-      return if slice.empty?
-
-      unless response.wrote_headers?
-        if response.version != "HTTP/1.0" && !response.headers.has_key?("Content-Length")
-          response.headers["Transfer-Encoding"] = "chunked"
-          @chunked = true
-        end
+      begin
+        previous_def
+      rescue ex : IO::Error
+      rescue ex : HTTP::Server::ClientError
       end
-
-      ensure_headers_written
-
-      if @chunked
-        slice.size.to_s(@io, 16)
-        @io << "\r\n"
-        @io.write(slice)
-        @io << "\r\n"
-      else
-        @io.write(slice)
-      end
-    rescue ex : IO::Error
-      unbuffered_close
     end
 
-    # Copy-paste of https://github.com/crystal-lang/crystal/blob/1.2.2/src/http/server/response.cr#L274-L280
-    # but without the "raise" statement in `rescue ex`
+    # Same for unbuffered_flush()
     private def unbuffered_flush
-      @io.flush
-    rescue ex : IO::Error
-      unbuffered_close
+      begin
+        previous_def
+      rescue ex : IO::Error
+      rescue ex : HTTP::Server::ClientError
+      end
     end
   end
 end


### PR DESCRIPTION
Same as #2690, I just renamed the branch for clarity when it'll be merged.