### PR TITLE
FIX: Invalid Int32: (ArgumentError) in ChannelRenderer

### DIFF
--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -169,7 +169,7 @@ private module Parsers
       # When public subscriber count is disabled, the subscriberCountText isn't sent by InnerTube.
       # Always simpleText
       # TODO change default value to nil
-      subscriber_count = item_contents.dig?("subscriberCountText", "simpleText")
+      subscriber_count = item_contents.dig?("videoCountText", "simpleText")
         .try { |s| short_text_to_number(s.as_s.split(" ")[0]).to_i32 } || 0
 
       # Auto-generated channels doesn't have videoCountText


### PR DESCRIPTION
It's only a temporary fix until the YT devs get their things together but till then it works fine.
It's live on my [instance](https://invidio.xamh.de/), works just fine.
I understand if this gets blocked because it's only a matter of time till it breaks again :(