### PR TITLE
Fix description boxes smaller than 3 lines

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -515,7 +515,7 @@ hr {
 
 #descexpansionbutton ~ div {
   overflow: hidden;
-  height: 8.3em;
+  max-height: 8.3em;
 }
 
 #descexpansionbutton:checked ~ div {


### PR DESCRIPTION
If a video has no description, (without this commit) the description box will still take up 8.3em, even if there's no content in it.

This PR fixes that issue.