### PR TITLE
Add ability to disable notifications

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -66,6 +66,7 @@
     "preferences_listen_label": "Listen by default: ",
     "preferences_local_label": "Proxy videos: ",
     "preferences_watch_history_label": "Enable watch history: ",
+    "preferences_notifications_label": "Enable notifications: ",
     "preferences_speed_label": "Default speed: ",
     "preferences_quality_label": "Preferred video quality: ",
     "preferences_quality_option_dash": "DASH (adaptative quality)",

--- a/src/invidious/channels/channels.cr
+++ b/src/invidious/channels/channels.cr
@@ -226,7 +226,7 @@ def fetch_channel(ucid, pull_all_videos : Bool)
     # meaning the above timestamp is always null
     was_insert = Invidious::Database::ChannelVideos.insert(video)
 
-    if was_insert
+    if preferences.notifications && was_insert
       LOGGER.trace("fetch_channel: #{ucid} : video #{video_id} : Inserted, updating subscriptions")
       Invidious::Database::Users.add_notification(video)
     else
@@ -264,7 +264,9 @@ def fetch_channel(ucid, pull_all_videos : Bool)
         # so since they don't provide a published date here we can safely ignore them.
         if Time.utc - video.published > 1.minute
           was_insert = Invidious::Database::ChannelVideos.insert(video)
-          Invidious::Database::Users.add_notification(video) if was_insert
+          if preferences.notifications && was_insert
+            Invidious::Database::Users.add_notification(video)
+          end
         end
       end
 

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -24,6 +24,7 @@ struct ConfigPreferences
   property local : Bool = false
   property locale : String = "en-US"
   property watch_history : Bool = true
+  property notifications : Bool = true
   property max_results : Int32 = 40
   property notifications_only : Bool = false
   property player_style : String = "invidious"

--- a/src/invidious/routes/embed.cr
+++ b/src/invidious/routes/embed.cr
@@ -134,7 +134,9 @@ module Invidious::Routes::Embed
     # end
 
     if notifications && notifications.includes? id
-      Invidious::Database::Users.remove_notification(user.as(User), id)
+      if preferences.notifications
+        Invidious::Database::Users.remove_notification(user.as(User), id)
+      end
       env.get("user").as(User).notifications.delete(id)
       notifications.delete(id)
     end

--- a/src/invidious/routes/feeds.cr
+++ b/src/invidious/routes/feeds.cr
@@ -100,7 +100,9 @@ module Invidious::Routes::Feeds
     # we know a user has looked at their feed e.g. in the past 10 minutes,
     # they've already seen a video posted 20 minutes ago, and don't need
     # to be notified.
-    Invidious::Database::Users.clear_notifications(user)
+    if preferences.notifications
+      Invidious::Database::Users.clear_notifications(user)
+    end
     user.notifications = [] of String
     env.set "user", user
 
@@ -417,7 +419,9 @@ module Invidious::Routes::Feeds
         })
 
         was_insert = Invidious::Database::ChannelVideos.insert(video, with_premiere_timestamp: true)
-        Invidious::Database::Users.add_notification(video) if was_insert
+        if preferences.notifications && was_insert
+          Invidious::Database::Users.add_notification(video)
+        end
       end
     end
 

--- a/src/invidious/routes/preferences.cr
+++ b/src/invidious/routes/preferences.cr
@@ -51,6 +51,10 @@ module Invidious::Routes::PreferencesRoute
     watch_history ||= "off"
     watch_history = watch_history == "on"
 
+    notifications = env.params.body["notifications"]?.try &.as(String)
+    notifications ||= "off"
+    notifications = notifications == "on"
+
     speed = env.params.body["speed"]?.try &.as(String).to_f32?
     speed ||= CONFIG.default_user_preferences.speed
 
@@ -154,6 +158,7 @@ module Invidious::Routes::PreferencesRoute
       listen:                      listen,
       local:                       local,
       watch_history:               watch_history,
+      notifications:               notifications,
       locale:                      locale,
       max_results:                 max_results,
       notifications_only:          notifications_only,

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -80,7 +80,9 @@ module Invidious::Routes::Watch
     end
 
     if notifications && notifications.includes? id
-      Invidious::Database::Users.remove_notification(user.as(User), id)
+      if preferences.notifications
+        Invidious::Database::Users.remove_notification(user.as(User), id)
+      end
       env.get("user").as(User).notifications.delete(id)
       notifications.delete(id)
     end

--- a/src/invidious/user/preferences.cr
+++ b/src/invidious/user/preferences.cr
@@ -24,6 +24,7 @@ struct Preferences
   property listen : Bool = CONFIG.default_user_preferences.listen
   property local : Bool = CONFIG.default_user_preferences.local
   property watch_history : Bool = CONFIG.default_user_preferences.watch_history
+  property notifications : Bool = CONFIG.default_user_preferences.notifications
   property vr_mode : Bool = CONFIG.default_user_preferences.vr_mode
   property show_nick : Bool = CONFIG.default_user_preferences.show_nick
 

--- a/src/invidious/views/user/preferences.ecr
+++ b/src/invidious/views/user/preferences.ecr
@@ -207,6 +207,11 @@
                 <legend><%= translate(locale, "preferences_category_subscription") %></legend>
 
                 <div class="pure-control-group">
+                    <label for="notifications"><%= translate(locale, "preferences_notifications_label") %></label>
+                    <input name="notifications" id="notifications" type="checkbox" <% if preferences.notifications %>checked<% end %>>
+                </div>
+
+                <div class="pure-control-group">
                     <label for="watch_history"><%= translate(locale, "preferences_watch_history_label") %></label>
                     <input name="watch_history" id="watch_history" type="checkbox" <% if preferences.watch_history %>checked<% end %>>
                 </div>


### PR DESCRIPTION
This PR adds the ability to disable notifications.

-----

In error:
```
Showing last frame. Use --error-trace for full trace.

In src/invidious/channels/channels.cr:229:8

 229 | if preferences.notifications && was_insert
          ^----------
Error: undefined local variable or method 'preferences' for top-level
```