### PR TITLE
Added support for import and export of youtube playlists

### DIFF
--- a/src/invidious/user/exports.cr
+++ b/src/invidious/user/exports.cr
@@ -35,6 +35,8 @@ struct Invidious::User
                 json.object do
                   json.field "title", playlist.title
                   json.field "id", playlist.id
+                  json.field "video_count", playlist.video_count
+                  json.field "updated", playlist.updated
                 end
               end
             end

--- a/src/invidious/user/exports.cr
+++ b/src/invidious/user/exports.cr
@@ -4,6 +4,7 @@ struct Invidious::User
 
     def to_invidious(user : User)
       playlists = Invidious::Database::Playlists.select_like_iv(user.email)
+      youtube_playlists = Invidious::Database::Playlists.select_not_like_iv(user.email)
 
       return JSON.build do |json|
         json.object do
@@ -24,6 +25,16 @@ struct Invidious::User
                       end
                     end
                   end
+                end
+              end
+            end
+          end
+          json.field "youtube_playlists" do
+            json.array do
+              youtube_playlists.each do |playlist|
+                json.object do
+                  json.field "title", playlist.title
+                  json.field "id", playlist.id
                 end
               end
             end

--- a/src/invidious/user/imports.cr
+++ b/src/invidious/user/imports.cr
@@ -101,6 +101,16 @@ struct Invidious::User
           end
         end
       end
+
+      if youtube_playlists = data["youtube_playlists"]?.try &.as_a?
+        playlists.each do |item|
+          begin
+            playlist = get_playlist(item["id"])
+            subscribe_playlist(user, playlist)
+          rescue ex
+          end
+        end
+      end
     end
 
     # -------------------

--- a/src/invidious/user/imports.cr
+++ b/src/invidious/user/imports.cr
@@ -105,8 +105,7 @@ struct Invidious::User
       if youtube_playlists = data["youtube_playlists"]?.try &.as_a?
         playlists.each do |item|
           begin
-            playlist = get_playlist(item["id"])
-            subscribe_playlist(user, playlist)
+            subscribe_playlist(user, item)
           rescue ex
           end
         end


### PR DESCRIPTION
It has been bugging me that when you export and import user data it doesn't include any youtube playlists that the user is subscribed to, so every time I switch instances, I have to add my playlists by hand.

Unfortunately, I'm not a crystal expert and I don't have a working environment to test this, so some help on that regard would be appreciated.

I've added the title to the export for easier identification in case someone wants to remove some from the JSON by editing the file directly, but it can be removed either way, some input on this is also appreciated.