### PR TITLE
Removes annoying video switching | Fixes #2736

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -215,7 +215,7 @@ if (video_data.params.save_player_pos) {
         const raw = player.currentTime();
         const time = Math.floor(raw);
 
-        if(lastUpdated !== time) {
+        if(lastUpdated !== time && raw <= video_data.length_seconds - 15) {
             save_video_time(time);
             lastUpdated = time;
         }


### PR DESCRIPTION
 Add check to avoid saving player position to the length of the given video by saving a minimum of 15 seconds at the end