### PR TITLE
handle auto theme correctly with the manual toggle

### DIFF
--- a/assets/js/themes.js
+++ b/assets/js/themes.js
@@ -22,9 +22,11 @@ function setTheme(theme) {
     if (theme === THEME_DARK) {
         toggle_theme.children[0].className = 'icon ion-ios-sunny';
         document.body.className = 'dark-theme';
-    } else {
+    } else if (theme === THEME_LIGHT) {
         toggle_theme.children[0].className = 'icon ion-ios-moon';
         document.body.className = 'light-theme';
+    } else {
+        document.body.className = 'no-theme';
     }
 }
 


### PR DESCRIPTION
If the user used the manual toggle, they will not be able to get back to auto since it will force set to light theme. This should fix that.