### PR TITLE
Fix iOS 3 buttons separated lines

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -291,7 +291,7 @@ input[type="search"]::-webkit-search-cancel-button {
 
 .flexible { display: flex; }
 .flex-left  { flex: 1 1 100%; flex-wrap: wrap;   }
-.flex-right { flex: 1 0 max-content; flex-wrap: nowrap; }
+.flex-right { flex: 1 0 auto; flex-wrap: nowrap; }
 
 p.channel-name { margin: 0; }
 p.video-data   { margin: 0; font-weight: bold; font-size: 80%; }


### PR DESCRIPTION
On iOS 15,
before:
![before](https://user-images.githubusercontent.com/78271024/166099012-bf1344d5-885a-4ade-aaf5-c85d1f07cd97.jpg)
after:
![after](https://user-images.githubusercontent.com/78271024/166099017-590c211d-4422-419a-88d4-8b3900a7208d.jpg)
