### PR TITLE
Fix the video title overlay's colors in embed

### DIFF
--- a/assets/css/player.css
+++ b/assets/css/player.css
@@ -34,7 +34,7 @@
 .video-js.player-style-youtube .vjs-control-bar > .vjs-spacer {
   flex: 1;
   order: 2;
-} 
+}
 
 .video-js.player-style-youtube .vjs-play-progress .vjs-time-tooltip {
   display: none;
@@ -175,11 +175,14 @@ ul.vjs-menu-content::-webkit-scrollbar {
 .video-js.player-style-invidious .vjs-play-progress {
   background-color: rgba(0, 182, 240, 1);
 }
-vjs-menu-content
+
 /* Overlay */
 .video-js .vjs-overlay {
-  background-color: rgba(35, 35, 35, 0.75);
-  color: rgba(255, 255, 255, 1);
+  background-color: rgba(35, 35, 35, 0.75) !important;
+}
+.video-js .vjs-overlay * {
+  color: rgba(255, 255, 255, 1) !important;
+  text-align: center;
 }
 
 /* ProgressBar marker */


### PR DESCRIPTION
Fixes #3293

### **Screenshot of the result:**

![image](https://user-images.githubusercontent.com/52980486/189551109-4821d987-6be2-48fd-82fe-daef05b51750.png)
