### PR TITLE
Playlists: Fix duplicated videos across pages

### DIFF
--- a/src/invidious/routes/playlists.cr
+++ b/src/invidious/routes/playlists.cr
@@ -410,8 +410,8 @@ module Invidious::Routes::Playlists
       return error_template(500, ex)
     end
 
-    page_count = (playlist.video_count / 100).to_i
-    page_count += 1 if (playlist.video_count % 100) > 0
+    page_count = (playlist.video_count / 200).to_i
+    page_count += 1 if (playlist.video_count % 200) > 0
 
     if page > page_count
       return env.redirect "/playlist?list=#{plid}&page=#{page_count}"
@@ -422,7 +422,7 @@ module Invidious::Routes::Playlists
     end
 
     begin
-      videos = get_playlist_videos(playlist, offset: (page - 1) * 100)
+      videos = get_playlist_videos(playlist, offset: (page - 1) * 200)
     rescue ex
       return error_template(500, "Error encountered while retrieving playlist videos.<br>#{ex.message}")
     end


### PR DESCRIPTION
When going on a playlist with multiple pages, it would refetch a lot of the videos that were in the previous page. This PR will stop that from happening in some cases.

Example playlist: https://www.youtube.com/playlist?list=PLbio2sNGiPZOu6C1XtpLKVHHsheIP2MsH

closes https://github.com/iv-org/invidious/issues/3806

From what I can tell, this won't affect video urls with playlist ids in them