### PR TITLE
Make DASH absolute urls when local

### DIFF
--- a/src/invidious/routes/api/manifest.cr
+++ b/src/invidious/routes/api/manifest.cr
@@ -42,7 +42,7 @@ module Invidious::Routes::API::Manifest
 
     if local
       adaptive_fmts.each do |fmt|
-        fmt["url"] = JSON::Any.new(URI.parse(fmt["url"].as_s).request_target)
+        fmt["url"] = JSON::Any.new("#{HOST_URL}#{URI.parse(fmt["url"].as_s).request_target}")
       end
     end
 

--- a/src/invidious/routes/api/manifest.cr
+++ b/src/invidious/routes/api/manifest.cr
@@ -29,7 +29,7 @@ module Invidious::Routes::API::Manifest
 
         if local
           uri = URI.parse(url)
-          url = "#{uri.request_target}host/#{uri.host}/"
+          url = "#{HOST_URL}#{uri.request_target}host/#{uri.host}/"
         end
 
         "<BaseURL>#{url}</BaseURL>"


### PR DESCRIPTION
This PR makes the `BaseURL` in DASH manifest containing absolute urls instead of relative, which matches non-proxied DASH