### PR TITLE
quick fix for channel videos page bug

### DIFF
--- a/src/invidious/channels/videos.cr
+++ b/src/invidious/channels/videos.cr
@@ -30,7 +30,9 @@ def produce_channel_videos_continuation(ucid, page = 1, auto_generated = nil, so
         "15:embedded" => {
           "1:embedded" => {
             "1:string" => object_inner_2_encoded,
-            "2:string" => "00000000-0000-0000-0000-000000000000",
+          },
+          "2:embedded" => {
+            "1:string" => "00000000-0000-0000-0000-000000000000",
           },
           "3:varint" => sort_by_numerical,
         },

--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -773,6 +773,7 @@ end
 def extract_items(initial_data : InitialData, &block)
   if unpackaged_data = initial_data["contents"]?.try &.as_h
   elsif unpackaged_data = initial_data["response"]?.try &.as_h
+  elsif unpackaged_data = initial_data.dig?("onResponseReceivedActions", 1).try &.as_h
   elsif unpackaged_data = initial_data.dig?("onResponseReceivedActions", 0).try &.as_h
   else
     unpackaged_data = initial_data


### PR DESCRIPTION
- the protobuf position for possibly the `targetId` changed

before:
```
110 {
  3 {
    15 {
      1 {
        2: "00000000-0000-0000-0000-000000000000"
      }
      3: 1
    }
  }
}
```

after:
```
110 {
  3 {
    15 {
      2 {
        1: "00000000-0000-0000-0000-000000000000"
      }
      3: 1
    }
  }
}
```

- the real content continuationItems is situated inside the second item from the onResponseReceivedActions, I'm kinda lazy to write some code right now for instead looping over the array:

before:
```json
"onResponseReceivedActions":[
   {
      "clickTrackingParams":"CAAQhGciEwjtwIfN8Yb-AhVMyUkHHfV8DK0=",
      "reloadContinuationItemsCommand":{
         //// the actual content
      }
   }
]
```

after:
```json
"onResponseReceivedActions":[
   {
      "clickTrackingParams":"CAAQhGciEwjtwIfN8Yb-AhVMyUkHHfV8DK0=",
      "reloadContinuationItemsCommand":{
         
      }
   },
   {
      "clickTrackingParams":"CAAQhGciEwjtwIfN8Yb-AhVMyUkHHfV8DK0=",
      "reloadContinuationItemsCommand":{
         //// the actual content
      }
   }
]
```

fixes #3717