### PR TITLE
Search: Parse playlists when searching a channel

### DIFF
--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -381,7 +381,7 @@ private module Parsers
   # Parses an InnerTube itemSectionRenderer into a SearchVideo.
   # Returns nil when the given object isn't a ItemSectionRenderer
   #
-  # A itemSectionRenderer seems to be a simple wrapper for a videoRenderer, used
+  # A itemSectionRenderer seems to be a simple wrapper for a videoRenderer or a playlistRenderer, used
   # by the result page for channel searches. It is located inside a continuationItems
   # container.It is very similar to RichItemRendererParser
   #
@@ -394,6 +394,8 @@ private module Parsers
 
     private def self.parse(item_contents, author_fallback)
       child = VideoRendererParser.process(item_contents, author_fallback)
+      child ||= PlaylistRendererParser.process(item_contents, author_fallback)
+
       return child
     end
 


### PR DESCRIPTION
Test Url: `/search?q=channel%3AUCXuqSBlHAE6Xw-yeJA0Tunw+ces+2017`

Before (tested with an instance):
![image](https://github.com/iv-org/invidious/assets/78101139/f20f4a02-aa46-4042-9a96-00ee25623003)

After (tested locally):
![image](https://github.com/iv-org/invidious/assets/78101139/da84bd16-2fcf-4306-8a33-e007ff12f87e)
