### PR TITLE
Fix loading reddit comments when there are no threads found

### DIFF
--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -276,7 +276,7 @@ def fetch_reddit_comments(id, sort_by = "confidence")
 
     # For videos that have more than one thread, choose the one with the highest score
     threads = search_results.data.as(RedditListing).children
-    thread = threads.max_by? { |child| child.data.as(RedditLink).score }.try(&.data.as(RedditLink))
+    thread = threads.max_by?(&.data.as(RedditLink).score).try(&.data.as(RedditLink))
     result = thread.try do |t|
       body = client.get("/r/#{t.subreddit}/comments/#{t.id}.json?limit=100&sort=#{sort_by}", headers).body
       Array(RedditThing).from_json(body)

--- a/src/invidious/routes/api/v1/videos.cr
+++ b/src/invidious/routes/api/v1/videos.cr
@@ -330,18 +330,13 @@ module Invidious::Routes::API::V1::Videos
 
       begin
         comments, reddit_thread = fetch_reddit_comments(id, sort_by: sort_by)
-        content_html = template_reddit_comments(comments, locale)
-
-        content_html = fill_links(content_html, "https", "www.reddit.com")
-        content_html = replace_links(content_html)
       rescue ex
         comments = nil
         reddit_thread = nil
-        content_html = ""
       end
 
       if !reddit_thread || !comments
-        haltf env, 404
+        return error_json(404, "No reddit threads found")
       end
 
       if format == "json"
@@ -350,6 +345,9 @@ module Invidious::Routes::API::V1::Videos
 
         return reddit_thread.to_json
       else
+        content_html = template_reddit_comments(comments, locale)
+        content_html = fill_links(content_html, "https", "www.reddit.com")
+        content_html = replace_links(content_html)
         response = {
           "title"       => reddit_thread.title,
           "permalink"   => reddit_thread.permalink,


### PR DESCRIPTION
Fixes #2735

I'm not sure how the original issue saw the error page. I guess changes have happened since then because I only ever saw an error in the json that looked like `{"error":"Closed stream"}`. That was connected somehow to the use of `haltf` and replacing that I saw a simple error message along the lines of ` {"error":"Index out of bounds"}`.

The issue was when we didn't find any reddit threads for the video. I refactored a bit to clarify some of the code (like the query params).

One thing to point out is that when the "View Reddit comments" link is clicked, it still goes back to showing the youtube comments if none are found like it did before. The only change from the perspective of the client is in the http response code.

**Example with Reddit comments (no change)**: http://0.0.0.0:3000/api/v1/comments/9ItlOFLTUAs?source=reddit
**Example without Reddit comments**: http://0.0.0.0:3000/api/v1/comments/Mp9Qx6KMSO0?source=reddit