### PR TITLE
config.example.yml: Fix typo in pwgen command

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -460,7 +460,7 @@ jobs:
 ##
 ## Note: This parameter is mandatory and should be a random string.
 ## Such random string can be generated on linux with the following
-## command: `pwdgen 20 1`
+## command: `pwgen 20 1`
 ##
 ## Accepted values: a string
 ## Default: <none>


### PR DESCRIPTION
`pwdgen` -> `pwgen`.