### PR TITLE
Bump kemal dependency to v1.1.1

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -18,7 +18,7 @@ dependencies:
     version: ~> 0.18.0
   kemal:
     github: kemalcr/kemal
-    version: ~> 1.1.0
+    version: ~> 1.1.1
   protodec:
     github: iv-org/protodec
     version: ~> 0.1.4


### PR DESCRIPTION
Solves breakon playback on crystal 1.3.*
See: https://github.com/kemalcr/kemal/pull/628
Closes: https://github.com/iv-org/invidious/issues/2783