### PR TITLE
API: Add hashtag endpoint

### DIFF
--- a/src/invidious/routes/api/v1/search.cr
+++ b/src/invidious/routes/api/v1/search.cr
@@ -59,10 +59,8 @@ module Invidious::Routes::API::V1::Search
   def self.hashtag(env)
     hashtag = env.params.url["hashtag"]
 
-    # page does not change anything.
-    # page = env.params.query["page"]?.try &.to_i?|| 1
+    page = env.params.query["page"]?.try &.to_i? || 1
 
-    page = 1
     locale = env.get("preferences").as(Preferences).locale
     region = env.params.query["region"]?
     env.response.content_type = "application/json"

--- a/src/invidious/routes/api/v1/search.cr
+++ b/src/invidious/routes/api/v1/search.cr
@@ -55,4 +55,34 @@ module Invidious::Routes::API::V1::Search
       return error_json(500, ex)
     end
   end
+
+  def self.hashtag(env)
+    hashtag = env.params.url["hashtag"]
+
+    # page does not change anything.
+    # page = env.params.query["page"]?.try &.to_i?|| 1
+
+    page = 1
+    locale = env.get("preferences").as(Preferences).locale
+    region = env.params.query["region"]?
+    env.response.content_type = "application/json"
+
+    begin
+      results = Invidious::Hashtag.fetch(hashtag, page, region)
+    rescue ex
+      return error_json(400, ex)
+    end
+
+    JSON.build do |json|
+      json.object do
+        json.field "results" do
+          json.array do
+            results.each do |item|
+              item.to_json(locale, json)
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -243,6 +243,7 @@ module Invidious::Routing
       # Search
       get "/api/v1/search", {{namespace}}::Search, :search
       get "/api/v1/search/suggestions", {{namespace}}::Search, :search_suggestions
+      get "/api/v1/hashtag/:hashtag", {{namespace}}::Search, :hashtag
 
       # Authenticated
 


### PR DESCRIPTION
This PR will allow the hashtag endpoint to be parsed.

Example request:
`/api/v1/hashtag/hi`
Example response
![image](https://user-images.githubusercontent.com/78101139/226800508-c2ef5e4b-12b0-48df-842c-6d10527be1be.png)

Note:
I did not add support for pagination in the api as it seems to be broken when using the UI.

Example (page 1):
![image](https://user-images.githubusercontent.com/78101139/226782148-5892a147-a063-4d36-b08b-7d6e4fbfce93.png)

Example (page 2):
![image](https://user-images.githubusercontent.com/78101139/226782248-1c18cb4d-3256-4dc1-8b56-d34742d5548a.png)
