### PR TITLE
Customize scrollbar in Mozilla Firefox

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -370,6 +370,10 @@ span > select {
 }
 
 @media (prefers-color-scheme: light) {
+  html {
+    scrollbar-color: #303030 #f0f0f0;
+  }
+
   .no-theme a:hover,
   .no-theme a:active,
   .no-theme summary:hover  {
@@ -441,6 +445,10 @@ body.dark-theme {
 }
 
 @media (prefers-color-scheme: dark) {
+  html {
+    scrollbar-color: #f0f0f0 rgb(45, 45, 45);
+  }
+
   .no-theme a:hover,
   .no-theme a:active {
     color: rgb(0, 182, 240);


### PR DESCRIPTION
This uses the CSS's [`scrollbar-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Scrollbars) to change the colors of the scroll bar. For now it's only supported in Firefox.

For Chromium [`::-webkit-scrollbar`](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar) is supported, but it's not a standard yet, and there may also be a large incompatibilities between implementations...

**Before:**
<img width=500px src="https://user-images.githubusercontent.com/65136727/187166529-401eabbf-6062-4f48-aa49-37bb773914e5.png">
<img width=500px src="https://user-images.githubusercontent.com/65136727/187168617-912bac28-af76-4489-98de-25d6160b0719.png">



**After:**
<img width=500px src="https://user-images.githubusercontent.com/65136727/187166551-c7d7d072-b52f-4616-94b3-158500a37964.png">
<img width=500px src="https://user-images.githubusercontent.com/65136727/187168690-644539df-33e9-48d6-92e9-977318d43440.png">
