### PR TITLE
Update chart.lock

### DIFF
--- a/kubernetes/Chart.lock
+++ b/kubernetes/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami/
-  version: 11.1.3
-digest: sha256:79061645472b6fb342d45e8e5b3aacd018ef5067193e46a060bccdc99fe7f6e1
-generated: "2022-03-02T05:57:20.081432389+13:00"
+  version: 12.1.9
+digest: sha256:71ff342a6c0a98bece3d7fe199983afb2113f8db65a3e3819de875af2c45add7
+generated: "2023-01-20T20:42:32.757707004Z"


### PR DESCRIPTION
The chart.lock file wasn't updated when the postgresql chart depedency version was updated so the chart isn't working.

`helm dependency update` needs to be ran when updating the chart.

Alternatively, renovate could be used to automate this. See example: https://github.com/hippogriffin/invidious/pull/6/files

Example renovate config that updates all dependencies: https://github.com/hippogriffin/invidious/blob/master/renovate.json