### PR TITLE
Add the docs folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/doc/
+/docs/
 /dev/
 /lib/
 /bin/


### PR DESCRIPTION
Hey!

While hacking on `Invidious`, I've noticed that the `docs` folder generated by `crystal doc` is not being gitignored. I found the line `/doc/` in the `.gitignore` file, so I suppose its a typo. This MR fixes that typo :)