### PR TITLE
Add channel name to embeds

### DIFF
--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -9,7 +9,7 @@
 <meta name="keywords" content="<%= video.keywords.join(",") %>">
 <meta property="og:site_name" content="Invidious">
 <meta property="og:url" content="<%= HOST_URL %>/watch?v=<%= video.id %>">
-<meta property="og:title" content="<%= title %>">
+<meta property="og:title" content="<%= title %> by <%= author %>">
 <meta property="og:image" content="/vi/<%= video.id %>/maxres.jpg">
 <meta property="og:description" content="<%= HTML.escape(video.short_description) %>">
 <meta property="og:type" content="video.other">

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -7,9 +7,9 @@
 <meta name="thumbnail" content="<%= thumbnail %>">
 <meta name="description" content="<%= HTML.escape(video.short_description) %>">
 <meta name="keywords" content="<%= video.keywords.join(",") %>">
-<meta property="og:site_name" content="Invidious">
+<meta property="og:site_name" content="<%= author %> | Invidious">
 <meta property="og:url" content="<%= HOST_URL %>/watch?v=<%= video.id %>">
-<meta property="og:title" content="<%= title %> by <%= author %>">
+<meta property="og:title" content="<%= title %>">
 <meta property="og:image" content="/vi/<%= video.id %>/maxres.jpg">
 <meta property="og:description" content="<%= HTML.escape(video.short_description) %>">
 <meta property="og:type" content="video.other">


### PR DESCRIPTION
Fairly trivial, and title is self explanatory, however there are some notes incase anyone wants to build on this idea:

There is an [existing issue](https://github.com/iv-org/invidious/issues/3251) that is related. However, so as to keep things separate, I made a separate PR.

The example video I am using is: https://youtube.com/watch?v=czCFyzTVDR8

Ideally I'd want to have the channel name in a separate (clickable) link like YouTube's embeds (Discord is used as an example):

![image](https://user-images.githubusercontent.com/81344401/194701534-698a8134-7cea-4bfe-9a47-796ef75917b7.png)

However, the way YouTube does this seems a bit weird to me, and I'm not sure if this is OpenGraph compliant/compatible, so I decided to leave it out for the time being:
```html
<span itemprop="author" itemscope="" itemtype="http://schema.org/Person">
    <link itemprop="url" href="http://www.youtube.com/channel/UCz4a7agVFr1TxU-mpAP8hkw">
    <link itemprop="name" content="Soch by Mohak Mangal">
</span>
<script type="application/ld+json" nonce="c8LbRbPU2vjbBLiTESW1Tw">
    {"@context": "http://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "item": {"@id": "http:\/\/www.youtube.com\/channel\/UCz4a7agVFr1TxU-mpAP8hkw", "name": "Soch by Mohak Mangal"}}]}
</script>
```
