### PR TITLE
Video API: Improve NewPipe compatibility (part 2)

### DIFF
--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -413,6 +413,10 @@ struct Video
                 end
               end
 
+              # Livestream chunk infos
+              json.field "targetDurationSec", fmt["targetDurationSec"].as_i if fmt.has_key?("targetDurationSec")
+              json.field "maxDvrDurationSec", fmt["maxDvrDurationSec"].as_i if fmt.has_key?("maxDvrDurationSec")
+
               # Audio-related data
               json.field "audioQuality", fmt["audioQuality"] if fmt.has_key?("audioQuality")
               json.field "audioSampleRate", fmt["audioSampleRate"].as_s.to_i if fmt.has_key?("audioSampleRate")


### PR DESCRIPTION
Add 'targetDurationSec' and 'maxDvrDurationSec' to videos API


Related to https://github.com/iv-org/invidious/pull/3060
Related to https://github.com/TeamNewPipe/NewPipeExtractor/pull/833
Related to https://github.com/TeamNewPipe/NewPipe/pull/8220