### PR TITLE
Docker: Added tini for proper signal forwarding

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN if [[ "${release}" == 1 && "${disable_quic}" == 1 ]] ; then \
 
 
 FROM alpine:3.16
-RUN apk add --no-cache librsvg ttf-opensans
+RUN apk add --no-cache librsvg ttf-opensans tini
 WORKDIR /invidious
 RUN addgroup -g 1000 -S invidious && \
     adduser -u 1000 -S invidious -G invidious
@@ -58,4 +58,5 @@ RUN chmod o+rX -R ./assets ./config ./locales
 
 EXPOSE 3000
 USER invidious
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD [ "/invidious/invidious" ]

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -42,7 +42,7 @@ RUN if [[ "${release}" == 1 && "${disable_quic}" == 1 ]] ; then \
     fi
 
 FROM alpine:3.16
-RUN apk add --no-cache librsvg ttf-opensans
+RUN apk add --no-cache librsvg ttf-opensans tini
 WORKDIR /invidious
 RUN addgroup -g 1000 -S invidious && \
     adduser -u 1000 -S invidious -G invidious
@@ -57,4 +57,5 @@ RUN chmod o+rX -R ./assets ./config ./locales
 
 EXPOSE 3000
 USER invidious
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD [ "/invidious/invidious" ]


### PR DESCRIPTION
Currently, the TERM signal from docker is not handled, so the container is killed after the timeout. Adding [tini](https://github.com/krallin/tini) as the entrypoint solves this.