### PR TITLE
Channels: Use innertube to fetch the community tab

### DIFF
--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -608,19 +608,25 @@ private module Extractors
     private def self.unpack_section_list(contents)
       raw_items = [] of JSON::Any
 
-      contents.as_a.each do |renderer_container|
-        renderer_container_contents = renderer_container["itemSectionRenderer"]["contents"][0]
-
-        # Category extraction
-        if items_container = renderer_container_contents["shelfRenderer"]?
-          raw_items << renderer_container_contents
-          next
-        elsif items_container = renderer_container_contents["gridRenderer"]?
+      contents.as_a.each do |item|
+        if item_section_content = item.dig?("itemSectionRenderer", "contents")
+          raw_items += self.unpack_item_section(item_section_content)
         else
-          items_container = renderer_container_contents
+          raw_items << item
         end
+      end
 
-        items_container["items"]?.try &.as_a.each do |item|
+      return raw_items
+    end
+
+    private def self.unpack_item_section(contents)
+      raw_items = [] of JSON::Any
+
+      contents.as_a.each do |item|
+        # Category extraction
+        if container = item.dig?("gridRenderer", "items") || item.dig?("items")
+          raw_items += container.as_a
+        else
           raw_items << item
         end
       end


### PR DESCRIPTION
This was long overdue: don't rely on HTML scraping anymore, as these endpoints are rate limited. So now the community tab is extracted using innertube, and extracted using `extract_items(&)` as everything else.

The required Parser module (in `src/invidious/yt_backend/extractors.cr`) is for a future PR.