### PR TITLE
Add ability to disable all user notifications

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -295,6 +295,17 @@ https_only: false
 ##
 #admins: [""]
 
+##
+## Enable/Disable the user notifications for all users
+##
+## Note: On large instances, it is recommended to set this option to 'false'
+## in order to reduce the amount of data written to the database, and hence
+## improve the overall performance of the instance.
+##
+## Accepted values: true, false
+## Default: true
+##
+#enable_user_notifications: true
 
 # -----------------------------
 #  Background jobs

--- a/src/invidious/channels/channels.cr
+++ b/src/invidious/channels/channels.cr
@@ -228,7 +228,11 @@ def fetch_channel(ucid, pull_all_videos : Bool)
 
     if was_insert
       LOGGER.trace("fetch_channel: #{ucid} : video #{video_id} : Inserted, updating subscriptions")
-      Invidious::Database::Users.add_notification(video)
+      if CONFIG.enable_user_notifications
+        Invidious::Database::Users.add_notification(video)
+      else
+        Invidious::Database::Users.feed_needs_update(video)
+      end
     else
       LOGGER.trace("fetch_channel: #{ucid} : video #{video_id} : Updated")
     end
@@ -264,7 +268,13 @@ def fetch_channel(ucid, pull_all_videos : Bool)
         # so since they don't provide a published date here we can safely ignore them.
         if Time.utc - video.published > 1.minute
           was_insert = Invidious::Database::ChannelVideos.insert(video)
-          Invidious::Database::Users.add_notification(video) if was_insert
+          if was_insert
+            if CONFIG.enable_user_notifications
+              Invidious::Database::Users.add_notification(video)
+            else
+              Invidious::Database::Users.feed_needs_update(video)
+            end
+          end
         end
       end
 

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -110,6 +110,8 @@ class Config
   property hsts : Bool? = true
   # Disable proxying server-wide: options: 'dash', 'livestreams', 'downloads', 'local'
   property disable_proxy : Bool? | Array(String)? = false
+  # Enable the user notifications for all users
+  property enable_user_notifications : Bool = true
 
   # URL to the modified source code to be easily AGPL compliant
   # Will display in the footer, next to the main source code link

--- a/src/invidious/database/users.cr
+++ b/src/invidious/database/users.cr
@@ -154,6 +154,16 @@ module Invidious::Database::Users
   #  Update (misc)
   # -------------------
 
+  def feed_needs_update(video : ChannelVideo)
+    request = <<-SQL
+      UPDATE users
+      SET feed_needs_update = true
+      WHERE $1 = ANY(subscriptions)
+    SQL
+
+    PG_DB.exec(request, video.ucid)
+  end
+
   def update_preferences(user : User)
     request = <<-SQL
       UPDATE users

--- a/src/invidious/routes/embed.cr
+++ b/src/invidious/routes/embed.cr
@@ -147,7 +147,7 @@ module Invidious::Routes::Embed
     #   PG_DB.exec("UPDATE users SET watched = array_append(watched, $1) WHERE email = $2", id, user.as(User).email)
     # end
 
-    if notifications && notifications.includes? id
+    if CONFIG.enable_user_notifications && notifications && notifications.includes? id
       Invidious::Database::Users.remove_notification(user.as(User), id)
       env.get("user").as(User).notifications.delete(id)
       notifications.delete(id)

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -80,7 +80,7 @@ module Invidious::Routes::Watch
       Invidious::Database::Users.mark_watched(user.as(User), id)
     end
 
-    if notifications && notifications.includes? id
+    if CONFIG.enable_user_notifications && notifications && notifications.includes? id
       Invidious::Database::Users.remove_notification(user.as(User), id)
       env.get("user").as(User).notifications.delete(id)
       notifications.delete(id)

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -37,7 +37,9 @@ module Invidious::Routing
       get "/feed/webhook/:token", Routes::Feeds, :push_notifications_get
       post "/feed/webhook/:token", Routes::Feeds, :push_notifications_post
 
-      get "/modify_notifications", Routes::Notifications, :modify
+      if CONFIG.enable_user_notifications
+        get "/modify_notifications", Routes::Notifications, :modify
+      end
     {% end %}
 
     self.register_image_routes
@@ -260,8 +262,10 @@ module Invidious::Routing
       post "/api/v1/auth/tokens/register", {{namespace}}::Authenticated, :register_token
       post "/api/v1/auth/tokens/unregister", {{namespace}}::Authenticated, :unregister_token
 
-      get "/api/v1/auth/notifications", {{namespace}}::Authenticated, :notifications
-      post "/api/v1/auth/notifications", {{namespace}}::Authenticated, :notifications
+      if CONFIG.enable_user_notifications
+        get "/api/v1/auth/notifications", {{namespace}}::Authenticated, :notifications
+        post "/api/v1/auth/notifications", {{namespace}}::Authenticated, :notifications
+      end
 
       # Misc
       get "/api/v1/stats", {{namespace}}::Misc, :stats

--- a/src/invidious/views/feeds/subscriptions.ecr
+++ b/src/invidious/views/feeds/subscriptions.ecr
@@ -23,6 +23,8 @@
     </div>
 </div>
 
+<% if CONFIG.enable_user_notifications %>
+
 <center>
     <%= translate_count(locale, "subscriptions_unseen_notifs_count", notifications.size) %>
 </center>
@@ -38,6 +40,8 @@
     <%= rendered "components/item" %>
 <% end %>
 </div>
+
+<% end %>
 
 <div class="h-box">
     <hr>

--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -54,7 +54,7 @@
                         <div class="pure-u-1-4">
                             <a id="notification_ticker" title="<%= translate(locale, "Subscriptions") %>" href="/feed/subscriptions" class="pure-menu-heading">
                                 <% notification_count = env.get("user").as(Invidious::User).notifications.size %>
-                                <% if notification_count > 0 %>
+                                <% if CONFIG.enable_user_notifications && notification_count > 0 %>
                                     <span id="notification_count"><%= notification_count %></span> <i class="icon ion-ios-notifications"></i>
                                 <% else %>
                                     <i class="icon ion-ios-notifications-outline"></i>
@@ -170,7 +170,9 @@
         }.to_pretty_json
         %>
         </script>
+        <% if CONFIG.enable_user_notifications %>
         <script src="/js/notifications.js?v=<%= ASSET_COMMIT %>"></script>
+        <% end %>
     <% end %>
 </body>
 

--- a/src/invidious/views/user/preferences.ecr
+++ b/src/invidious/views/user/preferences.ecr
@@ -244,6 +244,7 @@
                     <input name="unseen_only" id="unseen_only" type="checkbox" <% if preferences.unseen_only %>checked<% end %>>
                 </div>
 
+                <% if CONFIG.enable_user_notifications %>
                 <div class="pure-control-group">
                     <label for="notifications_only"><%= translate(locale, "preferences_notifications_only_label") %></label>
                     <input name="notifications_only" id="notifications_only" type="checkbox" <% if preferences.notifications_only %>checked<% end %>>
@@ -254,6 +255,7 @@
                     <div class="pure-control-group">
                         <a href="#" data-onclick="notification_requestPermission"><%= translate(locale, "Enable web notifications") %></a>
                     </div>
+                <% end %>
                 <% end %>
             <% end %>
 


### PR DESCRIPTION
This PR adds the ability to disable all the user notifications in order to combat against the ever-growing disk space generated by refreshing the user notifications.

See https://github.com/iv-org/invidious/issues/2042#issuecomment-1029397786 for more info.

----

About the PR I have not disabled everything when the parameter is set to false, mainly in the file https://github.com/iv-org/invidious/blob/master/src/invidious/users.cr#L133 because I fear to break something. Feel free to improve my code about that if needed.

But the basic idea is implemented, no notification items are created when the setting `enable_user_notifications` is turned off and on the UI side the user won't see any notifications anymore.

---

A new method `feed_needs_update` in database/users.cr has been created in order to ask for Invidious to refresh the user feed without creating a new notification item.