### PR TITLE
Add video_context buttons in suggested video on watch view

### DIFF
--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -320,7 +320,12 @@ we're going to need to do it here in order to allow for translations.
                                         <% end %>
                                     </div>
 
-                                    <div class="pure-u-10-24" style="text-align:right">
+                                    <div class="pure-u-4-24">
+                                        <% endpoint_params = "?v=#{rv["id"]}" %>
+                                        <%= rendered "components/video-context-buttons" %>
+                                    </div>
+
+                                    <div class="pure-u-6-24" style="text-align:right">
                                         <b class="width:100%"><%=
                                             views = rv["view_count"]?.try &.to_i?
                                             views ||= rv["view_count_short"]?.try { |x| short_text_to_number(x) }


### PR DESCRIPTION
Closes #1928

The purpose of this PR is to propose the addition of video playing options (like audio only) on the suggested videos within the route `/watch`