### PR TITLE
Fix searchbar twitch

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -237,7 +237,6 @@ div.watched-indicator {
 }
 
 .searchbar input[type="search"]:focus {
-	margin: 0;
 	border: 2px solid;
 	border-color: rgba(0,0,0,0);
 	border-bottom-color: #FED;


### PR DESCRIPTION
`input` in `searchbar` has 1px margin out of focus. When it is on focus, this line causes element resize and twitch all below this bar.