### PR TITLE
Bump dependencies

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -42,7 +42,7 @@ shards:
 
   spectator:
     git: https://github.com/icy-arctic-fox/spectator.git
-    version: 0.10.4
+    version: 0.10.5
 
   sqlite3:
     git: https://github.com/crystal-lang/crystal-sqlite3.git

--- a/shard.lock
+++ b/shard.lock
@@ -1,5 +1,9 @@
 version: 2.0
 shards:
+  ameba:
+    git: https://github.com/crystal-ameba/ameba.git
+    version: 0.14.3
+
   athena-negotiation:
     git: https://github.com/athena-framework/negotiation.git
     version: 0.1.1
@@ -47,7 +51,3 @@ shards:
   sqlite3:
     git: https://github.com/crystal-lang/crystal-sqlite3.git
     version: 0.19.0
-
-  ameba:
-    git: https://github.com/crystal-ameba/ameba.git
-    version: 0.14.3

--- a/shard.lock
+++ b/shard.lock
@@ -10,7 +10,7 @@ shards:
 
   db:
     git: https://github.com/crystal-lang/crystal-db.git
-    version: 0.10.1
+    version: 0.11.0
 
   exception_page:
     git: https://github.com/crystal-loot/exception_page.git
@@ -30,7 +30,7 @@ shards:
 
   pg:
     git: https://github.com/will/crystal-pg.git
-    version: 0.24.0
+    version: 0.26.0
 
   protodec:
     git: https://github.com/iv-org/protodec.git
@@ -46,7 +46,7 @@ shards:
 
   sqlite3:
     git: https://github.com/crystal-lang/crystal-sqlite3.git
-    version: 0.18.0
+    version: 0.19.0
 
   ameba:
     git: https://github.com/crystal-ameba/ameba.git

--- a/shard.yml
+++ b/shard.yml
@@ -3,7 +3,7 @@ version: 0.20.1
 
 authors:
   - Omar Roth <omarroth@protonmail.com>
-  - Invidous team
+  - Invidious team
 
 targets:
   invidious:

--- a/shard.yml
+++ b/shard.yml
@@ -12,10 +12,10 @@ targets:
 dependencies:
   pg:
     github: will/crystal-pg
-    version: ~> 0.24.0
+    version: ~> 0.26.0
   sqlite3:
     github: crystal-lang/crystal-sqlite3
-    version: ~> 0.18.0
+    version: ~> 0.19.0
   kemal:
     github: kemalcr/kemal
     version: ~> 1.1.0

--- a/shard.yml
+++ b/shard.yml
@@ -32,7 +32,7 @@ dependencies:
 development_dependencies:
   spectator:
     github: icy-arctic-fox/spectator
-    version: ~> 0.10.4
+    version: ~> 0.10.5
   ameba:
     github: crystal-ameba/ameba
     version: ~> 0.14.3


### PR DESCRIPTION
* Update `sqlite3` from v0.18.0 to v0.19.0 ([changelog](https://github.com/crystal-lang/crystal-sqlite3/releases/tag/v0.19.0))
* Update `pg` from v0.24.0 to v0.26.0 ([[changelog](https://github.com/will/crystal-pg/blob/v0.26.0/CHANGELOG))
* Update `db` from v0.10.1 to v0.11.0 ([changelog](https://github.com/crystal-lang/crystal-db/releases/tag/v0.11.0), update required by `sqlite3` and `pg`)
* Update `spectator` from v0.10.4 to v0.10.5 ([changelog](https://gitlab.com/arctic-fox/spectator/-/blob/v0.10.5/CHANGELOG.md))