### PR TITLE
Fix parsing error in search results

### DIFF
--- a/src/invidious/channels/about.cr
+++ b/src/invidious/channels/about.cr
@@ -130,8 +130,9 @@ def get_about_info(ucid, locale) : AboutChannel
     tabs = tabs_json.reject { |node| node["tabRenderer"]?.nil? }.map(&.["tabRenderer"]["title"].as_s.downcase)
   end
 
-  sub_count = initdata["header"]["c4TabbedHeaderRenderer"]?.try &.["subscriberCountText"]?.try &.["simpleText"]?.try &.as_s?
-    .try { |text| short_text_to_number(text.split(" ")[0]) } || 0
+  sub_count = initdata
+    .dig?("header", "c4TabbedHeaderRenderer", "subscriberCountText", "simpleText").try &.as_s?
+    .try { |text| short_text_to_number(text.split(" ")[0]).to_i32 } || 0
 
   AboutChannel.new(
     ucid: ucid,

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -161,21 +161,19 @@ def number_with_separator(number)
   number.to_s.reverse.gsub(/(\d{3})(?=\d)/, "\\1,").reverse
 end
 
-def short_text_to_number(short_text : String) : Int32
-  case short_text
-  when .ends_with? "M"
-    number = short_text.rstrip(" mM").to_f
-    number *= 1000000
-  when .ends_with? "K"
-    number = short_text.rstrip(" kK").to_f
-    number *= 1000
-  else
-    number = short_text.rstrip(" ")
+def short_text_to_number(short_text : String) : Int64
+  matches = /(?<number>\d+(\.\d+)?)\s?(?<suffix>[mMkKbB])?/.match(short_text)
+  number = matches.try &.["number"].to_f || 0.0
+
+  case matches.try &.["suffix"].downcase
+  when "k" then number *= 1_000
+  when "m" then number *= 1_000_000
+  when "b" then number *= 1_000_000_000
   end
 
-  number = number.to_i
-
-  return number
+  return number.to_i64
+rescue ex
+  return 0_i64
 end
 
 def number_to_short_text(number)

--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -170,7 +170,7 @@ private module Parsers
       # Always simpleText
       # TODO change default value to nil
       subscriber_count = item_contents.dig?("subscriberCountText", "simpleText")
-        .try { |s| short_text_to_number(s.as_s.split(" ")[0]) } || 0
+        .try { |s| short_text_to_number(s.as_s.split(" ")[0]).to_i32 } || 0
 
       # Auto-generated channels doesn't have videoCountText
       # Taken from: https://github.com/iv-org/invidious/pull/2228#discussion_r717620922

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -43,7 +43,7 @@ module YoutubeAPI
     ClientType::Web => {
       name:       "WEB",
       name_proto: "1",
-      version:    "2.20220804.07.00",
+      version:    "2.20221118.01.00",
       api_key:    DEFAULT_API_KEY,
       screen:     "WATCH_FULL_SCREEN",
       os_name:    "Windows",


### PR DESCRIPTION
Fixes (partially) #3394

This makes the short number (e.g: 14.5k, 3.5M, 1.2B) parsing less prone to breaking, but the video/subs counts are sometimes broken, sometimes not.

There isn't much we can do other than wait for Youtube to stop being broken.