### PR TITLE
Allow to set a label for exempting from staling

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,4 +23,4 @@ jobs:
         stale-pr-label: "stale"
         ascending: true
         # Never mark feature requests/enhancements as stale
-        exempt-issue-labels: "feature-request,enhancement"
+        exempt-issue-labels: "feature-request,enhancement,exempt-stale"


### PR DESCRIPTION
I'll squash the PR in order to not have a strange commit name, just too lazy to update it through the cmd.