### PR TITLE
Remove insecure protocol in embedded view

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -751,7 +751,7 @@ if (window.location.pathname.startsWith("/embed/")) {
 
     // Create hyperlink for current instance
     redirect_element = document.createElement("a");
-    redirect_element.setAttribute("href", `http://${window.location.host}/watch?v=${window.location.pathname.replace("/embed/","")}`)
+    redirect_element.setAttribute("href", `//${window.location.host}/watch?v=${window.location.pathname.replace("/embed/","")}`)
     redirect_element.appendChild(document.createTextNode("Invidious"))
 
     watch_on_invidious_button.el().appendChild(redirect_element)


### PR DESCRIPTION
According [spec](https://url.spec.whatwg.org/#no-scheme-state) (case 2) no scheme = base scheme.
Link w/o scheme on `http` page will follow to `http`. On `https` to `https`, …