### PR TITLE
Safari audio double duration fix for iOS 15

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -675,8 +675,8 @@ if (player_data.preferred_caption_found) {
 if (navigator.vendor == "Apple Computer, Inc." && video_data.params.listen) {
     player.on('loadedmetadata', function () {
         player.on('timeupdate', function () {
-            if (player.remainingTime() < player.duration() / 2) {
-                player.currentTime(player.duration() + 1);
+            if (player.remainingTime() < player.duration() / 2 && player.remainingTime() >= 2) {
+                player.currentTime(player.duration() - 1);
             }
         });
     });


### PR DESCRIPTION
The previous method breaks Always Loop feature on iOS 15.
The previous player.currentTime(player.duration() + 1) sometimes breaks the entire player.
Now it jumps to (end - 1) seconds when the time goes between over half and (end - 2) seconds.
With Always Loop on, player will jump to the beginning after 1 second.