### PR TITLE
Change README.md badge from 'Mastodon' to 'Fediverse'

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
   </a>
   <br>
   <a rel="me" href="https://social.tchncs.de/@invidious">
-  <img alt="Mastodon: @invidious@social.tchncs.de" src="https://img.shields.io/badge/Mastodon-%40invidious%40social.tchncs.de-darkgreen">
+  <img alt="Mastodon: @invidious@social.tchncs.de" src="https://img.shields.io/badge/Fediverse-%40invidious%40social.tchncs.de-darkgreen">
   </a>
   <br>
   <a href="https://invidious.io/contact/">

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
   </a>
   <br>
   <a rel="me" href="https://social.tchncs.de/@invidious">
-  <img alt="Mastodon: @invidious@social.tchncs.de" src="https://img.shields.io/badge/Fediverse-%40invidious%40social.tchncs.de-darkgreen">
+  <img alt="Fediverse: @invidious@social.tchncs.de" src="https://img.shields.io/badge/Fediverse-%40invidious%40social.tchncs.de-darkgreen">
   </a>
   <br>
   <a href="https://invidious.io/contact/">


### PR DESCRIPTION
Mastodon is one of multiple softwares that compose the Fediverse ("Federeated Universe"). Some of the most popular softwares include Misskey, Plemora, PeerTube, and Pixelfed, among others. 

As each instance (server) integrates using ActivityPub, any one of these softwares can be used to follow users or reply to posts(/toots/notes) on any instance.

Most people seem to not realize that Mastodon is different from the "umbrella term" Fediverse. :)