### PR TITLE
Set cookies to Lax

### DIFF
--- a/src/invidious/user/cookies.cr
+++ b/src/invidious/user/cookies.cr
@@ -18,7 +18,7 @@ struct Invidious::User
         expires: Time.utc + 2.years,
         secure: SECURE,
         http_only: true,
-        samesite: HTTP::Cookie::SameSite::Strict
+        samesite: HTTP::Cookie::SameSite::Lax
       )
     end
 
@@ -32,7 +32,7 @@ struct Invidious::User
         expires: Time.utc + 2.years,
         secure: SECURE,
         http_only: false,
-        samesite: HTTP::Cookie::SameSite::Strict
+        samesite: HTTP::Cookie::SameSite::Lax
       )
     end
   end


### PR DESCRIPTION
From MDN https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite for Strict:

> [Strict](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#strict)
> Cookies will only be sent in a first-party context and not be sent along with requests initiated by third party websites.

But for Lax:

> Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), **but are sent when a user is navigating to the origin site (i.e., when following a link)**.

This PR modifies the `samesite` parameter for the cookies so that the cookies are used when a user visit invidious from an external website. The `samesite` parameter was changed in https://github.com/iv-org/invidious/pull/2895/files#diff-67c8d87dc6189f267ae6ac03076fcf99aa1225a6457b64edea6436bee54661f3R35

Fixes #3132