### PR TITLE
Comments: Don't break JavaScript when loading more

### DIFF
--- a/assets/js/watch.js
+++ b/assets/js/watch.js
@@ -282,7 +282,7 @@ function get_youtube_replies(target, load_more, load_replies) {
             if (load_more) {
                 body = body.parentNode.parentNode;
                 body.removeChild(body.lastElementChild);
-                body.innerHTML += response.contentHtml;
+                body.insertAdjacentHTML('beforeend', response.contentHtml);
             } else {
                 body.removeChild(body.lastElementChild);
 


### PR DESCRIPTION
closes https://github.com/iv-org/invidious/issues/3702

Updating the InnerHtml messes with javascript references as it refreshes the dom.

insertAdjacentHTML is functionally the same minus refreshing the dom