### PR TITLE
Disable decrypt_polling by default + add comment

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -352,10 +352,13 @@ feed_threads: 1
 ## Note: This part of the code generate a small amount of data every minute.
 ## This may not be desired if you have bandwidth limits set by your ISP.
 ##
-## Accepted values: true, false
-## Default: true
+## Note 2: This part of the code is currently broken, so changing
+## this setting has no impact.
 ##
-#decrypt_polling: true
+## Accepted values: true, false
+## Default: false
+##
+#decrypt_polling: false
 
 
 # -----------------------------

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -75,7 +75,7 @@ class Config
   @[YAML::Field(converter: Preferences::URIConverter)]
   property database_url : URI = URI.parse("")
   # Use polling to keep decryption function up to date
-  property decrypt_polling : Bool = true
+  property decrypt_polling : Bool = false
   # Used for crawling channels: threads should check all videos uploaded by a channel
   property full_refresh : Bool = false
   # Used to tell Invidious it is behind a proxy, so links to resources should be https://


### PR DESCRIPTION
After some testing the decrypt polling doesn't work anymore, for example encrypted age-restricted videos are not decrypted anymore.

Disabling this function until we fix it and add back the previous comment that got removed in https://github.com/iv-org/invidious/commit/644ba469451f2348219f99684e44e42a276bfd46