### PR TITLE
Auth: Add username to token callback

### DIFF
--- a/src/invidious/routes/account.cr
+++ b/src/invidious/routes/account.cr
@@ -262,6 +262,7 @@ module Invidious::Routes::Account
       end
 
       query["token"] = access_token
+      query["username"] = user.email
       url.query = query.to_s
 
       env.redirect url.to_s


### PR DESCRIPTION
When getting a token to a 3rd party, we need to at least the username to display it to the user (so they can logout if this is not their profile)
This adds the username to the callback.