### PR TITLE
Fix deprecated helm chart dependency

### DIFF
--- a/kubernetes/Chart.lock
+++ b/kubernetes/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 8.3.0
-digest: sha256:1feec3c396cbf27573dc201831ccd3376a4a6b58b2e7618ce30a89b8f5d707fd
-generated: "2020-02-07T13:39:38.624846+01:00"
+  repository: https://charts.helm.sh/stable/
+  version: 8.3.4
+digest: sha256:c6c9652ec333d0202cfa9c720dc58a41f8e9eea86c241de0a296d81adc4f111a
+generated: "2022-03-01T21:42:07.835046674+13:00"

--- a/kubernetes/Chart.lock
+++ b/kubernetes/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.helm.sh/stable/
-  version: 8.3.4
-digest: sha256:c6c9652ec333d0202cfa9c720dc58a41f8e9eea86c241de0a296d81adc4f111a
-generated: "2022-03-01T21:42:07.835046674+13:00"
+  repository: https://charts.bitnami.com/bitnami/
+  version: 11.1.3
+digest: sha256:79061645472b6fb342d45e8e5b3aacd018ef5067193e46a060bccdc99fe7f6e1
+generated: "2022-03-02T05:57:20.081432389+13:00"

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -17,6 +17,6 @@ maintainers:
   email: mail@leonklingele.de
 dependencies:
 - name: postgresql
-  version: ~8.3.0
-  repository: "https://charts.helm.sh/stable/"
+  version: ~11.1.3
+  repository: "https://charts.bitnami.com/bitnami/"
 engine: gotpl

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: invidious
 description: Invidious is an alternative front-end to YouTube
-version: 1.1.0
+version: 1.1.1
 appVersion: 0.20.1
 keywords:
 - youtube
@@ -18,5 +18,5 @@ maintainers:
 dependencies:
 - name: postgresql
   version: ~8.3.0
-  repository: "https://kubernetes-charts.storage.googleapis.com/"
+  repository: "https://charts.helm.sh/stable/"
 engine: gotpl

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -14,7 +14,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 50
 
 service:
-  type: clusterIP
+  type: ClusterIP
   port: 3000
   #loadBalancerIP:
 
@@ -34,12 +34,17 @@ securityContext:
 
 # See https://github.com/helm/charts/tree/master/stable/postgresql
 postgresql:
-  postgresqlUsername: kemal
-  postgresqlPassword: kemal
-  postgresqlDatabase: invidious
-  initdbUsername: kemal
-  initdbPassword: kemal
-  initdbScriptsConfigMap: invidious-postgresql-init
+  image:
+    registry: quay.io
+  auth:
+    username: kemal
+    password: kemal
+    database: invidious
+  primary:
+    initdb:
+      username: kemal
+      password: kemal
+      scriptsConfigMap: invidious-postgresql-init
 
 # Adapted from ../config/config.yml
 config:

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -32,7 +32,7 @@ securityContext:
   runAsGroup: 1000
   fsGroup: 1000
 
-# See https://github.com/helm/charts/tree/master/stable/postgresql
+# See https://github.com/bitnami/charts/tree/master/bitnami/postgresql
 postgresql:
   image:
     registry: quay.io


### PR DESCRIPTION
When attempting to deploy invidious via helm today I ran the initial `helm dep build` and encountered `Error: no repository definition for https://kubernetes-charts.storage.googleapis.com/. Please add the missing repos via 'helm repo add'`

This is because that repository is now deprecated, the new mirror is https://charts.helm.sh/stable/.  Refer: https://github.com/helm/charts/issues/24432 

This pull request fixes the mirror so others won't be caught out by the same issue.
