### PR TITLE
Don't continue when LOGIN_REQUIRED and no videoDetails element

### DIFF
--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -66,8 +66,10 @@ def extract_video_info(video_id : String, proxy_region : String? = nil)
     reason ||= subreason.try &.[]("runs").as_a.map(&.[]("text")).join("")
     reason ||= player_response.dig("playabilityStatus", "reason").as_s
 
-    # Stop here if video is not a scheduled livestream
-    if !{"LIVE_STREAM_OFFLINE", "LOGIN_REQUIRED"}.any?(playability_status)
+    # Stop here if video is not a scheduled livestream or
+    # for LOGIN_REQUIRED when videoDetails element is not found because retrying won't help
+    if !{"LIVE_STREAM_OFFLINE", "LOGIN_REQUIRED"}.any?(playability_status) ||
+       playability_status == "LOGIN_REQUIRED" && !player_response.dig?("videoDetails")
       return {
         "version" => JSON::Any.new(Video::SCHEMA_VERSION.to_i64),
         "reason"  => JSON::Any.new(reason),


### PR DESCRIPTION
~~I've no idea why playability `LOGIN_REQUIRED` is allowed to continue the parsing of the video, but this should not be allowed.~~

~~A video behind a login will not give more information than the playability status, hence there is no section for `videoDetails` in the JSON payload.~~

-----

Don't continue when the playability is `LOGIN_REQUIRED` and the element `videoDetails` at the root of the JSON payload is not found. When the element `videoDetails` is not present, this usually means that trying other clients won't do anything.

An age-restricted video has the element `videoDetails` but not a private video in order to keep the video description hidden, for example.

Closes #3402