### PR TITLE
Community: Minor HTML/CSS fixes

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -322,6 +322,16 @@ p.video-data   { margin: 0; font-weight: bold; font-size: 80%; }
 
 
 /*
+ * Comments & community posts
+ */
+
+#comments {
+  max-width: 800px;
+  margin: auto;
+}
+
+
+/*
  * Footer
  */
 

--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -330,6 +330,20 @@ p.video-data   { margin: 0; font-weight: bold; font-size: 80%; }
   margin: auto;
 }
 
+.video-iframe-wrapper {
+  position: relative;
+  height: 0;
+  padding-bottom: 56.25%;
+}
+
+.video-iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+}
 
 /*
  * Footer

--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -372,27 +372,19 @@ def template_youtube_comments(comments, locale, thin_mode, is_replies = false)
           </div>
           END_HTML
         when "video"
-          html << <<-END_HTML
-            <div class="pure-g">
-              <div class="pure-u-1 pure-u-md-1-2">
-                <div style="position:relative;width:100%;height:0;padding-bottom:56.25%;margin-bottom:5px">
-          END_HTML
-
           if attachment["error"]?
             html << <<-END_HTML
+            <div class="pure-g video-iframe-wrapper">
               <p>#{attachment["error"]}</p>
+            </div>
             END_HTML
           else
             html << <<-END_HTML
-              <iframe id='ivplayer' style='position:absolute;width:100%;height:100%;left:0;top:0' src='/embed/#{attachment["videoId"]?}?autoplay=0' style='border:none;'></iframe>
+            <div class="pure-g video-iframe-wrapper">
+              <iframe class="video-iframe" src='/embed/#{attachment["videoId"]?}?autoplay=0'></iframe>
+            </div>
             END_HTML
           end
-
-          html << <<-END_HTML
-                </div>
-              </div>
-            </div>
-          END_HTML
         else nil # Ignore
         end
       end

--- a/src/invidious/comments.cr
+++ b/src/invidious/comments.cr
@@ -390,6 +390,7 @@ def template_youtube_comments(comments, locale, thin_mode, is_replies = false)
       end
 
       html << <<-END_HTML
+      <p>
         <span title="#{Time.unix(child["published"].as_i64).to_s(translate(locale, "%A %B %-d, %Y"))}">#{translate(locale, "`x` ago", recode_date(Time.unix(child["published"].as_i64), locale))} #{child["isEdited"] == true ? translate(locale, "(edited)") : ""}</span>
         |
       END_HTML
@@ -408,6 +409,7 @@ def template_youtube_comments(comments, locale, thin_mode, is_replies = false)
 
       html << <<-END_HTML
         <i class="icon ion-ios-thumbs-up"></i> #{number_with_separator(child["likeCount"])}
+      </p>
       END_HTML
 
       if child["creatorHeart"]?


### PR DESCRIPTION
Some minor HTML and CSS fixes:
 * Limit width of comments to about 800 CSS pixels
 * Make embedded videos look better
 * Remove some inline style
 * Wrap the "footer" (publication date + link + likes) in `<p></p>` to space it out from the content

result:
![image](https://user-images.githubusercontent.com/52980486/236641154-7faa7b4c-adde-4c09-90ba-1af9a1cdd133.png)
