### PR TITLE
Handle long usernames gracefully

### DIFF
--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -67,7 +67,7 @@
                             </a>
                         </div>
                         <% if env.get("preferences").as(Preferences).show_nick %>
-                            <div class="pure-u-1-4">
+                            <div class="pure-u-1-4" style="overflow: hidden; white-space: nowrap;">
                                 <span id="user_name"><%= HTML.escape(env.get("user").as(Invidious::User).email) %></span>
                             </div>
                         <% end %>


### PR DESCRIPTION
I have adjusted the fix in https://github.com/11Tuvork28/invidious/commit/7e0fcf4aa62eaef25197b9a2d965fade3fbc9018 so that it does not rely on text size.

This should resolve #2597, preventing long usernames from displaying over the navigation bar. I was however not able to test this on my machine as I do not have the necessary build environment, however I did verify this in the browser inspector that this solves the problem.

Could someone please test this on an actual build of invidious? Thanks!