### PR TITLE
CSS. Wider settings name to less word wrap

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -527,3 +527,6 @@ p,
 
 /* Center the "invidious" logo on the search page */
 #logo > h1 { text-align: center; }
+
+/* Wider settings name to less word wrap */
+.pure-form-aligned .pure-control-group label { width: 19em; }


### PR DESCRIPTION
Almost all settings in almost every language is word wrapped. This small fix increases width of settings names.

Screenshots in some languages:
[es](https://user-images.githubusercontent.com/24810600/171429125-59aa7ba6-8cc1-44a0-aebb-94ef0c04f298.png) => [es wide](https://user-images.githubusercontent.com/24810600/171429132-ee05b52a-3918-48fb-bb02-9dec0cc89ab6.png)
[ja](https://user-images.githubusercontent.com/24810600/171429135-4916aebf-3135-4163-b4f6-7234efa6fbf2.png) => [ja wide](https://user-images.githubusercontent.com/24810600/171429137-b0521488-6f14-4fde-a1a9-2725706c9f7f.png)
[pr-br](https://user-images.githubusercontent.com/24810600/171429140-8e4e0819-8377-4882-b547-117065ff5c05.png) => [pt-br wide](https://user-images.githubusercontent.com/24810600/171429143-b6a79eef-203c-4f86-8484-d2f7544250ff.png)
[ru](https://user-images.githubusercontent.com/24810600/171429144-f7c3ee64-6dfe-4ff9-81c0-39ea5d4d8fb2.png) => [ru wide](https://user-images.githubusercontent.com/24810600/171429145-e7d0bd40-4ed2-40e6-ad16-e7e269090b4e.png)
