### PR TITLE
Channels: Fix index out of bounds error

### DIFF
--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -604,7 +604,7 @@ def text_to_parsed_content(text : String) : JSON::Any
       currentNode = {"text" => urlMatch[0], "navigationEndpoint" => {"urlEndpoint" => {"url" => urlMatch[0]}}}
       currentNodes << (JSON.parse(currentNode.to_json))
       # If text remain after match create new simple node with text after match
-      afterNode = {"text" => splittedLastNode.size > 0 ? splittedLastNode[1] : ""}
+      afterNode = {"text" => splittedLastNode.size > 1 ? splittedLastNode[1] : ""}
       currentNodes << (JSON.parse(afterNode.to_json))
     end
 


### PR DESCRIPTION
This error happens when the about section ends with a link, it probably also happens in comments as well.

Closes https://github.com/iv-org/invidious/issues/3413
Closes https://github.com/iv-org/invidious/issues/3270

Invidious:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/78101139/231319446-40230187-c8d4-4579-9c6f-f4e7b05143dc.png">

YouTube:
<img width="532" alt="image" src="https://user-images.githubusercontent.com/78101139/231319482-4d560481-ed15-420b-b40f-60a82b553f0f.png">
