### PR TITLE
YT Comments: Revert "isPinned" to a nil check

### DIFF
--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -181,7 +181,7 @@ def fetch_youtube_comments(id, cursor, format, locale, thin_mode, region, sort_b
               json.field "content", html_to_content(content_html)
               json.field "contentHtml", content_html
 
-              json.field "isPinned", (node_comment["pinnedCommentBadge"]?.try(&.as_bool) == true)
+              json.field "isPinned", (node_comment["pinnedCommentBadge"]? != nil)
 
               json.field "published", published.to_unix
               json.field "publishedText", translate(locale, "`x` ago", recode_date(published, locale))


### PR DESCRIPTION
"pinnedCommentBadge" is not a boolean, but a complex structure.

This commit fixes a wrong assumption I had during the rewiew of https://github.com/iv-org/invidious/pull/3626