### PR TITLE
Double quote variable to prevent sh error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ COPY ./.git/ ./.git/
 RUN crystal spec --warnings all \
     --link-flags "-lxml2 -llzma"
 
-RUN if [ ${release} == 1 ] ; then \
+RUN if [ "${release}" == 1 ] ; then \
         crystal build ./src/invidious.cr \
         --release \
         --static --warnings all \


### PR DESCRIPTION
During build of the image, this error message appears:

    Step 12/27 : RUN if [ ${release} == 1 ] ; then         crystal build ./src/invidious.cr         --release         --static --warnings all         --link-flags "-lxml2 -llzma";     else         crystal build ./src/invidious.cr         --static --warnings all         --link-flags "-lxml2 -llzma";     fi
     ---> Running in 44d8a5cd1f96
    sh: 1: unknown operand

When double-quoting the variable according to [shellcheck's SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086), the error notice is gone.