### PR TITLE
Include `_helpers.js` in embedded view

### DIFF
--- a/src/invidious/views/embed.ecr
+++ b/src/invidious/views/embed.ecr
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="/css/default.css?v=<%= ASSET_COMMIT %>">
     <link rel="stylesheet" href="/css/embed.css?v=<%= ASSET_COMMIT %>">
     <title><%= HTML.escape(video.title) %> - Invidious</title>
+    <script src="/js/_helpers.js?v=<%= ASSET_COMMIT %>"></script>
 </head>
 
 <body class="dark-theme">


### PR DESCRIPTION
`_helpers.js` already included in `template.ecr`, but this is not enough for /embed/ links.

![image](https://user-images.githubusercontent.com/24810600/178852047-608784d6-5b8b-4f76-a5fb-d37a38ff6a77.png)