### PR TITLE
docker-compose fix default port

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,6 @@
+version: "3"
+
+services:
+  invidious:
+    ports:
+      - "127.0.0.1:3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       context: .
       dockerfile: docker/Dockerfile
     restart: unless-stopped
-    ports:
-      - "127.0.0.1:3000:3000"
+    expose:
+      - "3000"
     environment:
       # Please read the following file for a comprehensive list of all available
       # configuration options and their associated syntax:


### PR DESCRIPTION
The default port is a very common and conflicts easily with services on the server.
Offering to serve it in a override.yml file allows the user to have an easy access to it while still permitting flexibility to the host.