### PR TITLE
Improve atom feeds

### DIFF
--- a/src/invidious/channels/channels.cr
+++ b/src/invidious/channels/channels.cr
@@ -54,9 +54,7 @@ struct ChannelVideo
     query_params["v"] = self.id
 
     xml.element("entry") do
-      xml.element("id") { xml.text "yt:video:#{self.id}" }
-      xml.element("yt:videoId") { xml.text self.id }
-      xml.element("yt:channelId") { xml.text self.ucid }
+      xml.element("id") { xml.text "ni://invidious/sha-256;" + sha256("video/#{self.id}") }
       xml.element("title") { xml.text self.title }
       xml.element("link", rel: "alternate", href: "#{HOST_URL}/watch?#{query_params}")
 

--- a/src/invidious/channels/channels.cr
+++ b/src/invidious/channels/channels.cr
@@ -50,9 +50,7 @@ struct ChannelVideo
     end
   end
 
-  def to_xml(locale, query_params, xml : XML::Builder)
-    query_params["v"] = self.id
-
+  def to_xml(xml : XML::Builder, query_params : HTTP::Params)
     xml.element("entry") do
       xml.element("id") { xml.text "ni://invidious/sha-256;" + sha256("video/#{self.id}") }
       xml.element("title") { xml.text self.title }
@@ -65,7 +63,7 @@ struct ChannelVideo
 
       xml.element("content", type: "xhtml") do
         xml.element("div", xmlns: "http://www.w3.org/1999/xhtml") do
-          xml.element("a", href: "#{HOST_URL}/watch?#{query_params}") do
+          xml.element("a", href: "#{HOST_URL}/watch?v=#{self.id}&#{query_params}") do
             xml.element("img", src: "#{HOST_URL}/vi/#{self.id}/mqdefault.jpg")
           end
         end
@@ -79,12 +77,6 @@ struct ChannelVideo
         xml.element("media:thumbnail", url: "#{HOST_URL}/vi/#{self.id}/mqdefault.jpg",
           width: "320", height: "180")
       end
-    end
-  end
-
-  def to_xml(locale, _xml : Nil = nil)
-    XML.build do |xml|
-      to_xml(locale, xml)
     end
   end
 

--- a/src/invidious/channels/channels.cr
+++ b/src/invidious/channels/channels.cr
@@ -50,36 +50,6 @@ struct ChannelVideo
     end
   end
 
-  def to_xml(xml : XML::Builder, query_params : HTTP::Params)
-    xml.element("entry") do
-      xml.element("id") { xml.text "ni://invidious/sha-256;" + sha256("video/#{self.id}") }
-      xml.element("title") { xml.text self.title }
-      xml.element("link", rel: "alternate", href: "#{HOST_URL}/watch?#{query_params}")
-
-      xml.element("author") do
-        xml.element("name") { xml.text self.author }
-        xml.element("uri") { xml.text "#{HOST_URL}/channel/#{self.ucid}" }
-      end
-
-      xml.element("content", type: "xhtml") do
-        xml.element("div", xmlns: "http://www.w3.org/1999/xhtml") do
-          xml.element("a", href: "#{HOST_URL}/watch?v=#{self.id}&#{query_params}") do
-            xml.element("img", src: "#{HOST_URL}/vi/#{self.id}/mqdefault.jpg")
-          end
-        end
-      end
-
-      xml.element("published") { xml.text self.published.to_s("%Y-%m-%dT%H:%M:%S%:z") }
-      xml.element("updated") { xml.text self.updated.to_s("%Y-%m-%dT%H:%M:%S%:z") }
-
-      xml.element("media:group") do
-        xml.element("media:title") { xml.text self.title }
-        xml.element("media:thumbnail", url: "#{HOST_URL}/vi/#{self.id}/mqdefault.jpg",
-          width: "320", height: "180")
-      end
-    end
-  end
-
   def to_tuple
     {% begin %}
       {

--- a/src/invidious/helpers/serialized_yt_data.cr
+++ b/src/invidious/helpers/serialized_yt_data.cr
@@ -14,44 +14,6 @@ struct SearchVideo
   property premiere_timestamp : Time?
   property author_verified : Bool
 
-  def to_xml(xml : XML::Builder, query_params : HTTP::Params)
-    xml.element("entry") do
-      xml.element("id") { xml.text "ni://invidious/sha-256;" + sha256("video/#{self.id}") }
-      xml.element("title") { xml.text self.title }
-      xml.element("link", rel: "alternate", href: "#{HOST_URL}/watch?#{query_params}")
-
-      xml.element("author") do
-        xml.element("name") { xml.text self.author }
-        xml.element("uri") { xml.text "#{HOST_URL}/channel/#{self.ucid}" }
-      end
-
-      xml.element("content", type: "xhtml") do
-        xml.element("div", xmlns: "http://www.w3.org/1999/xhtml") do
-          xml.element("a", href: "#{HOST_URL}/watch?v=#{self.id}&#{query_params}") do
-            xml.element("img", src: "#{HOST_URL}/vi/#{self.id}/mqdefault.jpg")
-          end
-
-          xml.element("p", style: "white-space:pre-wrap") do
-            xml.text html_to_content(self.description_html)
-          end
-        end
-      end
-
-      xml.element("published") { xml.text self.published.to_s("%Y-%m-%dT%H:%M:%S%:z") }
-
-      xml.element("media:group") do
-        xml.element("media:title") { xml.text self.title }
-        xml.element("media:thumbnail", url: "#{HOST_URL}/vi/#{self.id}/mqdefault.jpg",
-          width: "320", height: "180")
-        xml.element("media:description") { xml.text html_to_content(self.description_html) }
-      end
-
-      xml.element("media:community") do
-        xml.element("media:statistics", views: self.views)
-      end
-    end
-  end
-
   def to_json(locale : String?, json : JSON::Builder)
     json.object do
       json.field "type", "video"

--- a/src/invidious/helpers/serialized_yt_data.cr
+++ b/src/invidious/helpers/serialized_yt_data.cr
@@ -18,7 +18,7 @@ struct SearchVideo
     query_params["v"] = self.id
 
     xml.element("entry") do
-      xml.element("id") { xml.text self.id }
+      xml.element("id") { xml.text "ni://invidious/sha-256;" + sha256("video/#{self.id}") }
       xml.element("title") { xml.text self.title }
       xml.element("link", rel: "alternate", href: "#{HOST_URL}/watch?#{query_params}")
 

--- a/src/invidious/helpers/serialized_yt_data.cr
+++ b/src/invidious/helpers/serialized_yt_data.cr
@@ -14,9 +14,7 @@ struct SearchVideo
   property premiere_timestamp : Time?
   property author_verified : Bool
 
-  def to_xml(auto_generated, query_params, xml : XML::Builder)
-    query_params["v"] = self.id
-
+  def to_xml(xml : XML::Builder, query_params : HTTP::Params)
     xml.element("entry") do
       xml.element("id") { xml.text "ni://invidious/sha-256;" + sha256("video/#{self.id}") }
       xml.element("title") { xml.text self.title }
@@ -29,7 +27,7 @@ struct SearchVideo
 
       xml.element("content", type: "xhtml") do
         xml.element("div", xmlns: "http://www.w3.org/1999/xhtml") do
-          xml.element("a", href: "#{HOST_URL}/watch?#{query_params}") do
+          xml.element("a", href: "#{HOST_URL}/watch?v=#{self.id}&#{query_params}") do
             xml.element("img", src: "#{HOST_URL}/vi/#{self.id}/mqdefault.jpg")
           end
 
@@ -51,12 +49,6 @@ struct SearchVideo
       xml.element("media:community") do
         xml.element("media:statistics", views: self.views)
       end
-    end
-  end
-
-  def to_xml(auto_generated, query_params, _xml : Nil)
-    XML.build do |xml|
-      to_xml(auto_generated, query_params, xml)
     end
   end
 

--- a/src/invidious/helpers/serialized_yt_data.cr
+++ b/src/invidious/helpers/serialized_yt_data.cr
@@ -18,20 +18,13 @@ struct SearchVideo
     query_params["v"] = self.id
 
     xml.element("entry") do
-      xml.element("id") { xml.text "yt:video:#{self.id}" }
-      xml.element("yt:videoId") { xml.text self.id }
-      xml.element("yt:channelId") { xml.text self.ucid }
+      xml.element("id") { xml.text self.id }
       xml.element("title") { xml.text self.title }
       xml.element("link", rel: "alternate", href: "#{HOST_URL}/watch?#{query_params}")
 
       xml.element("author") do
-        if auto_generated
-          xml.element("name") { xml.text self.author }
-          xml.element("uri") { xml.text "#{HOST_URL}/channel/#{self.ucid}" }
-        else
-          xml.element("name") { xml.text author }
-          xml.element("uri") { xml.text "#{HOST_URL}/channel/#{ucid}" }
-        end
+        xml.element("name") { xml.text self.author }
+        xml.element("uri") { xml.text "#{HOST_URL}/channel/#{self.ucid}" }
       end
 
       xml.element("content", type: "xhtml") do
@@ -40,7 +33,9 @@ struct SearchVideo
             xml.element("img", src: "#{HOST_URL}/vi/#{self.id}/mqdefault.jpg")
           end
 
-          xml.element("p", style: "word-break:break-word;white-space:pre-wrap") { xml.text html_to_content(self.description_html) }
+          xml.element("p", style: "white-space:pre-wrap") do
+            xml.text html_to_content(self.description_html)
+          end
         end
       end
 

--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -13,9 +13,7 @@ struct PlaylistVideo
 
   def to_xml(xml : XML::Builder)
     xml.element("entry") do
-      xml.element("id") { xml.text "yt:video:#{self.id}" }
-      xml.element("yt:videoId") { xml.text self.id }
-      xml.element("yt:channelId") { xml.text self.ucid }
+      xml.element("id") { xml.text "ni://invidious/sha-256;" + sha256("video/#{self.id}") }
       xml.element("title") { xml.text self.title }
       xml.element("link", rel: "alternate", href: "#{HOST_URL}/watch?v=#{self.id}")
 

--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -11,35 +11,6 @@ struct PlaylistVideo
   property index : Int64
   property live_now : Bool
 
-  def to_xml(xml : XML::Builder, query_params : HTTP::Params)
-    xml.element("entry") do
-      xml.element("id") { xml.text "ni://invidious/sha-256;" + sha256("video/#{self.id}") }
-      xml.element("title") { xml.text self.title }
-      xml.element("link", rel: "alternate", href: "#{HOST_URL}/watch?v=#{self.id}")
-
-      xml.element("author") do
-        xml.element("name") { xml.text self.author }
-        xml.element("uri") { xml.text "#{HOST_URL}/channel/#{self.ucid}" }
-      end
-
-      xml.element("content", type: "xhtml") do
-        xml.element("div", xmlns: "http://www.w3.org/1999/xhtml") do
-          xml.element("a", href: "#{HOST_URL}/watch?v=#{self.id}&#{query_params}") do
-            xml.element("img", src: "#{HOST_URL}/vi/#{self.id}/mqdefault.jpg")
-          end
-        end
-      end
-
-      xml.element("published") { xml.text self.published.to_s("%Y-%m-%dT%H:%M:%S%:z") }
-
-      xml.element("media:group") do
-        xml.element("media:title") { xml.text self.title }
-        xml.element("media:thumbnail", url: "#{HOST_URL}/vi/#{self.id}/mqdefault.jpg",
-          width: "320", height: "180")
-      end
-    end
-  end
-
   def to_json(json : JSON::Builder, index : Int32? = nil)
     json.object do
       json.field "title", self.title

--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -11,7 +11,7 @@ struct PlaylistVideo
   property index : Int64
   property live_now : Bool
 
-  def to_xml(xml : XML::Builder)
+  def to_xml(xml : XML::Builder, query_params : HTTP::Params)
     xml.element("entry") do
       xml.element("id") { xml.text "ni://invidious/sha-256;" + sha256("video/#{self.id}") }
       xml.element("title") { xml.text self.title }
@@ -24,7 +24,7 @@ struct PlaylistVideo
 
       xml.element("content", type: "xhtml") do
         xml.element("div", xmlns: "http://www.w3.org/1999/xhtml") do
-          xml.element("a", href: "#{HOST_URL}/watch?v=#{self.id}") do
+          xml.element("a", href: "#{HOST_URL}/watch?v=#{self.id}&#{query_params}") do
             xml.element("img", src: "#{HOST_URL}/vi/#{self.id}/mqdefault.jpg")
           end
         end
@@ -38,10 +38,6 @@ struct PlaylistVideo
           width: "320", height: "180")
       end
     end
-  end
-
-  def to_xml(_xml : Nil = nil)
-    XML.build { |xml| to_xml(xml) }
   end
 
   def to_json(json : JSON::Builder, index : Int32? = nil)

--- a/src/invidious/rss_atom.cr
+++ b/src/invidious/rss_atom.cr
@@ -59,9 +59,6 @@ module Invidious::RssAtom
     id : String,
     properties : AtomProperties
   )
-    locale = env.get("preferences").as(Preferences).locale
-    params = HTTP::Params.parse(env.params.query["params"]? || "")
-
     return XML.build(indent: "  ", encoding: "UTF-8") do |xml|
       xml.element("feed",
         xmlns: "http://www.w3.org/2005/Atom",
@@ -111,7 +108,7 @@ module Invidious::RssAtom
 
         # Video entries
         videos.each do |video|
-          xml.element("entry") { atom_video(xml, video, params) }
+          xml.element("entry") { atom_video(xml, video, env.params.query) }
         end
       end
     end
@@ -122,7 +119,7 @@ module Invidious::RssAtom
     video_url = "#{HOST_URL}/watch?v=#{video.id}&#{query_params}"
     video_thumb = "#{HOST_URL}/vi/#{video.id}/mqdefault.jpg"
 
-    description = video.is_a?(SearchVideo) ? video.description_html : ""
+    description = video.is_a?(SearchVideo) ? video.description_html.gsub('\n', "<br/>\n") : ""
 
     xml.element("id") { xml.text "ni://invidious/sha-256;" + sha256("video/#{video.id}") }
     xml.element("title") { xml.text video.title }

--- a/src/invidious/rss_atom.cr
+++ b/src/invidious/rss_atom.cr
@@ -110,14 +110,7 @@ module Invidious::RssAtom
         end
 
         # Video entries
-        # TODO: Unify `.to_xml` methods
-        videos.each do |video|
-          case video
-          when .is_a?(PlaylistVideo) then video.to_xml(xml)
-          when .is_a?(ChannelVideo)  then video.to_xml(locale, params, xml)
-          when .is_a?(SearchVideo)   then video.to_xml(false, params, xml)
-          end
-        end
+        videos.each { |video| video.to_xml(xml, params) }
       end
     end
   end

--- a/src/invidious/rss_atom.cr
+++ b/src/invidious/rss_atom.cr
@@ -1,0 +1,124 @@
+require "xml"
+require "http/server"
+
+module Invidious::RssAtom
+  extend self
+
+  # TODO: Merge all of those in a single type
+  alias AnyVideo = SearchVideo | ChannelVideo | PlaylistVideo
+
+  #
+  # Feed properties structure
+  #
+
+  alias AltLink = NamedTuple(type: String, url: String)
+
+  struct AtomProperties
+    getter title : String
+    getter icon_url : String
+    getter author : String
+    getter author_url : String
+
+    getter date_published : String
+    getter date_updated : String
+
+    getter alt_links : Array(AltLink)
+
+    def initialize(
+      *, # All parameters must be named
+      @title = "", @icon_url = "",
+      @author = "", @author_url = "",
+      date_updated : Time | String = Time.utc,
+      date_published : Time | String = "",
+      @alt_links = [] of AltLink
+    )
+      # Convert publication date if needed
+      if date_published.is_a?(Time)
+        @date_published = date_published.to_rfc3339
+      else
+        @date_published = date_published
+      end
+
+      # Convert update date if needed
+      if date_updated.is_a?(Time)
+        @date_updated = date_updated.to_rfc3339
+      else
+        @date_updated = date_updated
+      end
+    end
+  end
+
+  #
+  # Atom Feed builder
+  #
+
+  def atom_feed_builder(
+    # Mandatory parameters
+    env : HTTP::Server::Context,
+    videos : Array(AnyVideo),
+    id : String,
+    properties : AtomProperties
+  )
+    locale = env.get("preferences").as(Preferences).locale
+    params = HTTP::Params.parse(env.params.query["params"]? || "")
+
+    return XML.build(indent: "  ", encoding: "UTF-8") do |xml|
+      xml.element("feed",
+        xmlns: "http://www.w3.org/2005/Atom",
+        "xmlns:media": "http://search.yahoo.com/mrss/",
+        "xml:lang": "en-US"
+      ) do
+        # The id must be unique, and an IANA-approved IRI, so use "ni://"
+        # Relevant RFC documents:
+        #  - https://datatracker.ietf.org/doc/html/rfc4287#section-4.2.6
+        #  - https://datatracker.ietf.org/doc/html/rfc6920
+        #
+        xml.element("id") { xml.text "ni://invidious/sha-256;" + sha256(id) }
+
+        # Feed title. Use author name if no title was provided
+        xml.element("title") do
+          xml.text(properties.title.empty? ? properties.author : properties.title)
+        end
+
+        if !properties.icon_url.empty?
+          icon_url = "#{HOST_URL}/gghpt/#{URI.parse(properties.icon_url).request_target}"
+          xml.element("icon") { xml.text icon_url }
+          xml.element("logo") { xml.text icon_url }
+        end
+
+        # Feed creation (if available) and update (mandatory) dates
+        if !properties.date_published.empty?
+          xml.element("published") { xml.text properties.date_published }
+        end
+
+        xml.element("updated") { xml.text properties.date_updated }
+
+        # Links
+        xml.element("link", rel: "self",
+          type: "application/atom+xml",
+          href: "#{HOST_URL}#{env.request.resource}"
+        )
+
+        properties.alt_links.each do |link|
+          xml.element("link", rel: "alternate", type: link[:type], href: link[:url])
+        end
+
+        # Author infos
+        xml.element("author") do
+          xml.element("name") { xml.text properties.author }
+          xml.element("uri") { xml.text properties.author_url } if !properties.author_url.empty?
+        end
+
+        # Video entries
+        # TODO: Unify `.to_xml` methods
+        videos.each do |video|
+          case video
+          when .is_a?(PlaylistVideo) then video.to_xml(xml)
+          when .is_a?(ChannelVideo)  then video.to_xml(locale, params, xml)
+          when .is_a?(SearchVideo)   then video.to_xml(false, params, xml)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Make the following changes to Atom feeds:
- Remove non-standard `<yt:videoId>` and `<yt:channelId>` elements
- Make entry IDs RFC compliant (must be an URI) => This should also prevent some web-based RSS readers from embedding the youtube player
- Base all URLs (icons, links, etc) on `HOST_URL`
- Fix the different problems reported by W3C validator

Notes:
- RSS feeds are TODO
- Player can't be embedded without breaking RFC compliance (See why in issues listed below)

Fixes #1064
Fixes #2248
Fixes #2249