### PR TITLE
Playlist import no refresh

### DIFF
--- a/src/invidious/user/imports.cr
+++ b/src/invidious/user/imports.cr
@@ -133,7 +133,7 @@ struct Invidious::User
             next if !video_id
 
             begin
-              video = get_video(video_id)
+              video = get_video(video_id, false)
             rescue ex
               next
             end


### PR DESCRIPTION
Playlist imports are very slow because of video refresh (imagine many playlists, with 500 videos each)
I'm wondering if refreshing all metadata is necessary here?

Please let me know if this is a bad idea.

Thanks