### PR TITLE
Add support for shorts

### DIFF
--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -21,10 +21,17 @@ def elapsed_text(elapsed)
 end
 
 def decode_length_seconds(string)
-  length_seconds = string.gsub(/[^0-9:]/, "").split(":").map &.to_i
+  length_seconds = string.gsub(/[^0-9:]/, "")
+  return 0_i32 if length_seconds.empty?
+
+  length_seconds = length_seconds.split(":").map { |x| x.to_i? || 0 }
   length_seconds = [0] * (3 - length_seconds.size) + length_seconds
-  length_seconds = Time::Span.new hours: length_seconds[0], minutes: length_seconds[1], seconds: length_seconds[2]
-  length_seconds = length_seconds.total_seconds.to_i
+
+  length_seconds = Time::Span.new(
+    hours: length_seconds[0],
+    minutes: length_seconds[1],
+    seconds: length_seconds[2]
+  ).total_seconds.to_i32
 
   return length_seconds
 end


### PR DESCRIPTION
Fixes #2708

"Shorts" are not properly handled in trending and other places.
This PRs is meant to support them.

Note: In the future, it'd be preferrable to re-do the classes for Video metadata storage, as the many different types of videos (live, premiere, shorts, etc...) are starting to cause issues. See https://github.com/iv-org/invidious/issues/2645#issuecomment-991997344