### PR TITLE
Expose version by default on api/v1/stats

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,6 @@ services:
           dbname: invidious
         full_refresh: false
         https_only: false
-        statistics_enabled: false
         domain:
     healthcheck:
       test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
           dbname: invidious
         full_refresh: false
         https_only: false
+        statistics_enabled: false
         domain:
     healthcheck:
       test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1

--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -4,10 +4,10 @@ module Invidious::Routes::API::V1::Misc
     env.response.content_type = "application/json"
 
     if !CONFIG.statistics_enabled
-      return error_json(400, "Statistics are not enabled.")
+      return {"software" => SOFTWARE}.to_json
+    else
+      return Invidious::Jobs::StatisticsRefreshJob::STATISTICS.to_json
     end
-
-    Invidious::Jobs::StatisticsRefreshJob::STATISTICS.to_json
   end
 
   # APIv1 currently uses the same logic for both


### PR DESCRIPTION
Close #1690

The purpose of this PR is to display version information within the `/api/v1/stats` route even when statistics are disabled.

(Note : I don't want to be awarded the bounty associated to the issue this PR is fixing.)