### PR TITLE
YT Comments: parse isPinned and strikethroughs

### DIFF
--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -181,6 +181,8 @@ def fetch_youtube_comments(id, cursor, format, locale, thin_mode, region, sort_b
               json.field "content", html_to_content(content_html)
               json.field "contentHtml", content_html
 
+              json.field "isPinned", (node_comment["pinnedCommentBadge"]? != nil)
+
               json.field "published", published.to_unix
               json.field "publishedText", translate(locale, "`x` ago", recode_date(published, locale))
 
@@ -670,6 +672,7 @@ def content_to_comment_html(content, video_id : String? = "")
     end
 
     text = "<b>#{text}</b>" if run["bold"]?
+    text = "<s>#{text}</s>" if run["strikethrough"]?
     text = "<i>#{text}</i>" if run["italics"]?
 
     text

--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -181,7 +181,7 @@ def fetch_youtube_comments(id, cursor, format, locale, thin_mode, region, sort_b
               json.field "content", html_to_content(content_html)
               json.field "contentHtml", content_html
 
-              json.field "isPinned", (node_comment["pinnedCommentBadge"]? != nil)
+              json.field "isPinned", (node_comment["pinnedCommentBadge"]?.try(&.as_bool) == true)
 
               json.field "published", published.to_unix
               json.field "publishedText", translate(locale, "`x` ago", recode_date(published, locale))


### PR DESCRIPTION
I only added api support for isPinned but strikethroughs can be displayed in Invidious with this PR:

Before:
![image](https://user-images.githubusercontent.com/78101139/217418790-d672e59f-4bc4-4b02-8ef2-2ccb0e28f932.png)

After:
![image](https://user-images.githubusercontent.com/78101139/217418613-23502e14-b950-4882-aacb-8c51e8c0a5e3.png)

YouTube:
![image](https://user-images.githubusercontent.com/78101139/217418885-521ec482-adcd-4a5c-8374-02e9f7f4f535.png)

Link to comment: https://www.youtube.com/watch?v=OqiXFXlYFi8&lc=UgxpIdc1QlWErEUhbkZ4AaABAg