### PR TITLE
Add prometheus metrics at /api/v1/metrics

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -186,6 +186,7 @@ end
 
 if CONFIG.statistics_enabled
   Invidious::Jobs.register Invidious::Jobs::StatisticsRefreshJob.new(PG_DB, SOFTWARE)
+  add_handler Metrics::METRICS_COLLECTOR
 end
 
 if (CONFIG.use_pubsub_feeds.is_a?(Bool) && CONFIG.use_pubsub_feeds.as(Bool)) || (CONFIG.use_pubsub_feeds.is_a?(Int32) && CONFIG.use_pubsub_feeds.as(Int32) > 0)

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -186,7 +186,7 @@ end
 
 if CONFIG.statistics_enabled
   Invidious::Jobs.register Invidious::Jobs::StatisticsRefreshJob.new(PG_DB, SOFTWARE)
-  add_handler Metrics::METRICS_COLLECTOR
+  add_handler Metrics::RouteMetricsCollector.new
 end
 
 if (CONFIG.use_pubsub_feeds.is_a?(Bool) && CONFIG.use_pubsub_feeds.as(Bool)) || (CONFIG.use_pubsub_feeds.is_a?(Int32) && CONFIG.use_pubsub_feeds.as(Int32) > 0)

--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -198,3 +198,11 @@ def get_playback_statistic
 
   return tracker.as(Hash(String, Int64 | Float64))
 end
+
+def to_prometheus_metrics(metrics_struct : Hash(String, Number)) : String
+  return String.build do |str|
+    metrics_struct.each.each do |key, value|
+      str << key << " " << value << "\n"
+    end
+  end
+end

--- a/src/invidious/jobs/statistics_refresh_job.cr
+++ b/src/invidious/jobs/statistics_refresh_job.cr
@@ -27,6 +27,11 @@ class Invidious::Jobs::StatisticsRefreshJob < Invidious::Jobs::BaseJob
     "playback" => {} of String => Int64 | Float64,
   }
 
+  STATISTICS_PROMETHEUS = {
+    "invidious_updated_at"                => Time.utc.to_unix,
+    "invidious_last_channel_refreshed_at" => 0_i64,
+  }
+
   private getter db : DB::Database
 
   def initialize(@db, @software_config : Hash(String, String))
@@ -58,6 +63,9 @@ class Invidious::Jobs::StatisticsRefreshJob < Invidious::Jobs::BaseJob
     users["total"] = Invidious::Database::Statistics.count_users_total
     users["activeHalfyear"] = Invidious::Database::Statistics.count_users_active_6m
     users["activeMonth"] = Invidious::Database::Statistics.count_users_active_1m
+
+    STATISTICS_PROMETHEUS["invidious_updated_at"] = Time.utc.to_unix
+    STATISTICS_PROMETHEUS["invidious_last_channel_refreshed_at"] = Invidious::Database::Statistics.channel_last_update.try &.to_unix || 0_i64
 
     STATISTICS["metadata"] = {
       "updatedAt"              => Time.utc.to_unix,

--- a/src/invidious/metrics.cr
+++ b/src/invidious/metrics.cr
@@ -1,0 +1,48 @@
+# Module containing an optional Kemal handler, which can be used
+# to collect metrics about the usage of various Invidious routes.
+module Metrics
+  record MetricLabels, request_method : String, request_route : String, response_code : Int32
+
+  # Counts how many a given route was used
+  REQUEST_COUNTERS              = Hash(MetricLabels, Int64).new
+
+  # Counts how much time was used to handle requests to each route
+  REQUEST_DURATION_SECONDS_SUMS = Hash(MetricLabels, Float32).new
+
+  # The handler which will record metrics when registered in a Kemal application 
+  METRICS_COLLECTOR = RouteMetricsCollector.new(REQUEST_COUNTERS, REQUEST_DURATION_SECONDS_SUMS)
+
+  class RouteMetricsCollector < Kemal::Handler
+    def initialize(
+      @num_of_request_counters : Hash(MetricLabels, Int64),
+      @request_duration_seconds_sums : Hash(MetricLabels, Float32)
+    )
+    end
+
+    def call(context : HTTP::Server::Context)
+      request_handling_started = Time.utc
+      begin
+        call_next(context)
+      ensure
+        request_handling_finished = Time.utc
+        request_path = context.route.path
+        request_method = context.request.method
+        seconds_spent_handling = (request_handling_finished - request_handling_started).to_f
+        response_status = context.response.status_code.to_i
+
+        LOGGER.trace("Collecting metrics: handling #{request_method} #{request_path} took #{seconds_spent_handling}s and finished with status #{response_status}")
+        metric_key = MetricLabels.new request_path, request_method, response_status
+
+        unless @num_of_request_counters.has_key?(metric_key)
+          @num_of_request_counters[metric_key] = 0
+        end
+        @num_of_request_counters[metric_key] += 1
+
+        unless @request_duration_seconds_sums.has_key?(metric_key)
+          @request_duration_seconds_sums[metric_key] = 0.0
+        end
+        @request_duration_seconds_sums[metric_key] += seconds_spent_handling
+      end
+    end
+  end
+end

--- a/src/invidious/metrics.cr
+++ b/src/invidious/metrics.cr
@@ -4,12 +4,12 @@ module Metrics
   record MetricLabels, request_method : String, request_route : String, response_code : Int32
 
   # Counts how many a given route was used
-  REQUEST_COUNTERS              = Hash(MetricLabels, Int64).new
+  REQUEST_COUNTERS = Hash(MetricLabels, Int64).new
 
   # Counts how much time was used to handle requests to each route
   REQUEST_DURATION_SECONDS_SUMS = Hash(MetricLabels, Float32).new
 
-  # The handler which will record metrics when registered in a Kemal application 
+  # The handler which will record metrics when registered in a Kemal application
   METRICS_COLLECTOR = RouteMetricsCollector.new(REQUEST_COUNTERS, REQUEST_DURATION_SECONDS_SUMS)
 
   class RouteMetricsCollector < Kemal::Handler

--- a/src/invidious/metrics.cr
+++ b/src/invidious/metrics.cr
@@ -3,20 +3,18 @@
 module Metrics
   record MetricLabels, request_method : String, request_route : String, response_code : Int32
 
-  # Counts how many a given route was used
-  REQUEST_COUNTERS = Hash(MetricLabels, Int64).new
-
-  # Counts how much time was used to handle requests to each route
-  REQUEST_DURATION_SECONDS_SUMS = Hash(MetricLabels, Float32).new
-
-  # The handler which will record metrics when registered in a Kemal application
-  METRICS_COLLECTOR = RouteMetricsCollector.new(REQUEST_COUNTERS, REQUEST_DURATION_SECONDS_SUMS)
-
   class RouteMetricsCollector < Kemal::Handler
-    def initialize(
-      @num_of_request_counters : Hash(MetricLabels, Int64),
-      @request_duration_seconds_sums : Hash(MetricLabels, Float32)
-    )
+    # Counts how many times a given route was used
+    @@num_of_request_counters = Hash(MetricLabels, Int64).new
+    # Counts how much time was used to handle requests to each route
+    @@request_duration_seconds_sums = Hash(MetricLabels, Float32).new
+
+    def self.num_of_request_counters
+      return @@num_of_request_counters
+    end
+
+    def self.request_duration_seconds_sums
+      return @@request_duration_seconds_sums
     end
 
     def call(context : HTTP::Server::Context)
@@ -33,15 +31,15 @@ module Metrics
         LOGGER.trace("Collecting metrics: handling #{request_method} #{request_path} took #{seconds_spent_handling}s and finished with status #{response_status}")
         metric_key = MetricLabels.new request_path, request_method, response_status
 
-        unless @num_of_request_counters.has_key?(metric_key)
-          @num_of_request_counters[metric_key] = 0
+        unless @@num_of_request_counters.has_key?(metric_key)
+          @@num_of_request_counters[metric_key] = 0
         end
-        @num_of_request_counters[metric_key] += 1
+        @@num_of_request_counters[metric_key] += 1
 
-        unless @request_duration_seconds_sums.has_key?(metric_key)
-          @request_duration_seconds_sums[metric_key] = 0.0
+        unless @@request_duration_seconds_sums.has_key?(metric_key)
+          @@request_duration_seconds_sums[metric_key] = 0.0
         end
-        @request_duration_seconds_sums[metric_key] += seconds_spent_handling
+        @@request_duration_seconds_sums[metric_key] += seconds_spent_handling
       end
     end
   end

--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -26,6 +26,11 @@ module Invidious::Routes::API::V1::Misc
     end
   end
 
+  def self.metrics(env)
+    env.response.content_type = "text/plain"
+    return to_prometheus_metrics(Invidious::Jobs::StatisticsRefreshJob::STATISTICS_PROMETHEUS)
+  end
+
   # APIv1 currently uses the same logic for both
   # user playlists and Invidious playlists. This means that we can't
   # reasonably split them yet. This should be addressed in APIv2

--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -32,7 +32,7 @@ module Invidious::Routes::API::V1::Misc
     env.response.content_type = "text/plain"
 
     return String.build do |str|
-      Metrics::REQUEST_COUNTERS.each do |metric_labels, value|
+      Metrics::RouteMetricsCollector.num_of_request_counters.each do |metric_labels, value|
         str << "http_requests_total{"
         str << "method=\"" << metric_labels.request_method << "\" "
         str << "route=\"" << metric_labels.request_route << "\" "
@@ -41,7 +41,7 @@ module Invidious::Routes::API::V1::Misc
         str << value << "\n"
       end
 
-      Metrics::REQUEST_DURATION_SECONDS_SUMS.each do |metric_labels, value|
+      Metrics::RouteMetricsCollector.request_duration_seconds_sums.each do |metric_labels, value|
         str << "http_request_duration_seconds_sum{"
         str << "method=\"" << metric_labels.request_method << "\" "
         str << "route=\"" << metric_labels.request_route << "\" "

--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -29,6 +29,11 @@ module Invidious::Routes::API::V1::Misc
   end
 
   def self.metrics(env)
+    if !CONFIG.statistics_enabled
+      env.response.status_code = 204
+      return
+    end
+
     env.response.content_type = "text/plain"
 
     return String.build do |str|

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -311,6 +311,7 @@ module Invidious::Routing
       # Misc
       get "/api/v1/stats", {{namespace}}::Misc, :stats
       if CONFIG.statistics_enabled
+        add_handler Metrics::METRICS_COLLECTOR
         get "/api/v1/metrics", {{namespace}}::Misc, :metrics
       end
       get "/api/v1/playlists/:plid", {{namespace}}::Misc, :get_playlist

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -310,6 +310,9 @@ module Invidious::Routing
 
       # Misc
       get "/api/v1/stats", {{namespace}}::Misc, :stats
+      if CONFIG.statistics_enabled
+        get "/api/v1/metrics", {{namespace}}::Misc, :metrics
+      end
       get "/api/v1/playlists/:plid", {{namespace}}::Misc, :get_playlist
       get "/api/v1/auth/playlists/:plid", {{namespace}}::Misc, :get_playlist
       get "/api/v1/mixes/:rdid", {{namespace}}::Misc, :mixes

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -310,13 +310,7 @@ module Invidious::Routing
 
       # Misc
       get "/api/v1/stats", {{namespace}}::Misc, :stats
-      if CONFIG.statistics_enabled
-        get "/api/v1/metrics", {{namespace}}::Misc, :metrics
-      else
-        get "/api/v1/metrics" do |env|
-          env.response.status_code = 204
-        end
-      end
+      get "/api/v1/metrics", {{namespace}}::Misc, :metrics
       get "/api/v1/playlists/:plid", {{namespace}}::Misc, :get_playlist
       get "/api/v1/auth/playlists/:plid", {{namespace}}::Misc, :get_playlist
       get "/api/v1/mixes/:rdid", {{namespace}}::Misc, :mixes

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -311,7 +311,6 @@ module Invidious::Routing
       # Misc
       get "/api/v1/stats", {{namespace}}::Misc, :stats
       if CONFIG.statistics_enabled
-        add_handler Metrics::METRICS_COLLECTOR
         get "/api/v1/metrics", {{namespace}}::Misc, :metrics
       end
       get "/api/v1/playlists/:plid", {{namespace}}::Misc, :get_playlist

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -312,6 +312,10 @@ module Invidious::Routing
       get "/api/v1/stats", {{namespace}}::Misc, :stats
       if CONFIG.statistics_enabled
         get "/api/v1/metrics", {{namespace}}::Misc, :metrics
+      else
+        get "/api/v1/metrics" do |env|
+          env.response.status_code = 204
+        end
       end
       get "/api/v1/playlists/:plid", {{namespace}}::Misc, :get_playlist
       get "/api/v1/auth/playlists/:plid", {{namespace}}::Misc, :get_playlist


### PR DESCRIPTION
Hello,

Please note that this MR is purely a suggestion for a feature. If you don't think that such a feature is needed, feel free to close it :)

---

This MR adds a prometheus-compatible `/api/v1/metrics` endpoint, which serves the subset of metrics (only numeric ones) contained in the `/api/v1/stats`, but in [Prometheus](https://prometheus.io/)-compatible format. The endpoint will only work if `statistics_enabled: true` in the configuration.

## Motivation

Having a prometheus-compatible endpoint could make it easier for instance maintainers to monitor their instance. I can only speak for myself, but I've found Prometheus to be quite useful both for monitoring and for setting alerts when one of my services goes down. There's not much useful information contained in the metrics added by this MR, however I can imagine that more useful metrics could be extracted from invidious. Unfortunately, I'm not familiar with the project's code at the moment, so I'm trying to take small steps here :)

## Possible paths for further development

1. Extracting more useful metrics. If you know any places in the code that could emit metrics that would be useful for instance maintaners, please point me there :smile:
2. Separate configuration option for enabling the metrics, instead of relying on `statistics_enabled`
3. Serving the metrics on a separate port and address, so it can be isolated to a network only accessible for the instance maintainer.

