### PR TITLE
Fix filter checkbox

### DIFF
--- a/src/invidious/frontend/search_filters.cr
+++ b/src/invidious/frontend/search_filters.cr
@@ -106,7 +106,7 @@ module Invidious::Frontend::SearchFilters
         {% feature = value.underscore %}
 
         str << "\t\t\t\t\t\t<div>"
-        str << "<input type='checkbox' name='features' id='filter-features-{{feature}}' value='{{feature}}'"
+        str << "<input type='checkbox' name='features' id='filter-feature-{{feature}}' value='{{feature}}'"
         str << " checked" if value.{{feature}}?
         str << '>'
 


### PR DESCRIPTION
Due to different prefixes in id (`filter-features` in `input` and `filter-feature` in `label`) click on `label` didn't affect corresponding checkbox.