### PR TITLE
Fix page shift on search bar focus

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -213,7 +213,7 @@ img.thumbnail {
 }
 
 .searchbar input[type="search"]:focus {
-	margin: 0 0 0.5px 0;
+	margin: 0;
 	border: 2px solid;
 	border-color: rgba(0,0,0,0);
 	border-bottom-color: #FED;


### PR DESCRIPTION
## What does this commit fix?
The search bar (while in focus) currently has a bottom margin which exceeds the height of the bar when it isn't in focus. When the search bar is clicked and brought into focus, all content further down the page shifts downwards. Firefox (and related browsers) further shift the contents by leaving the text in place while moving images and backgrounds. This can cause a visually displeasing result for the end user, possibly leaving them with a bad UX overall. If layout shifts are being prevented on a large scale, they should also be applied on a small scale.

## Nice talk, but let's see this content shift
I've zoomed in for clarity, but the shift is still noticeable at 100% zoom.

[firefox-loop.webm](https://user-images.githubusercontent.com/46414358/188753298-daf4bace-0933-437e-89d4-b54d6a215143.webm)