### PR TITLE
Use a regex to fix badly aligned captions

### DIFF
--- a/src/invidious/routes/api/v1/videos.cr
+++ b/src/invidious/routes/api/v1/videos.cr
@@ -130,7 +130,13 @@ module Invidious::Routes::API::V1::Videos
         end
       end
     else
+      # Some captions have "align:[start/end]" and "position:[num]%"
+      # attributes. Those are causing issues with VideoJS, which is unable
+      # to properly align the captions on the video, so we remove them.
+      #
+      # See: https://github.com/iv-org/invidious/issues/2391
       webvtt = YT_POOL.client &.get("#{url}&format=vtt").body
+        .gsub(/([0-9:.]+ --> [0-9:.]+).+/, "\\1")
     end
 
     if title = env.params.query["title"]?


### PR DESCRIPTION
Workaround for #2391

I'm not sure why *some* captions have alignment/offset values (subtitle form the video in linked issue):
```
WEBVTT
Kind: captions
Language: en
Style:
::cue(c.colorA0AAB4) { color: rgb(160,170,180);
 }
::cue(c.colorFEFEFE) { color: rgb(254,254,254);
 }
##

00:00:01.852 --> 00:00:06.991 position:97%
<c.colorA0AAB4>​​</c><c.colorFEFEFE><i>​ ​Hello everyone! Thank you for coming to my concert today! \ (•◡•) /​ ​</i></c><c.colorA0AAB4>​</c>

00:00:01.852 --> 00:00:06.991 position:97%
<c.colorA0AAB4>​​</c><c.colorFEFEFE><i>​ ​Hello everyone! Thank you for coming to my concert today! \ (•◡•) /​ ​</i></c><c.colorA0AAB4>​</c>

00:00:06.991 --> 00:00:11.562 position:98%
<c.colorA0AAB4>​​</c><c.colorFEFEFE><i>​ ​Regardless of whether it’s your first time or not, nice to meet you!​ ​</i></c><c.colorA0AAB4>​</c>

00:00:06.991 --> 00:00:11.562 position:98%
<c.colorA0AAB4>​​</c><c.colorFEFEFE><i>​ ​Regardless of whether it’s your first time or not, nice to meet you!​ ​</i></c><c.colorA0AAB4>​</c>

00:00:11.562 --> 00:00:16.166 position:97%
<c.colorA0AAB4>​​</c><c.colorFEFEFE><i>​ ​I can’t remember everyone’s faces, but please take it easy and remember me!​ ​</i></c><c.colorA0AAB4>​</c>

00:00:11.562 --> 00:00:16.166 position:97%
<c.colorA0AAB4>​​</c><c.colorFEFEFE><i>​ ​I can’t remember everyone’s faces, but please take it easy and remember me!​ ​</i></c><c.colorA0AAB4>​</c>

00:00:16.166 --> 00:00:18.302
<c.colorA0AAB4>​​</c><c.colorFEFEFE><i>​ ​Let’s go!​ ​</i></c><c.colorA0AAB4>​</c>

00:00:16.166 --> 00:00:18.302
<c.colorA0AAB4>​​</c><c.colorFEFEFE><i>​ ​Let’s go!​ ​</i></c><c.colorA0AAB4>​</c>
```