### PR TITLE
Enhance the development compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - invidious-db
 
   invidious-db:
-    image: docker.io/library/postgres:14-alpine
+    image: docker.io/library/postgres:14
     restart: unless-stopped
     volumes:
       - postgresdata:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - invidious-postgres
 
   invidious-postgres:
-    image: postgres:14
+    image: postgres:14-alpine
     restart: unless-stopped
     volumes:
       - postgresdata:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - invidious-db
 
   invidious-db:
-    image: postgres:14-alpine
+    image: docker.io/library/postgres:14-alpine
     restart: unless-stopped
     volumes:
       - postgresdata:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ version: "3"
 services:
 
   invidious:
-    container_name: invidious
     build:
       context: .
       dockerfile: docker/Dockerfile
@@ -36,7 +35,6 @@ services:
       - invidious-db
 
   invidious-db:
-    container_name: invidious-db
     image: postgres:14-alpine
     restart: unless-stopped
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,10 @@ services:
     ports:
       - "127.0.0.1:3000:3000"
     environment:
-      INVIDIOUS_CONFIG: |
       # Please read the following file for a comprehensive list of all available
       # configuration options and their associated syntax:
       # https://github.com/iv-org/invidious/blob/master/config/config.example.yml
+      INVIDIOUS_CONFIG: |
         check_tables: true
         db:
           dbname: invidious

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# This docker-compose file is made for development purpose and build an image from source, if you want to use Invidious in production, see the documentation.
+
 version: "3"
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,6 @@
-version: '3'
+version: "3"
 services:
-  postgres:
-    image: postgres:10
-    restart: unless-stopped
-    volumes:
-      - postgresdata:/var/lib/postgresql/data
-      - ./config/sql:/config/sql
-      - ./docker/init-invidious-db.sh:/docker-entrypoint-initdb.d/init-invidious-db.sh
-    environment:
-      POSTGRES_DB: invidious
-      POSTGRES_PASSWORD: kemal
-      POSTGRES_USER: kemal
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+
   invidious:
     build:
       context: .
@@ -21,27 +9,41 @@ services:
     ports:
       - "127.0.0.1:3000:3000"
     environment:
-      # Adapted from ./config/config.yml
       INVIDIOUS_CONFIG: |
-        channel_threads: 1
+      # Please read the following file for a comprehensive list of all available
+      # configuration options and their associated syntax:
+      # https://github.com/iv-org/invidious/blob/master/config/config.example.yml
         check_tables: true
-        feed_threads: 1
         db:
+          dbname: invidious
           user: kemal
           password: kemal
-          host: postgres
+          host: invidious-postgres
           port: 5432
-          dbname: invidious
-        full_refresh: false
-        https_only: false
-        domain:
+        # https_only: false
+        # domain:
+        # external_port:
     healthcheck:
       test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
       interval: 30s
       timeout: 5s
       retries: 2
     depends_on:
-      - postgres
+      - invidious-postgres
+
+  invidious-postgres:
+    image: postgres:14
+    restart: unless-stopped
+    volumes:
+      - postgresdata:/var/lib/postgresql/data
+      - ./config/sql:/config/sql
+      - ./docker/init-invidious-db.sh:/docker-entrypoint-initdb.d/init-invidious-db.sh
+    environment:
+      POSTGRES_DB: invidious
+      POSTGRES_USER: kemal
+      POSTGRES_PASSWORD: kemal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
 
 volumes:
   postgresdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,16 +15,17 @@ services:
       # configuration options and their associated syntax:
       # https://github.com/iv-org/invidious/blob/master/config/config.example.yml
       INVIDIOUS_CONFIG: |
-        check_tables: true
         db:
           dbname: invidious
           user: kemal
           password: kemal
           host: invidious-postgres
           port: 5432
-        # https_only: false
-        # domain:
+        check_tables: true
         # external_port:
+        # domain:
+        # https_only: false
+        # statistics_enabled: false
     healthcheck:
       test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,8 @@
-# This docker-compose file is made for development purpose and build an image from source, if you want to use Invidious in production, see the documentation.
+# Warning: This docker-compose file is made for development purposes.
+# Using it will build an image from the locally cloned repository.
+#
+# If you want to use Invidious in production, see the docker-compose.yml file provided
+# in the installation documentation: https://docs.invidious.io/Installation.md
 
 version: "3"
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ version: "3"
 services:
 
   invidious:
+    container_name: invidious
     build:
       context: .
       dockerfile: docker/Dockerfile
@@ -19,7 +20,7 @@ services:
           dbname: invidious
           user: kemal
           password: kemal
-          host: invidious-postgres
+          host: invidious-db
           port: 5432
         check_tables: true
         # external_port:
@@ -32,9 +33,10 @@ services:
       timeout: 5s
       retries: 2
     depends_on:
-      - invidious-postgres
+      - invidious-db
 
-  invidious-postgres:
+  invidious-db:
+    container_name: invidious-db
     image: postgres:14-alpine
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
Follow up to https://github.com/iv-org/documentation/pull/160#issuecomment-1039778281

Related to https://github.com/iv-org/documentation/pull/200 (wait for both to be ready - so that we can merge them at the same time)

Massively enhance the development compose:

- Make the production and development compose use the same (sane and clean) bases
- Change the restart policy for `unless-stopped` since `always` is bad practice
- Remove the network (that's completely useless)
- Remove the resources limiters (that's not really useful, and users should only use it if they need to)
- Remove the `willfarrell/autoheal` container: we can't vouch for it's usefulness, and its security (it has access to the docker socket, which is a massive security risk)
- Bump the postgres version to 14 since it's the latest and 10 [EOL in 8 months](https://www.postgresql.org/support/versioning/) ~~and move to an Alpine-based Postgres image~~
- Layout change (service then DB)
- ~~Enforce a container_name~~ **Edit:** https://github.com/iv-org/documentation/pull/200#discussion_r811676660