### PR TITLE
Comments: Fix display of youtube links

### DIFF
--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -440,7 +440,7 @@ def parse_link_endpoint(endpoint : JSON::Any, text : String, video_id : String)
       #  - https://github.com/iv-org/invidious/issues/3062
       text = %(<a href="#{url}">#{text}</a>)
     else
-      text = %(<a href="#{url}">#{reduce_uri(url)}</a>)
+      text = %(<a href="#{url}">#{reduce_uri(text)}</a>)
     end
   end
   return text


### PR DESCRIPTION
Closes #3910.

This small fix mediates #3910 as the full YouTube URL text is displayed for the mentioned channel URLs. 

See below for the before & after of API returns followed by the comment appearances. 

Cheers!

**Previously**
![Screenshot from 2023-06-12 09-39-30](https://github.com/iv-org/invidious/assets/83597346/ae33d45d-eab5-464d-9326-80af8df42052)

![Screenshot from 2023-06-12 09-52-02](https://github.com/iv-org/invidious/assets/83597346/7f821340-50e9-4a45-927b-61fdf0b70c68)

**With Fixes**
![Screenshot from 2023-06-12 09-43-15](https://github.com/iv-org/invidious/assets/83597346/0e9e0123-fa49-48e8-af4e-6d3d04cea76d)

![Screenshot from 2023-06-12 09-52-48](https://github.com/iv-org/invidious/assets/83597346/717c02ff-296b-4901-bc8b-ff48e6a82e64)

Edit: Added closes statement