### PR TITLE
Update to fetch related channels again

### DIFF
--- a/src/invidious/routes/api/v1/channels.cr
+++ b/src/invidious/routes/api/v1/channels.cr
@@ -96,21 +96,23 @@ module Invidious::Routes::API::V1::Channels
 
         json.field "relatedChannels" do
           json.array do
-            channel.related_channels.each do |related_channel|
-              json.object do
-                json.field "author", related_channel.author
-                json.field "authorId", related_channel.ucid
-                json.field "authorUrl", related_channel.author_url
+            if related_channels = channel.related_channels
+              fetch_related_channels(related_channels).each do |related_channel|
+                json.object do
+                  json.field "author", related_channel.author
+                  json.field "authorId", related_channel.ucid
+                  json.field "authorUrl", related_channel.author_url
 
-                json.field "authorThumbnails" do
-                  json.array do
-                    qualities = {32, 48, 76, 100, 176, 512}
+                  json.field "authorThumbnails" do
+                    json.array do
+                      qualities = {32, 48, 76, 100, 176, 512}
 
-                    qualities.each do |quality|
-                      json.object do
-                        json.field "url", related_channel.author_thumbnail.gsub(/=\d+/, "=s#{quality}")
-                        json.field "width", quality
-                        json.field "height", quality
+                      qualities.each do |quality|
+                        json.object do
+                          json.field "url", related_channel.author_thumbnail.gsub(/=\d+/, "=s#{quality}")
+                          json.field "width", quality
+                          json.field "height", quality
+                        end
                       end
                     end
                   end

--- a/src/invidious/routes/api/v1/channels.cr
+++ b/src/invidious/routes/api/v1/channels.cr
@@ -96,23 +96,21 @@ module Invidious::Routes::API::V1::Channels
 
         json.field "relatedChannels" do
           json.array do
-            if related_channels = channel.related_channels
-              fetch_related_channels(related_channels).each do |related_channel|
-                json.object do
-                  json.field "author", related_channel.author
-                  json.field "authorId", related_channel.ucid
-                  json.field "authorUrl", related_channel.author_url
+            fetch_related_channels(channel).each do |related_channel|
+              json.object do
+                json.field "author", related_channel.author
+                json.field "authorId", related_channel.ucid
+                json.field "authorUrl", related_channel.author_url
 
-                  json.field "authorThumbnails" do
-                    json.array do
-                      qualities = {32, 48, 76, 100, 176, 512}
+                json.field "authorThumbnails" do
+                  json.array do
+                    qualities = {32, 48, 76, 100, 176, 512}
 
-                      qualities.each do |quality|
-                        json.object do
-                          json.field "url", related_channel.author_thumbnail.gsub(/=\d+/, "=s#{quality}")
-                          json.field "width", quality
-                          json.field "height", quality
-                        end
+                    qualities.each do |quality|
+                      json.object do
+                        json.field "url", related_channel.author_thumbnail.gsub(/=\d+/, "=s#{quality}")
+                        json.field "width", quality
+                        json.field "height", quality
                       end
                     end
                   end


### PR DESCRIPTION
Fixes #2749
Relates to #483

Fetching channel info seems to no longer return related channels. Instead, we have to fetch the data found in the **Channels** tab. Because this is an extra API request, I updated the code to only make it when related channels are actually used which is just one place.

The structs used in this included `DB::Serializable` but weren't actually saved to the database. I updated them to be `record`'s.

## Testing

Go to `http://0.0.0.0:3000/api/v1/channels/UCXuqSBlHAE6Xw-yeJA0Tunw?fields=relatedChannels` on master and see that it returns an empty list. Now go to it on this branch and it should return all of the channels found in this picture

<details>
<summary>LTT Featured Channels</summary>
<br>
<img width="677" alt="Screen Shot 2022-01-08 at 12 27 38 PM" src="https://user-images.githubusercontent.com/17329408/148655452-3a09edd4-ae5c-4359-8cae-b55cf20ce0ba.png">
</details>

`http://0.0.0.0:3000/api/v1/channels/UC38UpcvhpPqY2QmttdvWemA?fields=relatedChannels` is an example of a channel that doesn't have any related channels and doesn't break

