### PR TITLE
Player MobileUi fast forward/backward rate

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -145,7 +145,7 @@ function isMobile() {
 }
 
 if (isMobile()) {
-    player.mobileUi();
+    player.mobileUi({ touchControls: { seekSeconds: 5 * player.playbackRate() } });
 
     var buttons = ['playToggle', 'volumePanel', 'captionsButton'];
 
@@ -274,6 +274,9 @@ function updateCookie(newVolume, newSpeed) {
 
 player.on('ratechange', function () {
     updateCookie(null, player.playbackRate());
+    if (isMobile()) {
+        player.mobileUi({ touchControls: { seekSeconds: 5 * player.playbackRate() } });
+    }
 });
 
 player.on('volumechange', function () {


### PR DESCRIPTION
The fast forward/backward seconds will be adjusted according to playback rate (same as YouTube app behavior).
5 seconds is used when the playback rate is 1x. Previously it was 10 seconds. I believe most of the users watch videos at 2x, so the change will not be obvious.