### PR TITLE
Videos: ignore empty music entries

### DIFF
--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -330,7 +330,10 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
     # Used when the video has multiple songs
     if song_title = music_desc.dig?("carouselLockupRenderer", "videoLockup", "compactVideoRenderer", "title")
       # "simpleText" for plain text / "runs" when song has a link
-      song = song_title["simpleText"]? || song_title.dig("runs", 0, "text")
+      song = song_title["simpleText"]? || song_title.dig?("runs", 0, "text")
+
+      # some videos can have empty tracks. See: https://www.youtube.com/watch?v=eBGIQ7ZuuiU
+      next if !song
     end
 
     music_desc.dig?("carouselLockupRenderer", "infoRows").try &.as_a.each do |desc|


### PR DESCRIPTION
There is an empty music track in the video provided in the issue (https://www.youtube.com/watch?v=eBGIQ7ZuuiU)
This causes an error to occur that prevents the page from rendering.
This PR will exclude the missing track from being parsed.

YouTube screenshot for context:
![empty track followed by the correct "Never gonna give you up" track](https://user-images.githubusercontent.com/78101139/228109255-666171c3-cb5b-4b06-8f0a-dbd20ffb4526.png)

closes https://github.com/iv-org/invidious/issues/3706
