### PR TITLE
Added API Authentication

### DIFF
--- a/src/invidious/database/sessions.cr
+++ b/src/invidious/database/sessions.cr
@@ -62,9 +62,9 @@ module Invidious::Database::SessionIDs
     PG_DB.query_one?(request, sid, as: String)
   end
 
-  def select_token(sid : String) : String?
+  def select_one(sid : String) : {session: String, issued: Time}
     request = <<-SQL
-      SELECT id FROM session_ids
+      SELECT id, issued FROM session_ids
       WHERE id = $1
     SQL
 

--- a/src/invidious/database/sessions.cr
+++ b/src/invidious/database/sessions.cr
@@ -68,7 +68,7 @@ module Invidious::Database::SessionIDs
       WHERE id = $1
     SQL
 
-    PG_DB.query_one?(request, sid, as: String)
+    PG_DB.query_one?(request, sid, as: {session: String, issued: Time})
   end
 
   def select_all(email : String) : Array({session: String, issued: Time})

--- a/src/invidious/database/sessions.cr
+++ b/src/invidious/database/sessions.cr
@@ -62,7 +62,7 @@ module Invidious::Database::SessionIDs
     PG_DB.query_one?(request, sid, as: String)
   end
 
-  def select_one(sid : String) : {session: String, issued: Time}
+  def select_one(sid : String) : {session: String, issued: Time}?
     request = <<-SQL
       SELECT id, issued FROM session_ids
       WHERE id = $1

--- a/src/invidious/helpers/tokens.cr
+++ b/src/invidious/helpers/tokens.cr
@@ -87,10 +87,10 @@ def validate_request(token, session, request, key, locale = nil)
 
   scopes = token["scopes"].as_a.map(&.as_s)
   scope = ""
-  if scopes.includes?("::")
-    scope = "#{request.method}::#{request.path.lchop("/api/v1/").lstrip("/")}"
-  else
+  if request.path.includes?("auth")
     scope = "#{request.method}:#{request.path.lchop("/api/v1/auth/").lstrip("/")}"
+  else
+    scope = "#{request.method}::#{request.path.lchop("/api/v1/").lstrip("/")}"
   end
   if !scopes_include_scope(scopes, scope)
     raise InfoException.new("Invalid scope")

--- a/src/invidious/helpers/tokens.cr
+++ b/src/invidious/helpers/tokens.cr
@@ -117,6 +117,7 @@ def scope_includes_scope(scope, subset)
     subset_methods, subset_endpoint = subset.split("::")
   else
     methods, endpoint = scope.split(":")
+    subset_methods, subset_endpoint = subset.split(":")
   end
   methods = methods.split(";").map(&.upcase).reject(&.empty?).sort!
   endpoint = endpoint.downcase

--- a/src/invidious/helpers/tokens.cr
+++ b/src/invidious/helpers/tokens.cr
@@ -86,11 +86,12 @@ def validate_request(token, session, request, key, locale = nil)
   end
 
   scopes = token["scopes"].as_a.map(&.as_s)
-  scope = ""
   if request.path.includes?("auth")
     scope = "#{request.method}:#{request.path.lchop("/api/v1/auth/").lstrip("/")}"
+  elsif request.path.includes?("v1")
+    scope = "#{request.method}:#{request.path.lchop("/api/v1/").lstrip("/")}"
   else
-    scope = "#{request.method}::#{request.path.lchop("/api/v1/").lstrip("/")}"
+    scope = "#{request.method}:#{request.path.lstrip("/")}"
   end
   if !scopes_include_scope(scopes, scope)
     raise InfoException.new("Invalid scope")
@@ -112,16 +113,11 @@ def validate_request(token, session, request, key, locale = nil)
 end
 
 def scope_includes_scope(scope, subset)
-  if scope.includes?("::")
-    methods, endpoint = scope.split("::")
-    subset_methods, subset_endpoint = subset.split("::")
-  else
-    methods, endpoint = scope.split(":")
-    subset_methods, subset_endpoint = subset.split(":")
-  end
+  methods, endpoint = scope.split(":")
   methods = methods.split(";").map(&.upcase).reject(&.empty?).sort!
   endpoint = endpoint.downcase
 
+  subset_methods, subset_endpoint = subset.split(":")
   subset_methods = subset_methods.split(";").map(&.upcase).sort!
   subset_endpoint = subset_endpoint.downcase
 

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -77,7 +77,7 @@ module Invidious::Routes::API::V1::Authentication
             # Fix token formatting
             formatted_tokens : Array(JSON::Any) = Array(JSON::Any).new
             captcha["tokens"].each do |tok|
-              formatted_tokens << JSON.Parse(tok)
+              formatted_tokens << JSON.parse(tok)
             end
             captcha_request = JSON.build do |json|
               json.object do

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -41,8 +41,7 @@ module Invidious::Routes::API::V1::Authentication
         password = password.byte_slice(0, 55)
         # send captcha if enabled
         if CONFIG.captcha_enabled
-          # captcha_response = nil
-          put body_json
+          captcha_response = nil
           captcha_response = CaptchaResponse.from_json(body_json)
           # begin
           # rescue ex

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -72,12 +72,15 @@ module Invidious::Routes::API::V1::Authentication
           else
             # send captcha
             captcha = Invidious::User::Captcha.generate_text(HMAC_KEY, ":register")
-            # TODO Fix the formatting of tokens when it is recieved
-            # from Captcha.generate_text
+            # Fix token formatting
+            formatted_tokens : Array(JSON::Any) = Array(JSON::Any).new
+            captcha["tokens"].each do |tok|
+              formatted_tokens << JSON.Parse(tok)
+            end
             captcha_request = JSON.build do |json|
               json.object do
                 json.field "question", captcha["question"]
-                json.field "tokens", Array(String).from_json(captcha["tokens"])
+                json.field "tokens", formatted_tokens
               end
             end
             return captcha_request

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -15,7 +15,7 @@ module Invidious::Routes::API::V1::Authentication
           if old_sid != ""
             Invidious::Database::SessionIDs.delete(sid: old_sid)
           end
-          if token = Invidious::Database::SessionIDs.select_token(sid: sid)
+          if token = Invidious::Database::SessionIDs.select_one(sid: sid)
             response = JSON.build do |json|
               json.object do
                 json.field "session", token[:session]

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -1,7 +1,7 @@
 module Invidious::Routes::API::V1::Authentication
   def self.register(env)
     env.response.content_type = "application/json"
-    body_json : String = env.request.body
+    body_json : String = env.request.body.gets_to_end
     if CONFIG.registration_enabled
       creds = nil
       begin

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -19,16 +19,35 @@ module Invidious::Routes::API::V1::Authentication
 
       if creds
         # user is registering
-        password = creds.password
         username = creds.username
-        if creds.password.empty?
-          return error_json(401, "Password cannot be empty")
-        end
-        # See https://security.stackexchange.com/a/39851
-        if creds.password.bytesize > 55
-          return error_json(400, "Password cannot be longer than 55 characters")
+        password = creds.password
+
+        if username.nil? || username.empty?
+          return error_json(401, "User ID is a required field")
         end
 
+        if password.nil? || password.empty?
+          return error_json(401, "Password is a required field")
+        end
+
+        if username.empty?
+          return error_json(401, "Username cannot be empty")
+        end
+
+        if password.empty?
+          return error_json(401, "Password cannot be empty")
+        end
+
+        if username.bytesize > 254
+          return error_json(401)
+        end
+
+        # See https://security.stackexchange.com/a/39851
+        if password.bytesize > 55
+          return error_json(401, "Password cannot be longer than 55 characters")
+        end
+
+        username = username.byte_slice(0, 254)
         password = password.byte_slice(0, 55)
 
         if CONFIG.captcha_enabled

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -83,8 +83,8 @@ module Invidious::Routes::API::V1::Authentication
           # process captcha response
           locale = env.get("preferences").as(Preferences).locale
 
-          username = creds.username.downcase
-          password = creds.password
+          username = captcha_response.username.downcase
+          password = captcha_response.password
           username = "" if username.nil?
           password = "" if password.nil?
 

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -1,7 +1,7 @@
 module Invidious::Routes::API::V1::Authentication
   def self.register(env)
     env.response.content_type = "application/json"
-    body_json : String = env.request.body || "{}"
+    body_json : String = env.request.body
     if CONFIG.registration_enabled
       creds = nil
       begin

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -1,10 +1,11 @@
 module Invidious::Routes::API::V1::Authentication
   def self.register(env)
     env.response.content_type = "application/json"
+    body_json = env.request.body || "{}"
     if CONFIG.registration_enabled
       creds = nil
       begin
-        creds = Credentials.from_json(env.request.body || "{}")
+        creds = Credentials.from_json(body_json)
       rescue
       end
       # get user info
@@ -36,7 +37,11 @@ module Invidious::Routes::API::V1::Authentication
         password = password.byte_slice(0, 55)
         # send captcha if enabled
         if CONFIG.captcha_enabled
-          captcha_response = CaptchaResponse.from_json(env.request.body || "{}")
+          captcha_response = nil
+          begin
+            captcha_response = CaptchaResponse.from_json(body_json)
+          rescue
+          end
           if captcha_response
             answer = captcha_response.answer
             tokens = captcha_response.tokens

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -60,7 +60,6 @@ module Invidious::Routes::API::V1::Authentication
             error_exception = Exception.new
             tokens.each do |tok|
               begin
-                # TO-DO fix formatting of tokens when recieved from Captcha.generate_text
                 validate_request(tok, answer, env.request, HMAC_KEY, locale)
                 found_valid_captcha = true
               rescue ex
@@ -115,7 +114,6 @@ module Invidious::Routes::API::V1::Authentication
 
   def self.api_login(env)
     env.response.content_type = "application/json"
-    # locale = env.get("preferences").as(Preferences).locale
     if !CONFIG.login_enabled
       return error_json(400, "Login has been disabled by administrator")
     else
@@ -184,5 +182,3 @@ struct CredentialsLogin
   property password : String
   property token : String
 end
-
-text = "Ryan said, \"Hello!\""

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -38,10 +38,11 @@ module Invidious::Routes::API::V1::Authentication
         # send captcha if enabled
         if CONFIG.captcha_enabled
           captcha_response = nil
-          begin
-            captcha_response = CaptchaResponse.from_json(body_json)
-          rescue
-          end
+          captcha_response = CaptchaResponse.from_json(body_json)
+          # begin
+          # rescue ex
+
+          # end
           if captcha_response
             answer = captcha_response.answer
             tokens = captcha_response.tokens

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -119,7 +119,7 @@ struct CaptchaResponse
   include YAML::Serializable
 
   property answer : String
-  property tokens : Array()
+  # property tokens : Array()
 end
 
 struct Credentials

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -55,7 +55,13 @@ module Invidious::Routes::API::V1::Authentication
             # send captcha
             captcha = Invidious::User::Captcha.generate_text(HMAC_KEY)
             # puts captcha
-            return captcha
+            response = JSON.build do |json|
+              json.object do
+                json.field "question", captcha["question"]
+                json.field "tokens", captcha["tokens"]
+              end
+            end
+            return response
           end
         end
         # create user

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -92,7 +92,7 @@ module Invidious::Routes::API::V1::Authentication
     if !CONFIG.login_enabled
       return error_json(400, "Login has been disabled by administrator")
     else
-      creds = Login.from_json(env.request.body || "{}")
+      creds = {{namespace}}::Login.from_json(env.request.body || "{}")
       user = Invidious::Database::Users.select(email: creds.username)
       old_sid = creds.token
       if user

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -11,11 +11,11 @@ module Invidious::Routes::API::V1::Authentication
         creds = nil
       end
 
-      begin
-        captcha_response = CaptchaResponse.from_json(env.request.body || "{}")
-      rescue JSON::SerializableError
-        captcha_response = nil
-      end
+      # begin
+      #   captcha_response = CaptchaResponse.from_json(env.request.body || "{}")
+      # rescue JSON::SerializableError
+      #   captcha_response = nil
+      # end
 
       if creds
         # user is registering
@@ -38,17 +38,17 @@ module Invidious::Routes::API::V1::Authentication
           return captcha
         end
       end
-      if captcha_response
-        # process captcha response
-        answer = captcha_response.answer
-        answer = answer.lstrip('0')
-        answer = OpenSSL::HMAC.hexdigest(:sha256, HMAC_KEY, answer)
-        begin
-          validate_request(tokens[0], answer, env.request, HMAC_KEY, locale)
-        rescue ex
-          return error_jsonror(400, ex)
-        end
-      end
+      # if captcha_response
+      #   # process captcha response
+      #   answer = captcha_response.answer
+      #   answer = answer.lstrip('0')
+      #   answer = OpenSSL::HMAC.hexdigest(:sha256, HMAC_KEY, answer)
+      #   begin
+      #     validate_request(, answer, env.request, HMAC_KEY, locale)
+      #   rescue ex
+      #     return error_jsonror(400, ex)
+      #   end
+      # end
       # create user if we made it past credentials and captcha
       sid = Base64.urlsafe_encode(Random::Secure.random_bytes(32))
       user, sid = create_user(sid, email, password)
@@ -119,6 +119,7 @@ struct CaptchaResponse
   include YAML::Serializable
 
   property answer : String
+  property tokens : Array()
 end
 
 struct Credentials

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -250,7 +250,18 @@ struct CaptchaResponse
   property username : String
   property password : String
   property answer : String
-  property tokens : Array(String)
+  property tokens : Array(CaptchaToken)
+end
+
+struct CaptchaToken
+  include JSON::Serializable
+  include YAML::Serializable
+
+  property session : String
+  property expire : Int64
+  property scopes : Array(String)
+  property nonce : String
+  property signature : String
 end
 
 struct Credentials

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -51,9 +51,9 @@ module Invidious::Routes::API::V1::Authentication
       # end
       # create user if we made it past credentials and captcha
       sid = Base64.urlsafe_encode(Random::Secure.random_bytes(32))
-      user, sid = create_user(sid, email, password)
+      user, sid = create_user(sid, username, password)
       Invidious::Database::Users.insert(user)
-      Invidious::Database::SessionIDs.insert(sid, email)
+      Invidious::Database::SessionIDs.insert(sid, username)
       # send user info
       if token = Invidious::Database::SessionIDs.select_one(sid: sid)
         response = JSON.build do |json|

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -20,15 +20,9 @@ module Invidious::Routes::API::V1::Authentication
       if creds
         # user is registering
         username = creds.username
+        username ||= ""
         password = creds.password
-
-        if username.nil? || username.empty?
-          return error_json(401, "User ID is a required field")
-        end
-
-        if password.nil? || password.empty?
-          return error_json(401, "Password is a required field")
-        end
+        password ||= ""
 
         if username.empty?
           return error_json(401, "Username cannot be empty")

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -83,6 +83,31 @@ module Invidious::Routes::API::V1::Authentication
           # process captcha response
           locale = env.get("preferences").as(Preferences).locale
 
+          username = creds.username.downcase
+          password = creds.password
+          username = "" if username.nil?
+          password = "" if password.nil?
+
+          if username.empty?
+            return error_json(401, "Username cannot be empty")
+          end
+
+          if password.empty?
+            return error_json(401, "Password cannot be empty")
+          end
+
+          if username.bytesize > 254
+            return error_json(401, "Username cannot be longer than 254 characters")
+          end
+
+          # See https://security.stackexchange.com/a/39851
+          if password.bytesize > 55
+            return error_json(401, "Password cannot be longer than 55 characters")
+          end
+
+          username = username.byte_slice(0, 254)
+          password = password.byte_slice(0, 55)
+
           answer = captcha_response.answer
           answer = answer.lstrip('0')
           answer = OpenSSL::HMAC.hexdigest(:sha256, HMAC_KEY, answer)

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -15,14 +15,17 @@ module Invidious::Routes::API::V1::Authentication
           if old_sid != ""
             Invidious::Database::SessionIDs.delete(sid: old_sid)
           end
-          token = Invidious::Database::SessionIDs.select_token(sid: sid)
-          response = JSON.build do |json|
-            json.object do
-              json.field "session", token[:session]
-              json.field "issued", token[:issued].to_unix
+          if token = Invidious::Database::SessionIDs.select_token(sid: sid)
+            response = JSON.build do |json|
+              json.object do
+                json.field "session", token[:session]
+                json.field "issued", token[:issued].to_unix
+              end
             end
+            return response
+          else
+            return error_json(500, "Token not found")
           end
-          return response
         else
           return error_json(401, "Wrong username or password")
         end

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -19,10 +19,10 @@ module Invidious::Routes::API::V1::Authentication
 
       if creds
         # user is registering
-        username = creds.username
-        username ||= ""
+        username = "" if username.nil?
+        username = creds.username.downcase
+        password = "" if password.nil?
         password = creds.password
-        password ||= ""
 
         if username.empty?
           return error_json(401, "Username cannot be empty")

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -11,11 +11,11 @@ module Invidious::Routes::API::V1::Authentication
       if user
         if Crypto::Bcrypt::Password.new(creds.password).verify(creds.password.byte_slice(0, 55))
           sid = Base64.urlsafe_encode(Random::Secure.random_bytes(32))
-          Invidious::Database::SessionIDs.insert(sid, creds.username)
+          Invidious::Database::SessionIDs.insert(sid: sid, email: creds.username)
           if old_sid != ""
             Invidious::Database::SessionIDs.delete(sid: old_sid)
           end
-          token = Invidious::Database::SessionIDs.select_token(sid)
+          token = Invidious::Database::SessionIDs.select_token(sid: sid)
           response = JSON.build do |json|
             json.object do
               json.field "session", token[:session]

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -1,7 +1,7 @@
 module Invidious::Routes::API::V1::Authentication
   def self.register(env)
     env.response.content_type = "application/json"
-    body_json = env.request.body || "{}"
+    body_json : String = env.request.body || "{}"
     if CONFIG.registration_enabled
       creds = nil
       begin
@@ -38,6 +38,7 @@ module Invidious::Routes::API::V1::Authentication
         # send captcha if enabled
         if CONFIG.captcha_enabled
           # captcha_response = nil
+          put body_json
           captcha_response = CaptchaResponse.from_json(body_json)
           # begin
           # rescue ex

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -1,7 +1,11 @@
 module Invidious::Routes::API::V1::Authentication
   def self.register(env)
     env.response.content_type = "application/json"
-    body_json : String = env.request.body.gets_to_end
+    body_io = env.request.body
+    body_json = "{}"
+    if body_io
+      body_json = env.request.body!.gets_to_end
+    end
     if CONFIG.registration_enabled
       creds = nil
       begin

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -69,13 +69,13 @@ module Invidious::Routes::API::V1::Authentication
             # send captcha
             captcha = Invidious::User::Captcha.generate_text(HMAC_KEY, ":register")
             # puts captcha
-            response = JSON.build do |json|
+            captcha_request = JSON.build do |json|
               json.object do
                 json.field "question", captcha["question"]
                 json.field "tokens", captcha["tokens"]
               end
             end
-            return response
+            return captcha_request
           end
         end
         # create user

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -58,6 +58,7 @@ module Invidious::Routes::API::V1::Authentication
             error_exception = Exception.new
             tokens.each do |tok|
               begin
+                # TO-DO fix formatting of tokens when recieved from Captcha.generate_text
                 validate_request(tok, answer, env.request, HMAC_KEY, locale)
                 found_valid_captcha = true
               rescue ex
@@ -71,11 +72,12 @@ module Invidious::Routes::API::V1::Authentication
           else
             # send captcha
             captcha = Invidious::User::Captcha.generate_text(HMAC_KEY, ":register")
-            # puts captcha
+            # TODO Fix the formatting of tokens when it is recieved
+            # from Captcha.generate_text
             captcha_request = JSON.build do |json|
               json.object do
                 json.field "question", captcha["question"]
-                json.field "tokens", captcha["tokens"]
+                json.field "tokens", Array(String).from_json(captcha["tokens"])
               end
             end
             return captcha_request

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -1,3 +1,5 @@
+require "json"
+
 module Invidious::Routes::API::V1::Authentication
   def self.register(env)
     env.response.content_type = "application/json"

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -51,7 +51,7 @@ module Invidious::Routes::API::V1::Authentication
             begin
               validate_request(captcha_response.tokens[0], answer, env.request, HMAC_KEY, locale)
             rescue ex
-              return error_jsonror(400, ex)
+              return error_json(400, ex)
             end
           else
             # send captcha

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -92,7 +92,7 @@ module Invidious::Routes::API::V1::Authentication
     if !CONFIG.login_enabled
       return error_json(400, "Login has been disabled by administrator")
     else
-      creds = Credentials.from_json(env.request.body || "{}")
+      creds = Login.from_json(env.request.body || "{}")
       user = Invidious::Database::Users.select(email: creds.username)
       old_sid = creds.token
       if user

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -92,7 +92,7 @@ module Invidious::Routes::API::V1::Authentication
     if !CONFIG.login_enabled
       return error_json(400, "Login has been disabled by administrator")
     else
-      creds = {{namespace}}::Login.from_json(env.request.body || "{}")
+      creds = Invidious::Routes::API::V1::Authentication::Login.from_json(env.request.body || "{}")
       user = Invidious::Database::Users.select(email: creds.username)
       old_sid = creds.token
       if user

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -92,7 +92,7 @@ module Invidious::Routes::API::V1::Authentication
     if !CONFIG.login_enabled
       return error_json(400, "Login has been disabled by administrator")
     else
-      creds = Invidious::Routes::API::V1::Authentication::Login.from_json(env.request.body || "{}")
+      creds = CredentialsLogin.from_json(env.request.body || "{}")
       user = Invidious::Database::Users.select(email: creds.username)
       old_sid = creds.token
       if user
@@ -149,7 +149,7 @@ struct Credentials
   property password : String
 end
 
-struct Login
+struct CredentialsLogin
   include JSON::Serializable
   include YAML::Serializable
 

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -126,7 +126,7 @@ module Invidious::Routes::API::V1::Authentication
           end
 
           if !found_valid_captcha
-            return error_template(500, error_exception)
+            return error_json(500, error_exception)
           end
           # create user
           sid = Base64.urlsafe_encode(Random::Secure.random_bytes(32))

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -36,7 +36,7 @@ module Invidious::Routes::API::V1::Authentication
         # send captcha if enabled
         if CONFIG.captcha_enabled
           # send captcha
-          captcha = Invidious::User::Captcha.generate_text(HMAC_KEY)
+          captcha = Invidious::User::Captcha.generate_text(HMAC_KEY, ":captcha")
           # puts captcha
           response = JSON.build do |json|
             json.object do

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -19,10 +19,10 @@ module Invidious::Routes::API::V1::Authentication
 
       if creds
         # user is registering
-        username = "" if username.nil?
         username = creds.username.downcase
-        password = "" if password.nil?
         password = creds.password
+        username = "" if username.nil?
+        password = "" if password.nil?
 
         if username.empty?
           return error_json(401, "Username cannot be empty")

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -39,7 +39,7 @@ module Invidious::Routes::API::V1::Authentication
         end
 
         if username.bytesize > 254
-          return error_json(401)
+          return error_json(401, "Username cannot be longer than 254 characters")
         end
 
         # See https://security.stackexchange.com/a/39851

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -37,7 +37,7 @@ module Invidious::Routes::API::V1::Authentication
         password = password.byte_slice(0, 55)
         # send captcha if enabled
         if CONFIG.captcha_enabled
-          captcha_response = nil
+          # captcha_response = nil
           captcha_response = CaptchaResponse.from_json(body_json)
           # begin
           # rescue ex

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -1,4 +1,74 @@
 module Invidious::Routes::API::V1::Authentication
+  def self.register(env)
+    env.response.content_type = "application/json"
+    if !CONFIG.registration_enabled
+      return error_json(400, "Registration has been disabled by administrator")
+    else
+      # check if user is registering or responding to captcha
+      begin
+        creds = Credentials.from_json(env.request.body || "{}")
+      rescue JSON::SerializableError
+        creds = nil
+      end
+
+      begin
+        captcha_response = CaptchaRespone.from_json(env.request.body || "{}")
+      rescue JSON::SerializableError
+        captcha_response = nil
+      end
+
+      if creds
+        # user is registering
+        password = creds.password
+        username = creds.username
+        if creds.password.empty?
+          return error_json(401, "Password cannot be empty")
+        end
+        # See https://security.stackexchange.com/a/39851
+        if creds.password.bytesize > 55
+          return error_json(400, "Password cannot be longer than 55 characters")
+        end
+
+        password = password.byte_slice(0, 55)
+
+        if CONFIG.captcha_enabled
+          # if captcha is enabled, send captcha
+          captcha = Invidious::User::Captcha.generate_text(HMAC_KEY)
+          # puts captcha
+          return captcha
+        end
+      end
+      if captcha_response
+        # process captcha response
+        answer = captcha_response.answer
+        answer = answer.lstrip('0')
+        answer = OpenSSL::HMAC.hexdigest(:sha256, HMAC_KEY, answer)
+        begin
+          validate_request(tokens[0], answer, env.request, HMAC_KEY, locale)
+        rescue ex
+          return error_jsonror(400, ex)
+        end
+      end
+      # create user if we made it past credentials and captcha
+      sid = Base64.urlsafe_encode(Random::Secure.random_bytes(32))
+      user, sid = create_user(sid, email, password)
+      Invidious::Database::Users.insert(user)
+      Invidious::Database::SessionIDs.insert(sid, email)
+      # send user info
+      if token = Invidious::Database::SessionIDs.select_one(sid: sid)
+        response = JSON.build do |json|
+          json.object do
+            json.field "session", token[:session]
+            json.field "issued", token[:issued].to_unix
+          end
+        end
+        return response
+      else
+        return error_json(500, "Token not found")
+      end
+    end
+  end
+
   def self.login(env)
     env.response.content_type = "application/json"
     # locale = env.get("preferences").as(Preferences).locale
@@ -42,6 +112,13 @@ module Invidious::Routes::API::V1::Authentication
     Invidious::Database::SessionIDs.delete(sid: sid)
     env.response.status_code = 200
   end
+end
+
+struct CaptchaResponse
+  include JSON::Serializable
+  include YAML::Serializable
+
+  property answer : String
 end
 
 struct Credentials

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -9,6 +9,8 @@ module Invidious::Routes::API::V1::Authentication
       end
       # get user info
       if creds
+        locale = env.get("preferences").as(Preferences).locale
+
         username = creds.username.downcase
         password = creds.password
         username = "" if username.nil?

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -73,7 +73,7 @@ module Invidious::Routes::API::V1::Authentication
             end
           else
             # send captcha
-            captcha = Invidious::User::Captcha.generate_text(HMAC_KEY, "POST::register")
+            captcha = Invidious::User::Captcha.generate_text(HMAC_KEY, ":api_register")
             # Fix token formatting
             formatted_tokens : Array(JSON::Any) = Array(JSON::Any).new
             captcha["tokens"].each do |tok|

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -111,7 +111,7 @@ module Invidious::Routes::API::V1::Authentication
           answer = Digest::MD5.hexdigest(answer.downcase.strip)
 
           if tokens.empty?
-            return error_template(500, "Erroneous CAPTCHA")
+            return error_json(500, "Erroneous CAPTCHA")
           end
 
           found_valid_captcha = false

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -43,14 +43,14 @@ module Invidious::Routes::API::V1::Authentication
           # check if user is responding to captcha
           if captcha_response
             # process captcha response
-            # answer = captcha_response.answer
-            # answer = answer.lstrip('0')
-            # answer = OpenSSL::HMAC.hexdigest(:sha256, HMAC_KEY, answer)
-            # begin
-            #  validate_request(, answer, env.request, HMAC_KEY, locale)
-            # rescue ex
-            #  return error_jsonror(400, ex)
-            # end
+            answer = captcha_response.answer
+            answer = answer.lstrip('0')
+            answer = OpenSSL::HMAC.hexdigest(:sha256, HMAC_KEY, answer)
+            begin
+              validate_request(captcha_response.tokens[0], answer, env.request, HMAC_KEY, locale)
+            rescue ex
+              return error_jsonror(400, ex)
+            end
           else
             # send captcha
             captcha = Invidious::User::Captcha.generate_text(HMAC_KEY)
@@ -144,7 +144,7 @@ struct CaptchaResponse
   property username : String
   property password : String
   property answer : String
-  # property tokens : Array()
+  property tokens : Array(String)
 end
 
 struct Credentials

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -4,7 +4,7 @@ module Invidious::Routes::API::V1::Authentication
     body_io = env.request.body
     body_json = "{}"
     if body_io
-      body_json = env.request.body!.gets_to_end
+      body_json = env.request.body.not_nil!.gets_to_end
     end
     if CONFIG.registration_enabled
       creds = nil

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -9,6 +9,7 @@ module Invidious::Routes::API::V1::Authentication
       end
       # get user info
       if creds
+        locale = env.get("preferences").as(Preferences).locale
         username = creds.username.downcase
         password = creds.password
         username = "" if username.nil?

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -36,11 +36,7 @@ module Invidious::Routes::API::V1::Authentication
         password = password.byte_slice(0, 55)
         # send captcha if enabled
         if CONFIG.captcha_enabled
-          captcha_response = nil
-          begin
-            captcha_response = CaptchaResponse.from_json(env.request.body || "{}")
-          rescue
-          end
+          captcha_response = CaptchaResponse.from_json(env.request.body || "{}")
           if captcha_response
             answer = captcha_response.answer
             tokens = captcha_response.tokens

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -64,7 +64,7 @@ module Invidious::Routes::API::V1::Authentication
             end
           else
             # send captcha
-            captcha = Invidious::User::Captcha.generate_text(HMAC_KEY, ":captcha")
+            captcha = Invidious::User::Captcha.generate_text(HMAC_KEY, ":register")
             # puts captcha
             response = JSON.build do |json|
               json.object do

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -13,7 +13,7 @@ module Invidious::Routes::API::V1::Authentication
           sid = Base64.urlsafe_encode(Random::Secure.random_bytes(32))
           Invidious::Database::SessionIDs.insert(sid, creds.username)
           if old_sid != ""
-            Invidious::Database::SessionIDs.delete(old_sid)
+            Invidious::Database::SessionIDs.delete(sid: old_sid)
           end
           token = Invidious::Database::SessionIDs.select_token(sid)
           response = JSON.build do |json|

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -250,19 +250,19 @@ struct CaptchaResponse
   property username : String
   property password : String
   property answer : String
-  property tokens : Array(CaptchaToken)
+  property tokens : Array(JSON::Any)
 end
 
-struct CaptchaToken
-  include JSON::Serializable
-  include YAML::Serializable
+# struct CaptchaToken
+#   include JSON::Serializable
+#   include YAML::Serializable
 
-  property session : String
-  property expire : Int64
-  property scopes : Array(String)
-  property nonce : String
-  property signature : String
-end
+#   property session : String
+#   property expire : Int64
+#   property scopes : Array(String)
+#   property nonce : String
+#   property signature : String
+# end
 
 struct Credentials
   include JSON::Serializable

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -10,7 +10,7 @@ module Invidious::Routes::API::V1::Authentication
       creds = nil
       begin
         creds = Credentials.from_json(body_json)
-      rescue
+      rescue JSON::SerializableError
       end
       # get user info
       if creds
@@ -42,11 +42,10 @@ module Invidious::Routes::API::V1::Authentication
         # send captcha if enabled
         if CONFIG.captcha_enabled
           captcha_response = nil
-          captcha_response = CaptchaResponse.from_json(body_json)
-          # begin
-          # rescue ex
-
-          # end
+          begin
+            captcha_response = CaptchaResponse.from_json(body_json)
+          rescue JSON::SerializableError
+          end
           if captcha_response
             answer = captcha_response.answer
             tokens = captcha_response.tokens

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -12,7 +12,7 @@ module Invidious::Routes::API::V1::Authentication
       end
 
       begin
-        captcha_response = CaptchaRespone.from_json(env.request.body || "{}")
+        captcha_response = CaptchaResponse.from_json(env.request.body || "{}")
       rescue JSON::SerializableError
         captcha_response = nil
       end

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -73,7 +73,7 @@ module Invidious::Routes::API::V1::Authentication
             end
           else
             # send captcha
-            captcha = Invidious::User::Captcha.generate_text(HMAC_KEY, ":register")
+            captcha = Invidious::User::Captcha.generate_text(HMAC_KEY, "POST::register")
             # Fix token formatting
             formatted_tokens : Array(JSON::Any) = Array(JSON::Any).new
             captcha["tokens"].each do |tok|
@@ -280,3 +280,5 @@ struct CredentialsLogin
   property password : String
   property token : String
 end
+
+text = "Ryan said, \"Hello!\""

--- a/src/invidious/routes/api/v1/authentication.cr
+++ b/src/invidious/routes/api/v1/authentication.cr
@@ -9,7 +9,7 @@ module Invidious::Routes::API::V1::Authentication
       user = Invidious::Database::Users.select(email: creds.username)
       old_sid = creds.token
       if user
-        if Crypto::Bcrypt::Password.new(creds.password).verify(creds.password.byte_slice(0, 55))
+        if Crypto::Bcrypt::Password.new(user.password.not_nil!).verify(creds.password.byte_slice(0, 55))
           sid = Base64.urlsafe_encode(Random::Secure.random_bytes(32))
           Invidious::Database::SessionIDs.insert(sid: sid, email: creds.username)
           if old_sid != ""

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -246,6 +246,7 @@ module Invidious::Routing
 
       # Authentication
       post "/api/v1/register", {{namespace}}::Authentication, :register
+      post "/api/v1/captcha", {{namespace}}::Authentication, :captcha
       post "/api/v1/login", {{namespace}}::Authentication, :login
       post "/api/v1/signout", {{namespace}}::Authentication, :signout
 

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -245,9 +245,9 @@ module Invidious::Routing
       get "/api/v1/hashtag/:hashtag", {{namespace}}::Search, :hashtag
 
       # Authentication
-      post "/api/v1/register", {{namespace}}::Authentication, :api_register
-      post "/api/v1/login", {{namespace}}::Authentication, :api_login
-      post "/api/v1/signout", {{namespace}}::Authentication, :api_signout
+      post "/api/v1/api_register", {{namespace}}::Authentication, :api_register
+      post "/api/v1/api_login", {{namespace}}::Authentication, :api_login
+      post "/api/v1/api_signout", {{namespace}}::Authentication, :api_signout
 
       # Authenticated
 

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -245,8 +245,8 @@ module Invidious::Routing
       get "/api/v1/hashtag/:hashtag", {{namespace}}::Search, :hashtag
 
       # Authentication
-      post "/api/v1/auth/login", {{namespace}}::Authentication, :login
-      post "/api/v1/auth/signout", {{namespace}}::Authentication, :signout
+      post "/api/v1/login", {{namespace}}::Authentication, :login
+      post "/api/v1/signout", {{namespace}}::Authentication, :signout
 
       # Authenticated
 

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -245,6 +245,7 @@ module Invidious::Routing
       get "/api/v1/hashtag/:hashtag", {{namespace}}::Search, :hashtag
 
       # Authentication
+      post "/api/v1/register", {{namespace}}::Authentication, :register
       post "/api/v1/login", {{namespace}}::Authentication, :login
       post "/api/v1/signout", {{namespace}}::Authentication, :signout
 

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -245,10 +245,9 @@ module Invidious::Routing
       get "/api/v1/hashtag/:hashtag", {{namespace}}::Search, :hashtag
 
       # Authentication
-      post "/api/v1/register", {{namespace}}::Authentication, :register
-      post "/api/v1/captcha", {{namespace}}::Authentication, :captcha
-      post "/api/v1/login", {{namespace}}::Authentication, :login
-      post "/api/v1/signout", {{namespace}}::Authentication, :signout
+      post "/api/v1/register", {{namespace}}::Authentication, :api_register
+      post "/api/v1/login", {{namespace}}::Authentication, :api_login
+      post "/api/v1/signout", {{namespace}}::Authentication, :api_signout
 
       # Authenticated
 

--- a/src/invidious/user/captcha.cr
+++ b/src/invidious/user/captcha.cr
@@ -61,12 +61,12 @@ struct Invidious::User
       }
     end
 
-    def generate_text(key)
+    def generate_text(key, scope = ":login")
       response = make_client(TEXTCAPTCHA_URL, &.get("/github.com/iv.org/invidious.json").body)
       response = JSON.parse(response)
 
       tokens = response["a"].as_a.map do |answer|
-        generate_response(answer.as_s, {":login"}, key, use_nonce: true)
+        generate_response(answer.as_s, {scope}, key, use_nonce: true)
       end
 
       return {


### PR DESCRIPTION
The current routes for authentication (`/register`, `/login`, and `/signout`) are not designed to handle API requests in order to authenticate. I have created the respective routes for authenticating through purely the API: `/api/v1/api_register`, `/api/v1/api_login/`, and `/api/v1/signout`. Any feed back would be appreciated. I tried to keep the general structure and methods consistent with the rest of the project, however I ran into a scope conflict when using a route like `/api/v1/register`, since these are already pointing to the front-end. I also added a few non-breaking changes to `Invidious::Helpers::Tokens.validate_request` and `Invidous::User::Captcha.generate_text` to make the authentication possible through the API.

As this is my first time ever creating a pull request, let alone touching Crystal Lang and Ruby, feel free to make changes and advice.