### PR TITLE
Add ability to add proxy domains via ENV

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -98,6 +98,22 @@ db:
 domain:
 
 ##
+## A list of domains where external proxy servers. This is used
+## to build the urls used for proxing videos.
+## When none is set invidious will be used for proxiying.
+## This generally only needs to be set for bigger instances,
+## a example proxy url would be like ['proxy.example.com'].
+## Using a list urls might look like this:
+## ['proxy-eu1.example.com','proxy-eu2.example.com']
+## Invidious would then choose at random which request gets one
+## of the proxy servers
+##
+## Accepted values: a list of fully qualified domain names (FQDN)
+## Default: [""]
+##
+proxy_domains: [""]
+
+##
 ## Tell Invidious that it is behind a proxy that provides only
 ## HTTPS, so all links must use the https:// scheme. This
 ## setting MUST be set to true if invidious is behind a

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -88,6 +88,8 @@ class Config
   property hmac_key : String?
   # Domain to be used for links to resources on the site where an absolute URL is required
   property domain : String?
+  # Domain list of external proxy servers to be used, when multiple are set they will be randomly choosen
+  property proxy_domains : Array(String) = [] of String
   # Subscribe to channels using PubSubHubbub (requires domain, hmac_key)
   property use_pubsub_feeds : Bool | Int32 = false
   property popular_enabled : Bool = true

--- a/src/invidious/routes/api/manifest.cr
+++ b/src/invidious/routes/api/manifest.cr
@@ -7,6 +7,11 @@ module Invidious::Routes::API::Manifest
     local = env.params.query["local"]?.try &.== "true"
     id = env.params.url["id"]
     region = env.params.query["region"]?
+    proxy_url = HOST_URL
+
+    if CONFIG.proxy_domains.size > 0 && local
+      proxy_url = ("https:///" + CONFIG.proxy_domains.[Random.rand(CONFIG.proxy_domains.size)])
+    end
 
     # Since some implementations create playlists based on resolution regardless of different codecs,
     # we can opt to only add a source to a representation if it has a unique height within that representation
@@ -29,7 +34,7 @@ module Invidious::Routes::API::Manifest
 
         if local
           uri = URI.parse(url)
-          url = "#{HOST_URL}#{uri.request_target}host/#{uri.host}/"
+          url = "#{proxy_url}#{uri.request_target}host/#{uri.host}/"
         end
 
         "<BaseURL>#{url}</BaseURL>"
@@ -42,7 +47,7 @@ module Invidious::Routes::API::Manifest
 
     if local
       adaptive_fmts.each do |fmt|
-        fmt["url"] = JSON::Any.new("#{HOST_URL}#{URI.parse(fmt["url"].as_s).request_target}")
+        fmt["url"] = JSON::Any.new("#{proxy_url}#{URI.parse(fmt["url"].as_s).request_target}")
       end
     end
 
@@ -164,6 +169,11 @@ module Invidious::Routes::API::Manifest
     end
 
     local = env.params.query["local"]?.try &.== "true"
+    proxy_url = HOST_URL
+
+    if CONFIG.proxy_domains.size > 0 && local
+      proxy_url = ("https:///" + CONFIG.proxy_domains.[Random.rand(CONFIG.proxy_domains.size)])
+    end
 
     env.response.content_type = "application/x-mpegURL"
     env.response.headers.add("Access-Control-Allow-Origin", "*")
@@ -203,7 +213,7 @@ module Invidious::Routes::API::Manifest
 
         raw_params["local"] = "true"
 
-        "#{HOST_URL}/videoplayback?#{raw_params}"
+        "#{proxy_url}/videoplayback?#{raw_params}"
       end
     end
 
@@ -219,6 +229,11 @@ module Invidious::Routes::API::Manifest
     end
 
     local = env.params.query["local"]?.try &.== "true"
+    proxy_url = HOST_URL
+
+    if CONFIG.proxy_domains.size > 0 && local
+      proxy_url = ("https:///" + CONFIG.proxy_domains.[Random.rand(CONFIG.proxy_domains.size)])
+    end
 
     env.response.content_type = "application/x-mpegURL"
     env.response.headers.add("Access-Control-Allow-Origin", "*")
@@ -226,7 +241,7 @@ module Invidious::Routes::API::Manifest
     manifest = response.body
 
     if local
-      manifest = manifest.gsub("https://www.youtube.com", HOST_URL)
+      manifest = manifest.gsub("https://www.youtube.com", proxy_url)
       manifest = manifest.gsub("index.m3u8", "index.m3u8?local=true")
     end
 

--- a/src/invidious/routes/video_playback.cr
+++ b/src/invidious/routes/video_playback.cr
@@ -262,6 +262,11 @@ module Invidious::Routes::VideoPlayback
 
     region = env.params.query["region"]?
     local = (env.params.query["local"]? == "true")
+    proxy_url = HOST_URL
+
+    if CONFIG.proxy_domains.size > 0 && local
+      proxy_url = ("https:///" + CONFIG.proxy_domains.[Random.rand(CONFIG.proxy_domains.size)])
+    end
 
     title = env.params.query["title"]?
 
@@ -285,7 +290,7 @@ module Invidious::Routes::VideoPlayback
     end
 
     if local
-      url = URI.parse(url).request_target.not_nil!
+      url = proxy_url + URI.parse(url).request_target.not_nil!
       url += "&title=#{URI.encode_www_form(title, space_to_plus: false)}" if title
     end
 

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -129,8 +129,14 @@ module Invidious::Routes::Watch
     adaptive_fmts = video.adaptive_fmts
 
     if params.local
-      fmt_stream.each { |fmt| fmt["url"] = JSON::Any.new(URI.parse(fmt["url"].as_s).request_target) }
-      adaptive_fmts.each { |fmt| fmt["url"] = JSON::Any.new(URI.parse(fmt["url"].as_s).request_target) }
+      proxy_url = HOST_URL
+
+      if CONFIG.proxy_domains.size > 0 && params.local
+        proxy_url = ("https:///" + CONFIG.proxy_domains.[Random.rand(CONFIG.proxy_domains.size)])
+      end
+
+      fmt_stream.each { |fmt| fmt["url"] = JSON::Any.new(proxy_url + URI.parse(fmt["url"].as_s).request_target) }
+      adaptive_fmts.each { |fmt| fmt["url"] = JSON::Any.new(proxy_url + URI.parse(fmt["url"].as_s).request_target) }
     end
 
     video_streams = video.video_streams


### PR DESCRIPTION
This PR adds the ability to add a list of proxy domains used for proxying videos, the domain is randomly chosen. If no domains are configured the `HOST_URL` is used.
The domains can be configured using in either the config.yaml or ENV
`proxy_domains: ["..","...",".."]`

Also this implementation assumes https to be available on the proxy domains.