### PR TITLE
Increased footer text contrast to 7:1 ratio

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -302,7 +302,7 @@ p.video-data   { margin: 0; font-weight: bold; font-size: 80%; }
  */
 
 footer {
-  color: #919191;
+  color: #adadad;
   margin-top: auto;
   padding: 1.5em 0;
   text-align: center;


### PR DESCRIPTION
Increased footer text contrast to 7:1 ratio for accessibility as stated in WCAG21. Being footer supplementary content, the 4.5:1 could have been used as well if prefered.

https://github.com/iv-org/invidious/issues/672#issuecomment-1100810591