### PR TITLE
Refresh channels cleanup

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -132,7 +132,7 @@ end
 # Start jobs
 
 if CONFIG.channel_threads > 0
-  Invidious::Jobs.register Invidious::Jobs::RefreshChannelsJob.new(PG_DB)
+  Invidious::Jobs.register Invidious::Jobs::RefreshChannelsJob.new
 end
 
 if CONFIG.feed_threads > 0

--- a/src/invidious/database/channels.cr
+++ b/src/invidious/database/channels.cr
@@ -76,6 +76,14 @@ module Invidious::Database::Channels
 
     return PG_DB.query_all(request, as: InvidiousChannel)
   end
+
+  def select_all : Array(InvidiousChannel)
+    request = <<-SQL
+      SELECT * FROM channels
+    SQL
+
+    return PG_DB.query_all(rqeuest, as: InvidiousChannel)
+  end
 end
 
 #

--- a/src/invidious/database/channels.cr
+++ b/src/invidious/database/channels.cr
@@ -82,7 +82,7 @@ module Invidious::Database::Channels
       SELECT * FROM channels
     SQL
 
-    return PG_DB.query_all(rqeuest, as: InvidiousChannel)
+    return PG_DB.query_all(request, as: InvidiousChannel)
   end
 end
 

--- a/src/invidious/jobs/refresh_channels_job.cr
+++ b/src/invidious/jobs/refresh_channels_job.cr
@@ -9,7 +9,6 @@ class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
     loop do
       LOGGER.debug("RefreshChannelsJob: Refreshing all channels")
       Invidious::Database::Channels.select_all.each do |channel|
-        id = channel.id
         if active_fibers >= lim_fibers
           LOGGER.trace("RefreshChannelsJob: Fiber limit reached, waiting...")
           if active_channel.receive
@@ -18,35 +17,24 @@ class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
           end
         end
 
-        LOGGER.debug("RefreshChannelsJob: #{id} : Spawning fiber")
+        LOGGER.debug("RefreshChannelsJob: #{channel.id} : Spawning fiber")
         active_fibers += 1
         spawn do
-          begin
-            LOGGER.trace("RefreshChannelsJob: #{id} fiber : Fetching channel")
-            channel = fetch_channel(id, CONFIG.full_refresh)
-
+          if refresh_channel(channel)
             lim_fibers = max_fibers
-
-            LOGGER.trace("RefreshChannelsJob: #{id} fiber : Updating DB")
-            Invidious::Database::Channels.update_author(id, channel.author)
-          rescue ex
-            LOGGER.error("RefreshChannelsJob: #{id} : #{ex.message}")
-            if ex.message == "Deleted or invalid channel"
-              Invidious::Database::Channels.update_mark_deleted(id)
+          else
+            lim_fibers = 1
+            LOGGER.error("RefreshChannelsJob: #{channel.id} fiber : backing off for #{backoff}s")
+            sleep backoff
+            if backoff < 1.days
+              backoff += backoff
             else
-              lim_fibers = 1
-              LOGGER.error("RefreshChannelsJob: #{id} fiber : backing off for #{backoff}s")
-              sleep backoff
-              if backoff < 1.days
-                backoff += backoff
-              else
-                backoff = 1.days
-              end
+              backoff = 1.days
             end
-          ensure
-            LOGGER.debug("RefreshChannelsJob: #{id} fiber : Done")
-            active_channel.send(true)
           end
+
+          LOGGER.debug("RefreshChannelsJob: #{channel.id} fiber : Done")
+          active_channel.send(true)
         end
       end
 
@@ -54,6 +42,25 @@ class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
       LOGGER.debug("RefreshChannelsJob: Done, sleeping for thirty minutes")
       sleep 30.minutes
       Fiber.yield
+    end
+  end
+
+  private def refresh_channel(channel : InvidiousChannel) : Bool
+    id = channel.id
+
+    LOGGER.trace("RefreshChannelsJob: #{id} fiber : Fetching channel")
+    channel = fetch_channel(id, CONFIG.full_refresh)
+
+    LOGGER.trace("RefreshChannelsJob: #{id} fiber : Updating DB")
+    Invidious::Database::Channels.update_author(id, channel.author)
+    return true
+  rescue ex
+    LOGGER.error("RefreshChannelsJob: #{id} : #{ex.message}")
+    if ex.message == "Deleted or invalid channel"
+      Invidious::Database::Channels.update_mark_deleted(id) if id
+      return true
+    else
+      return false
     end
   end
 end

--- a/src/invidious/jobs/refresh_channels_job.cr
+++ b/src/invidious/jobs/refresh_channels_job.cr
@@ -1,9 +1,4 @@
 class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
-  private getter db : DB::Database
-
-  def initialize(@db)
-  end
-
   def begin
     max_fibers = CONFIG.channel_threads
     lim_fibers = max_fibers


### PR DESCRIPTION
Separated out the job's purpose from implementation code. The only difference in the implementation is that now, the `lim_fibers` is set back to `max_fibers` if an error occurs but it was because the channel no longer exists. Before it would not update `lim_fibers` so it would be the same as it was before.

I think there are some potential issues with this job implementation (and it probably carries over to others) but I didn't attempt to make any changes to that.

- _EVERY_ channel is updated every time the job is run instead of just channels that we would identify as needing update
- The backoff is never reset for the life of the job so if this job fails the second day invidious runs and moves the backoff to 1 day, two years later it will still wait a full day if a request fails if the app hasn't been restarted
- The backoff applies to individual channel fibers which means that if there's a youtube problem, we tie up all of the max channel threads in sleeping rather than the main fiber for the job
- That's a LOT of implementation code! Is there an abstraction we can extract?
- We mark channels as deleted, but SELECT sql query does not account for it so we try to refetch deleted channels over and over
- Since we fetch the originally stored author, we could only update the author if it's changed