### PR TITLE
Search: Fix channel search

### DIFF
--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -18,6 +18,7 @@ private ITEM_PARSERS = {
   Parsers::CategoryRendererParser,
   Parsers::RichItemRendererParser,
   Parsers::ReelItemRendererParser,
+  Parsers::ItemSectionRendererParser,
   Parsers::ContinuationItemRendererParser,
 }
 
@@ -370,6 +371,30 @@ private module Parsers
         url:              url,
         badges:           badges,
       })
+    end
+
+    def self.parser_name
+      return {{@type.name}}
+    end
+  end
+
+  # Parses an InnerTube itemSectionRenderer into a SearchVideo.
+  # Returns nil when the given object isn't a ItemSectionRenderer
+  #
+  # A itemSectionRenderer seems to be a simple wrapper for a videoRenderer, used
+  # by the result page for channel searches. It is located inside a continuationItems
+  # container.It is very similar to RichItemRendererParser
+  #
+  module ItemSectionRendererParser
+    def self.process(item : JSON::Any, author_fallback : AuthorFallback)
+      if item_contents = item.dig?("itemSectionRenderer", "contents", 0)
+        return self.parse(item_contents, author_fallback)
+      end
+    end
+
+    private def self.parse(item_contents, author_fallback)
+      child = VideoRendererParser.process(item_contents, author_fallback)
+      return child
     end
 
     def self.parser_name


### PR DESCRIPTION
Parses ItemSectionRenderer to fix channel search
closes https://github.com/iv-org/invidious/issues/3594

# Test
1) In the Invidious search bar, search `channel:UCHqwzhcFOsoFFh33Uy8rAgQ antenna`
![image](https://user-images.githubusercontent.com/78101139/226779664-56c7be9b-8d3f-461c-b175-93088ff88142.png)
(notice that it now only says antenna in the search bar)

<details>
<summary>Urls</summary>

`/search?q=antenna&channel=UCHqwzhcFOsoFFh33Uy8rAgQ?page=1`
`/api/v1/channels/UCHqwzhcFOsoFFh33Uy8rAgQ/search?q=antenna?page=1`
</details>

2) click next page
![image](https://user-images.githubusercontent.com/78101139/226779718-b93c9e58-b3b2-4598-a9ad-ab7850ca52d6.png)
different results are shown

<details>
<summary>Urls</summary>

`/search?q=antenna&channel=UCHqwzhcFOsoFFh33Uy8rAgQ&page=2`
`/api/v1/channels/UCHqwzhcFOsoFFh33Uy8rAgQ/search?q=antenna&page=2`
</details>