### PR TITLE
Fix Missing hash key: "selected" (KeyError)

### DIFF
--- a/src/invidious/channels/community.cr
+++ b/src/invidious/channels/community.cr
@@ -13,7 +13,7 @@ def fetch_channel_community(ucid, continuation, locale, format, thin_mode)
 
   if !continuation || continuation.empty?
     initial_data = extract_initial_data(response.body)
-    body = initial_data["contents"]?.try &.["twoColumnBrowseResultsRenderer"]["tabs"].as_a.select { |tab| tab["tabRenderer"]?.try &.["selected"].as_bool.== true }[0]?
+    body = initial_data["contents"]?.try &.["twoColumnBrowseResultsRenderer"]["tabs"].as_a.select { |tab| tab["tabRenderer"]?.try &.["selected"]?.try &.as_bool == true }[0]?
 
     if !body
       raise InfoException.new("Could not extract community tab.")

--- a/src/invidious/channels/community.cr
+++ b/src/invidious/channels/community.cr
@@ -13,13 +13,11 @@ def fetch_channel_community(ucid, continuation, locale, format, thin_mode)
 
   if !continuation || continuation.empty?
     initial_data = extract_initial_data(response.body)
-    body = initial_data["contents"]?.try &.["twoColumnBrowseResultsRenderer"]["tabs"].as_a.select { |tab| tab["tabRenderer"]?.try &.["selected"]?.try &.as_bool == true }[0]?
+    body = extract_selected_tab(initial_data["contents"]["twoColumnBrowseResultsRenderer"]["tabs"])["content"]["sectionListRenderer"]["contents"][0]["itemSectionRenderer"]
 
     if !body
       raise InfoException.new("Could not extract community tab.")
     end
-
-    body = body["tabRenderer"]["content"]["sectionListRenderer"]["contents"][0]["itemSectionRenderer"]
   else
     continuation = produce_channel_community_continuation(ucid, continuation)
 

--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -417,7 +417,7 @@ private module Extractors
   #     {"tabRenderer":  {
   #       "endpoint": {...}
   #       "title": "Playlists",
-  #       "selected": true,
+  #       "selected": true, # Is nil unless tab is selected
   #       "content": {...},
   #       ...
   #     }}

--- a/src/invidious/yt_backend/extractors_utils.cr
+++ b/src/invidious/yt_backend/extractors_utils.cr
@@ -84,7 +84,7 @@ end
 
 def extract_selected_tab(tabs)
   # Extract the selected tab from the array of tabs Youtube returns
-  return selected_target = tabs.as_a.select(&.["tabRenderer"]?.try &.["selected"].as_bool)[0]["tabRenderer"]
+  return selected_target = tabs.as_a.select(&.["tabRenderer"]?.try &.["selected"]?.try &.as_bool)[0]["tabRenderer"]
 end
 
 def fetch_continuation_token(items : Array(JSON::Any))


### PR DESCRIPTION
Fixes #3152

This YouTube change affects all changes and was first noticed in #3152 when YouTube probably did A/B testing.
Go to any instance and visit a channel and go to playlists/community.

The selected key in TabRenderer is now only present if the tab is selected.

I tested my patch against a few channels:
- UCXuqSBlHAE6Xw-yeJA0Tunw/playlists and community
- UCQJ-a2IzCJ-gwlHvqvOWGhw/playlists and community
- UCAXKoxJLJj-Zm-Ulk4jRUJw/playlists and community

and against all these list in this [comment](https://github.com/iv-org/invidious/issues/3152#issuecomment-1159723475)

<details>
<summary>Backtrace</summary>
<p>
   
```
Missing hash key: "selected" (KeyError)
  from /usr/share/crystal/src/hash.cr:1080:9 in '[]'
  from src/invidious/yt_backend/extractors_utils.cr:48:70 in 'process'
  from src/invidious/yt_backend/extractors.cr:622:8 in 'extract_items'
  from src/invidious/channels/playlists.cr:33:13 in 'fetch_channel_playlists'
  from src/invidious/routes/channels.cr:59:27 in 'playlists'
  from lib/kemal/src/kemal/route.cr:13:9 in '->'
  from src/invidious/helpers/handlers.cr:30:37 in 'call'
  from /usr/share/crystal/src/http/server/handler.cr:28:7 in 'call'
  from /usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
  from lib/kemal/src/kemal/filter_handler.cr:21:7 in 'call'
  from /usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
  from /usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
  from /usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
  from /usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
  from /usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
  from src/ext/kemal_static_file_handler.cr:167:15 in 'call'
  from /usr/share/crystal/src/http/server/handler.cr:28:7 in 'call'
  from /usr/share/crystal/src/http/server/handler.cr:28:7 in 'call'
  from /usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
  from lib/kemal/src/kemal/init_handler.cr:12:7 in 'process'
  from /usr/share/crystal/src/http/server.cr:500:5 in '->'
  from /usr/share/crystal/src/fiber.cr:146:11 in 'run'
  from ???
```
</p>
</details>