### PR TITLE
Ignore "/" key handling if search box is focused

### DIFF
--- a/assets/js/handlers.js
+++ b/assets/js/handlers.js
@@ -146,7 +146,17 @@
     // Handle keypresses
     window.addEventListener('keydown', (event) => {
         // Ignore modifier keys
-        if (event.ctrlKey || event.metaKey) { return; }
+        if (event.ctrlKey || event.metaKey) return;
+
+        // Ignore shortcuts if any text input is focused
+        let focused_tag = document.activeElement.tagName.toLowerCase();
+        let focused_type = document.activeElement.type.toLowerCase();
+        let allowed = /^(button|checkbox|file|radio|submit)$/;
+
+        if (focused_tag === "textarea" ||
+           (focused_tag === "input" && !focused_type.match(allowed))
+        )
+            return;
 
         // Focus search bar on '/'
         if (event.key == "/") {


### PR DESCRIPTION
Fixes a side effect of https://github.com/iv-org/invidious/pull/2814
See: https://github.com/iv-org/invidious/issues/2791#issuecomment-1018264144