### PR TITLE
Warn about hmac key deadline

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -57,8 +57,9 @@ end
 # Simple alias to make code easier to read
 alias IV = Invidious
 
-CONFIG   = Config.load
-HMAC_KEY = CONFIG.hmac_key || Random::Secure.hex(32)
+CONFIG              = Config.load
+HMAC_KEY_CONFIGURED = CONFIG.hmac_key != nil
+HMAC_KEY            = CONFIG.hmac_key || Random::Secure.hex(32)
 
 PG_DB       = DB.open CONFIG.database_url
 ARCHIVE_URL = URI.parse("https://archive.org")
@@ -229,6 +230,10 @@ Kemal.config.logger = LOGGER
 Kemal.config.host_binding = Kemal.config.host_binding != "0.0.0.0" ? Kemal.config.host_binding : CONFIG.host_binding
 Kemal.config.port = Kemal.config.port != 3000 ? Kemal.config.port : CONFIG.port
 Kemal.config.app_name = "Invidious"
+
+if !HMAC_KEY_CONFIGURED
+  LOGGER.warn("Please configure hmac_key by July 1st, see more here: https://github.com/iv-org/invidious/issues/3854")
+end
 
 # Use in kemal's production mode.
 # Users can also set the KEMAL_ENV environmental variable for this to be set automatically.

--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -111,6 +111,14 @@
                 </div>
             <% end %>
 
+            <% if env.get? "user" %>
+                <% if !HMAC_KEY_CONFIGURED && CONFIG.admins.includes? env.get("user").as(Invidious::User).email %>
+                <div class="h-box">
+                        <h3><p>Message for admin: please configure hmac_key, <a href="https://github.com/iv-org/invidious/issues/3854">see more here</a>.</p></h3>
+                    </div>
+                <% end %>
+            <% end %>
+
             <%= content %>
 
             <footer>


### PR DESCRIPTION
Related to #3854

To be removed on the 1st July and replaced with the implementation that force the hmac_key parameter.

Screenshot of the message displayed only for the administrator(s):
![image](https://github.com/iv-org/invidious/assets/4016501/0ff1a256-a1df-461d-8e57-140874a4819b)
