### PR TITLE
Filters visual improvement

### DIFF
--- a/assets/css/search.css
+++ b/assets/css/search.css
@@ -5,6 +5,7 @@ summary {
 	font-size: 1.17em;
 	font-weight: bold;
 	margin: 0 auto 10px auto;
+	cursor: pointer;
 }
 
 summary::-webkit-details-marker,

--- a/assets/css/search.css
+++ b/assets/css/search.css
@@ -20,7 +20,7 @@ summary:before {
 	width: 40px;
 }
 
-details[open] > summary:before { content: "[ ‒ ]"; }
+details[open] > summary:before { content: "[ − ]"; }
 
 
 #filters-box {


### PR DESCRIPTION
Two small changes:
* Pointer cursor on filter panel toggler
* [Real minus sign](https://en.wikipedia.org/wiki/Plus_and_minus_signs) instead of [hyphen-minus](https://en.wikipedia.org/wiki/Hyphen-minus). Minus sign has same width as plus sign. Hyphen-minus is shorter, which leads to twitching text on panel toggle

GitHub shows no difference between ‒ and − because of monospace font 😸 (and in this sentence too, because of small font size, huh)