### PR TITLE
Create videos caching table as UNLOGGED

### DIFF
--- a/config/sql/videos.sql
+++ b/config/sql/videos.sql
@@ -2,7 +2,7 @@
 
 -- DROP TABLE public.videos;
 
-CREATE TABLE IF NOT EXISTS public.videos
+CREATE UNLOGGED TABLE IF NOT EXISTS public.videos
 (
   id text NOT NULL,
   info text,


### PR DESCRIPTION
From the doc for `UNLOGGED` (https://www.postgresql.org/docs/10/sql-createtable.html):
> If specified, the table is created as an unlogged table. Data written to unlogged tables is not written to the write-ahead log (see Chapter 30), which makes them considerably faster than ordinary tables. However, they are not crash-safe: an unlogged table is automatically truncated after a crash or unclean shutdown. The contents of an unlogged table are also not replicated to standby servers. Any indexes created on an unlogged table are automatically unlogged as well.

For a table used for caching, it doesn't make sense to have a fail proof table, as this table is repopulated by invidious as soon as the data is removed and recommend this table to be truncated every week.

Moreover, having unlogged table improves the performance by a lot.