### PR TITLE
Remove puts statements in config.cr

### DIFF
--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -161,16 +161,13 @@ class Config
         {% env_id = "INVIDIOUS_#{ivar.id.upcase}" %}
 
         if ENV.has_key?({{env_id}})
-            # puts %(Config.{{ivar.id}} : Loading from env var {{env_id}})
             env_value = ENV.fetch({{env_id}})
             success = false
 
             # Use YAML converter if specified
             {% ann = ivar.annotation(::YAML::Field) %}
             {% if ann && ann[:converter] %}
-                puts %(Config.{{ivar.id}} : Parsing "#{env_value}" as {{ivar.type}} with {{ann[:converter]}} converter)
                 config.{{ivar.id}} = {{ann[:converter]}}.from_yaml(YAML::ParseContext.new, YAML::Nodes.parse(ENV.fetch({{env_id}})).nodes[0])
-                puts %(Config.{{ivar.id}} : Set to #{config.{{ivar.id}}})
                 success = true
 
             # Use regular YAML parser otherwise
@@ -181,9 +178,7 @@ class Config
                 {{ivar_types}}.each do |ivar_type|
                     if !success
                         begin
-                            # puts %(Config.{{ivar.id}} : Trying to parse "#{env_value}" as #{ivar_type})
                             config.{{ivar.id}} = ivar_type.from_yaml(env_value)
-                            puts %(Config.{{ivar.id}} : Set to #{config.{{ivar.id}}} (#{ivar_type}))
                             success = true
                         rescue
                             # nop


### PR DESCRIPTION
Removing a few `puts` statements in `config.cr` which tend to print sensitive variables (e.g. database credentials) to the log output.

Another option might be to hook these into the logger somehow which would allow them to be printed at a debug level, but this would imply wider changes.