### PR TITLE
Add e-mail contact to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
   <img alt="Mastodon: @invidious@social.tchncs.de" src="https://img.shields.io/badge/Mastodon-%40invidious%40social.tchncs.de-darkgreen">
   </a>
   <br>
-  <a href="#contact">
+  <a href="#contact-the-team-directly">
   <img alt="Contact the team directly" src="https://img.shields.io/badge/Contact%20the%20team%20directly-darkgreen">
   </a>
 </div>

--- a/README.md
+++ b/README.md
@@ -48,13 +48,10 @@
   <a rel="me" href="https://social.tchncs.de/@invidious">
   <img alt="Mastodon: @invidious@social.tchncs.de" src="https://img.shields.io/badge/Mastodon-%40invidious%40social.tchncs.de-darkgreen">
   </a>
-  
-  <h5>E-mail us:</h5>
-  <ul>
-  <li>General Inquiries (forwarded to every team member): <code>contact [at] invidious [dot] io</code> (Note: before sending a bug report please check that it hasn't already be reported on GitHub - bug reports sent to this address will be copied to GitHub)</li>
-  <li>Security issues (forwarded to the two project owners, <a href="https://github.com/TheFrenchGhosty">@TheFrenchGhosty</a> and <a href="https://github.com/Perflyst">@Perflyst</a>): <code>security [at] invidious [dot] io</code></li>
-  </ul>
-    
+  <br>
+  <a href="#contact">
+  <img alt="Contact the team directly" src="https://img.shields.io/badge/Contact%20the%20team%20directly-darkgreen">
+  </a>
 </div>
 
 
@@ -151,6 +148,19 @@ Weblate also allows you to log-in with major SSO providers like Github, Gitlab, 
 - [PeerTubeify](https://gitlab.com/Cha_deL/peertubeify): On YouTube, displays a link to the same video on PeerTube, if it exists.
 - [MusicPiped](https://github.com/deep-gaurav/MusicPiped): A material design music player that streams music from YouTube.
 - [HoloPlay](https://github.com/stephane-r/HoloPlay): Funny Android application connecting on Invidious API's with search, playlists and favorites.
+
+
+## Contact the team directly
+
+Every team member is available through GitHub or through the Matrix room (bridged to IRC), however, if you need/have too, you can contact the team directly via e-mail (remove `+SPAMGUARD` from the addresses):
+
+- General Inquiries (forwarded to every team member): `contact +SPAMGUARD [at] invidious [dot] io`
+
+Note: before sending a bug report please check that it hasn't already be reported on GitHub - bug reports sent to this address will be copied to GitHub
+
+- Security issues (forwarded to the two project owners, <a href="https://github.com/TheFrenchGhosty">@TheFrenchGhosty</a> and <a href="https://github.com/Perflyst">@Perflyst</a>): `security +SPAMGUARD [at] invidious [dot] io`
+
+Note: the creation of a PGP key for this address is planned
 
 
 ## Liability

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Weblate also allows you to log-in with major SSO providers like Github, Gitlab, 
 
 ## Contact the team directly
 
-Every team member is available through GitHub or through the Matrix room (bridged to IRC), however, if you need/have too, you can contact the team directly via e-mail (remove `+SPAMGUARD` from the addresses):
+Every team member is available through GitHub or through the Matrix room (bridged to IRC), however, if you need/have to, you can contact the team directly via e-mail (remove `+SPAMGUARD` from the addresses):
 
 - General Inquiries (forwarded to every team member): `contact +SPAMGUARD [at] invidious [dot] io`
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
   
   <h5>E-mail us:</h5>
   <ul>
-  <li>General Inquiries (forwarded to every team member): <code>contact [at] invidious [dot] io</code> (Note: before sending a bug reports please check that it hasn't already be reported on GitHub - bug reports sent to this address will be copied to GitHub)</li>
+  <li>General Inquiries (forwarded to every team member): <code>contact [at] invidious [dot] io</code> (Note: before sending a bug report please check that it hasn't already be reported on GitHub - bug reports sent to this address will be copied to GitHub)</li>
   <li>Security issues (forwarded to the two project owners, <a href="https://github.com/TheFrenchGhosty">@TheFrenchGhosty</a> and <a href="https://github.com/Perflyst">@Perflyst</a>): <code>security [at] invidious [dot] io</code></li>
   </ul>
     

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
   </a>
   <br>
   <a href="#contact-the-team-directly">
-  <img alt="Contact the team directly" src="https://img.shields.io/badge/Contact%20the%20team%20directly-darkgreen">
+  <img alt="Contact the team directly" src="https://img.shields.io/badge/E%2d%2dmail-darkgreen">
   </a>
 </div>
 
@@ -154,7 +154,7 @@ Weblate also allows you to log-in with major SSO providers like Github, Gitlab, 
 
 Every team member is available through GitHub or through the Matrix room (bridged to IRC), however, if you need/have to, you can contact the team directly via e-mail (remove `+SPAMGUARD` from the addresses):
 
-- General Inquiries (forwarded to every team member): `contact +SPAMGUARD [at] invidious [dot] io`
+- General Inquiries (forwarded to all team members): `contact +SPAMGUARD [at] invidious [dot] io`
 
 Note: before sending a bug report please check that it hasn't already be reported on GitHub - bug reports sent to this address will be copied to GitHub
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@
   <a rel="me" href="https://social.tchncs.de/@invidious">
   <img alt="Mastodon: @invidious@social.tchncs.de" src="https://img.shields.io/badge/Mastodon-%40invidious%40social.tchncs.de-darkgreen">
   </a>
+  
+  <h5>E-mail us:</h5>
+  <ul>
+  <li>General Inquiries (forwarded to every team member): <code>contact [at] invidious [dot] io</code> (Note: before sending a bug reports please check that it hasn't already be reported on GitHub - bug reports sent to this address will be copied to GitHub)</li>
+  <li>Security issues (forwarded to the two project owners, <a href="https://github.com/TheFrenchGhosty">@TheFrenchGhosty</a> and <a href="https://github.com/Perflyst">@Perflyst</a>): <code>security [at] invidious [dot] io</code></li>
+  </ul>
+    
 </div>
 
 


### PR DESCRIPTION
This will ideally be moved to the website at a later date.

Rendered version: https://github.com/iv-org/invidious/blob/TheFrenchGhosty-email/README.md#e-mail-us

(I know it doesn't look great but it should be temporary-ish)