### PR TITLE
Related channel may contain a continuation entry

### DIFF
--- a/src/invidious/routes/api/v1/channels.cr
+++ b/src/invidious/routes/api/v1/channels.cr
@@ -97,7 +97,11 @@ module Invidious::Routes::API::V1::Channels
         json.field "relatedChannels" do
           json.array do
             # Fetch related channels
-            related_channels = fetch_related_channels(channel)
+            begin
+              related_channels = fetch_related_channels(channel)
+            rescue ex
+              related_channels = [] of AboutRelatedChannel
+            end
 
             related_channels.each do |related_channel|
               json.object do

--- a/src/invidious/routes/api/v1/channels.cr
+++ b/src/invidious/routes/api/v1/channels.cr
@@ -96,7 +96,10 @@ module Invidious::Routes::API::V1::Channels
 
         json.field "relatedChannels" do
           json.array do
-            fetch_related_channels(channel).each do |related_channel|
+            # Fetch related channels
+            related_channels = fetch_related_channels(channel)
+
+            related_channels.each do |related_channel|
               json.object do
                 json.field "author", related_channel.author
                 json.field "authorId", related_channel.ucid
@@ -118,7 +121,8 @@ module Invidious::Routes::API::V1::Channels
               end
             end
           end
-        end
+        end # relatedChannels
+
       end
     end
   end


### PR DESCRIPTION
Closes #2867

The list of related channels can contain a `continuationItemRenderer`.

Other notes from that patch: only 12 channels are provided at a time (that's not a lot), and the continuation token yet again depends on the last entry from the list

```json
{
  "80226972:0:embedded": {
    "2:0:string": "UCPygLEFniGZmehxouDK-vbw",
    "3:1:base64": {
      // This part can be sent alone in a browse request
      "2:string": "channels",
      "3:varint": 3,
      "4:varint": 0,
      "6:varint": 1,
      "7:varint": 1,
      "61:base64": {
        "1:string": "",
        "2:embedded": {
          "3:string": "UCAu_kUWh9SfMcW5_veIGH4A"
        }
      }
      // end
    },
    "35:2:string": "browse-feedUCPygLEFniGZmehxouDK-vbwchannels139"
  }
}
```