### PR TITLE
Fix captions regex

### DIFF
--- a/src/invidious/routes/api/v1/videos.cr
+++ b/src/invidious/routes/api/v1/videos.cr
@@ -136,7 +136,7 @@ module Invidious::Routes::API::V1::Videos
       #
       # See: https://github.com/iv-org/invidious/issues/2391
       webvtt = YT_POOL.client &.get("#{url}&format=vtt").body
-        .gsub(/([0-9:.]+ --> [0-9:.]+).+/, "\\1")
+        .gsub(/([0-9:.]{12} --> [0-9:.]{12}).+/, "\\1")
     end
 
     if title = env.params.query["title"]?


### PR DESCRIPTION
This ensures that the regex doesn't match an already properly formatted line.

Previously, it removed the last digit as follows:
```
// valid line
00:00:00.000 --> 00:00:01.000

// same line after replace
00:00:00.000 --> 00:00:01.00
```

Closes #2909