### PR TITLE
Fix a dead link to Docker install documentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # Using it will build an image from the locally cloned repository.
 #
 # If you want to use Invidious in production, see the docker-compose.yml file provided
-# in the installation documentation: https://docs.invidious.io/Installation.md
+# in the installation documentation: https://docs.invidious.io/installation/
 
 version: "3"
 services:


### PR DESCRIPTION
This just changes a link in the docker-compose file, the current one points to a 404.