### PR TITLE
API: add authorVerified where possible + provide channel tabs list

### DIFF
--- a/src/invidious/helpers/serialized_yt_data.cr
+++ b/src/invidious/helpers/serialized_yt_data.cr
@@ -74,6 +74,7 @@ struct SearchVideo
       json.field "author", self.author
       json.field "authorId", self.ucid
       json.field "authorUrl", "/channel/#{self.ucid}"
+      json.field "authorVerified", self.author_verified
 
       json.field "videoThumbnails" do
         Invidious::JSONify::APIv1.thumbnails(json, self.id)

--- a/src/invidious/routes/api/v1/channels.cr
+++ b/src/invidious/routes/api/v1/channels.cr
@@ -89,6 +89,8 @@ module Invidious::Routes::API::V1::Channels
         json.field "descriptionHtml", channel.description_html
 
         json.field "allowedRegions", channel.allowed_regions
+        json.field "tabs", channel.tabs
+        json.field "authorVerified", channel.verified
 
         json.field "latestVideos" do
           json.array do


### PR DESCRIPTION
Most endpoints should now return if the author is verified (I think playlist is missing it but there isn't any parsing for it on the web side so I did not implement it). 
https://github.com/iv-org/invidious/issues/3323

The channel endpoint also noe returns the tabs available which can be useful for third party clients.

I also noticed that comments have a 'verified' instead of 'authorVerified' property so it might be worth changing that for consistency.