### PR TITLE
Revert html escaping of backtrace

### DIFF
--- a/src/invidious/helpers/errors.cr
+++ b/src/invidious/helpers/errors.cr
@@ -46,7 +46,7 @@ def error_template_helper(env : HTTP::Server::Context, status_code : Int32, exce
 
   TEXT
 
-  issue_template += github_details("Backtrace", HTML.escape(exception.inspect_with_backtrace))
+  issue_template += github_details("Backtrace", exception.inspect_with_backtrace)
 
   # URLs for the error message below
   url_faq = "https://github.com/iv-org/documentation/blob/master/docs/faq.md"


### PR DESCRIPTION
HTML escaping is useless, as the backtrace ends up in a `<code></code>` block.