### PR TITLE
Search: Allow browser suggestions

### DIFF
--- a/src/invidious/views/components/search_box.ecr
+++ b/src/invidious/views/components/search_box.ecr
@@ -1,6 +1,6 @@
 <form class="pure-form" action="/search" method="get">
 	<fieldset>
-		<input type="search" id="searchbox" autocomplete="off" autocorrect="off"
+		<input type="search" id="searchbox" autocorrect="off"
 		autocapitalize="none" spellcheck="false" <% if autofocus %>autofocus<% end %>
 		name="q" placeholder="<%= translate(locale, "search") %>"
 		title="<%= translate(locale, "search") %>"


### PR DESCRIPTION
`autocomplete=off` prevents the browser from suggesting previous searches. This PR removes this attribute.

Of course this does not suggests searches previously done on other devices / browsers, but suggestions from local search history are still very helpful, especially on touchscreens / small devices like phones where typing can be tedious, especially since autocorrect is disabled on this field. 

I have been using this for a couple weeks on Desktop Firefox on Linux (laptop and PinePhone) without seeing negative effects from this.

See #3704