### PR TITLE
Captions: Add ability to use Innertube's transcripts API

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -187,7 +187,7 @@ https_only: false
 ##
 ## Useful for larger instances as InnerTube is **not ratelimited**. See https://github.com/iv-org/invidious/issues/2567
 ##
-## Subtitle experience may differ slightly on Invidious.  
+## Subtitle experience may differ slightly on Invidious.
 ##
 ## Accepted values: true, false
 ## Default: false

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -182,6 +182,19 @@ https_only: false
 #force_resolve:
 
 
+##
+## Use Innertube's transcripts API instead of timedtext for closed captions
+##
+## Useful for larger instances as InnerTube is **not ratelimited**. See https://github.com/iv-org/invidious/issues/2567
+##
+## Subtitle experience may differ slightly on Invidious.  
+##
+## Accepted values: true, false
+## Default: false
+##
+# use_innertube_for_captions: false
+
+
 # -----------------------------
 #  Logging
 # -----------------------------

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -129,6 +129,9 @@ class Config
   # Use quic transport for youtube api
   property use_quic : Bool = false
 
+  # Use Innertube's transcripts API instead of timedtext for closed captions
+  property use_innertube_for_captions : Bool = false
+
   # Saved cookies in "name1=value1; name2=value2..." format
   @[YAML::Field(converter: Preferences::StringToCookies)]
   property cookies : HTTP::Cookies = HTTP::Cookies.new

--- a/src/invidious/frontend/watch_page.cr
+++ b/src/invidious/frontend/watch_page.cr
@@ -7,7 +7,7 @@ module Invidious::Frontend::WatchPage
     getter full_videos : Array(Hash(String, JSON::Any))
     getter video_streams : Array(Hash(String, JSON::Any))
     getter audio_streams : Array(Hash(String, JSON::Any))
-    getter captions : Array(Invidious::Videos::CaptionMetadata)
+    getter captions : Array(Invidious::Videos::Captions::Metadata)
 
     def initialize(
       @full_videos,

--- a/src/invidious/frontend/watch_page.cr
+++ b/src/invidious/frontend/watch_page.cr
@@ -7,7 +7,7 @@ module Invidious::Frontend::WatchPage
     getter full_videos : Array(Hash(String, JSON::Any))
     getter video_streams : Array(Hash(String, JSON::Any))
     getter audio_streams : Array(Hash(String, JSON::Any))
-    getter captions : Array(Invidious::Videos::Caption)
+    getter captions : Array(Invidious::Videos::CaptionMetadata)
 
     def initialize(
       @full_videos,

--- a/src/invidious/routes/api/v1/videos.cr
+++ b/src/invidious/routes/api/v1/videos.cr
@@ -87,70 +87,78 @@ module Invidious::Routes::API::V1::Videos
       caption = caption[0]
     end
 
-    url = URI.parse("#{caption.base_url}&tlang=#{tlang}").request_target
+    if CONFIG.use_innertube_for_captions
+      params = Invidious::Videos::Transcript.generate_param(id, caption.language_code, caption.auto_generated)
+      initial_data = YoutubeAPI.transcript(params.to_s)
 
-    # Auto-generated captions often have cues that aren't aligned properly with the video,
-    # as well as some other markup that makes it cumbersome, so we try to fix that here
-    if caption.name.includes? "auto-generated"
-      caption_xml = YT_POOL.client &.get(url).body
+      webvtt = Invidious::Videos::Transcript.convert_transcripts_to_vtt(initial_data, caption.language_code)
+    else
+      # Timedtext API handling
+      url = URI.parse("#{caption.base_url}&tlang=#{tlang}").request_target
 
-      if caption_xml.starts_with?("<?xml")
-        webvtt = caption.timedtext_to_vtt(caption_xml, tlang)
-      else
-        caption_xml = XML.parse(caption_xml)
+      # Auto-generated captions often have cues that aren't aligned properly with the video,
+      # as well as some other markup that makes it cumbersome, so we try to fix that here
+      if caption.name.includes? "auto-generated"
+        caption_xml = YT_POOL.client &.get(url).body
 
-        webvtt = String.build do |str|
-          str << <<-END_VTT
-          WEBVTT
-          Kind: captions
-          Language: #{tlang || caption.language_code}
+        if caption_xml.starts_with?("<?xml")
+          webvtt = caption.timedtext_to_vtt(caption_xml, tlang)
+        else
+          caption_xml = XML.parse(caption_xml)
+
+          webvtt = String.build do |str|
+            str << <<-END_VTT
+            WEBVTT
+            Kind: captions
+            Language: #{tlang || caption.language_code}
 
 
-          END_VTT
+            END_VTT
 
-          caption_nodes = caption_xml.xpath_nodes("//transcript/text")
-          caption_nodes.each_with_index do |node, i|
-            start_time = node["start"].to_f.seconds
-            duration = node["dur"]?.try &.to_f.seconds
-            duration ||= start_time
+            caption_nodes = caption_xml.xpath_nodes("//transcript/text")
+            caption_nodes.each_with_index do |node, i|
+              start_time = node["start"].to_f.seconds
+              duration = node["dur"]?.try &.to_f.seconds
+              duration ||= start_time
 
-            if caption_nodes.size > i + 1
-              end_time = caption_nodes[i + 1]["start"].to_f.seconds
-            else
-              end_time = start_time + duration
+              if caption_nodes.size > i + 1
+                end_time = caption_nodes[i + 1]["start"].to_f.seconds
+              else
+                end_time = start_time + duration
+              end
+
+              start_time = "#{start_time.hours.to_s.rjust(2, '0')}:#{start_time.minutes.to_s.rjust(2, '0')}:#{start_time.seconds.to_s.rjust(2, '0')}.#{start_time.milliseconds.to_s.rjust(3, '0')}"
+              end_time = "#{end_time.hours.to_s.rjust(2, '0')}:#{end_time.minutes.to_s.rjust(2, '0')}:#{end_time.seconds.to_s.rjust(2, '0')}.#{end_time.milliseconds.to_s.rjust(3, '0')}"
+
+              text = HTML.unescape(node.content)
+              text = text.gsub(/<font color="#[a-fA-F0-9]{6}">/, "")
+              text = text.gsub(/<\/font>/, "")
+              if md = text.match(/(?<name>.*) : (?<text>.*)/)
+                text = "<v #{md["name"]}>#{md["text"]}</v>"
+              end
+
+              str << <<-END_CUE
+              #{start_time} --> #{end_time}
+              #{text}
+
+
+              END_CUE
             end
-
-            start_time = "#{start_time.hours.to_s.rjust(2, '0')}:#{start_time.minutes.to_s.rjust(2, '0')}:#{start_time.seconds.to_s.rjust(2, '0')}.#{start_time.milliseconds.to_s.rjust(3, '0')}"
-            end_time = "#{end_time.hours.to_s.rjust(2, '0')}:#{end_time.minutes.to_s.rjust(2, '0')}:#{end_time.seconds.to_s.rjust(2, '0')}.#{end_time.milliseconds.to_s.rjust(3, '0')}"
-
-            text = HTML.unescape(node.content)
-            text = text.gsub(/<font color="#[a-fA-F0-9]{6}">/, "")
-            text = text.gsub(/<\/font>/, "")
-            if md = text.match(/(?<name>.*) : (?<text>.*)/)
-              text = "<v #{md["name"]}>#{md["text"]}</v>"
-            end
-
-            str << <<-END_CUE
-            #{start_time} --> #{end_time}
-            #{text}
-
-
-            END_CUE
           end
         end
-      end
-    else
-      # Some captions have "align:[start/end]" and "position:[num]%"
-      # attributes. Those are causing issues with VideoJS, which is unable
-      # to properly align the captions on the video, so we remove them.
-      #
-      # See: https://github.com/iv-org/invidious/issues/2391
-      webvtt = YT_POOL.client &.get("#{url}&format=vtt").body
-      if webvtt.starts_with?("<?xml")
-        webvtt = caption.timedtext_to_vtt(webvtt)
       else
+        # Some captions have "align:[start/end]" and "position:[num]%"
+        # attributes. Those are causing issues with VideoJS, which is unable
+        # to properly align the captions on the video, so we remove them.
+        #
+        # See: https://github.com/iv-org/invidious/issues/2391
         webvtt = YT_POOL.client &.get("#{url}&format=vtt").body
-          .gsub(/([0-9:.]{12} --> [0-9:.]{12}).+/, "\\1")
+        if webvtt.starts_with?("<?xml")
+          webvtt = caption.timedtext_to_vtt(webvtt)
+        else
+          webvtt = YT_POOL.client &.get("#{url}&format=vtt").body
+            .gsub(/([0-9:.]{12} --> [0-9:.]{12}).+/, "\\1")
+        end
       end
     end
 

--- a/src/invidious/routes/api/v1/videos.cr
+++ b/src/invidious/routes/api/v1/videos.cr
@@ -89,7 +89,7 @@ module Invidious::Routes::API::V1::Videos
 
     if CONFIG.use_innertube_for_captions
       params = Invidious::Videos::Transcript.generate_param(id, caption.language_code, caption.auto_generated)
-      initial_data = YoutubeAPI.transcript(params.to_s)
+      initial_data = YoutubeAPI.get_transcript(params)
 
       webvtt = Invidious::Videos::Transcript.convert_transcripts_to_vtt(initial_data, caption.language_code)
     else

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -24,7 +24,7 @@ struct Video
   property updated : Time
 
   @[DB::Field(ignore: true)]
-  @captions = [] of Invidious::Videos::Caption
+  @captions = [] of Invidious::Videos::CaptionMetadata
 
   @[DB::Field(ignore: true)]
   property adaptive_fmts : Array(Hash(String, JSON::Any))?
@@ -215,9 +215,9 @@ struct Video
     keywords.includes? "YouTube Red"
   end
 
-  def captions : Array(Invidious::Videos::Caption)
+  def captions : Array(Invidious::Videos::CaptionMetadata)
     if @captions.empty? && @info.has_key?("captions")
-      @captions = Invidious::Videos::Caption.from_yt_json(info["captions"])
+      @captions = Invidious::Videos::CaptionMetadata.from_yt_json(info["captions"])
     end
 
     return @captions

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -24,7 +24,7 @@ struct Video
   property updated : Time
 
   @[DB::Field(ignore: true)]
-  @captions = [] of Invidious::Videos::CaptionMetadata
+  @captions = [] of Invidious::Videos::Captions::Metadata
 
   @[DB::Field(ignore: true)]
   property adaptive_fmts : Array(Hash(String, JSON::Any))?
@@ -215,9 +215,9 @@ struct Video
     keywords.includes? "YouTube Red"
   end
 
-  def captions : Array(Invidious::Videos::CaptionMetadata)
+  def captions : Array(Invidious::Videos::Captions::Metadata)
     if @captions.empty? && @info.has_key?("captions")
-      @captions = Invidious::Videos::CaptionMetadata.from_yt_json(info["captions"])
+      @captions = Invidious::Videos::Captions::Metadata.from_yt_json(info["captions"])
     end
 
     return @captions

--- a/src/invidious/videos/caption.cr
+++ b/src/invidious/videos/caption.cr
@@ -1,7 +1,7 @@
 require "json"
 
 module Invidious::Videos
-  struct Caption
+  struct CaptionMetadata
     property name : String
     property language_code : String
     property base_url : String
@@ -10,12 +10,12 @@ module Invidious::Videos
     end
 
     # Parse the JSON structure from Youtube
-    def self.from_yt_json(container : JSON::Any) : Array(Caption)
+    def self.from_yt_json(container : JSON::Any) : Array(CaptionMetadata)
       caption_tracks = container
         .dig?("playerCaptionsTracklistRenderer", "captionTracks")
         .try &.as_a
 
-      captions_list = [] of Caption
+      captions_list = [] of CaptionMetadata
       return captions_list if caption_tracks.nil?
 
       caption_tracks.each do |caption|
@@ -25,7 +25,7 @@ module Invidious::Videos
         language_code = caption["languageCode"].to_s
         base_url = caption["baseUrl"].to_s
 
-        captions_list << Caption.new(name, language_code, base_url)
+        captions_list << CaptionMetadata.new(name, language_code, base_url)
       end
 
       return captions_list

--- a/src/invidious/videos/caption.cr
+++ b/src/invidious/videos/caption.cr
@@ -1,107 +1,109 @@
 require "json"
 
 module Invidious::Videos
-  struct CaptionMetadata
-    property name : String
-    property language_code : String
-    property base_url : String
+  module Captions
+    struct Metadata
+      property name : String
+      property language_code : String
+      property base_url : String
 
-    property auto_generated : Bool
+      property auto_generated : Bool
 
-    def initialize(@name, @language_code, @base_url, @auto_generated)
-    end
-
-    # Parse the JSON structure from Youtube
-    def self.from_yt_json(container : JSON::Any) : Array(CaptionMetadata)
-      caption_tracks = container
-        .dig?("playerCaptionsTracklistRenderer", "captionTracks")
-        .try &.as_a
-
-      captions_list = [] of CaptionMetadata
-      return captions_list if caption_tracks.nil?
-
-      caption_tracks.each do |caption|
-        name = caption["name"]["simpleText"]? || caption["name"]["runs"][0]["text"]
-        name = name.to_s.split(" - ")[0]
-
-        language_code = caption["languageCode"].to_s
-        base_url = caption["baseUrl"].to_s
-
-        auto_generated = false
-        if caption["kind"]? && caption["kind"] == "asr"
-          auto_generated = true
-        end
-
-        captions_list << CaptionMetadata.new(name, language_code, base_url, auto_generated)
+      def initialize(@name, @language_code, @base_url, @auto_generated)
       end
 
-      return captions_list
-    end
+      # Parse the JSON structure from Youtube
+      def self.from_yt_json(container : JSON::Any) : Array(Captions::Metadata)
+        caption_tracks = container
+          .dig?("playerCaptionsTracklistRenderer", "captionTracks")
+          .try &.as_a
 
-    def timedtext_to_vtt(timedtext : String, tlang = nil) : String
-      # In the future, we could just directly work with the url. This is more of a POC
-      cues = [] of XML::Node
-      tree = XML.parse(timedtext)
-      tree = tree.children.first
+        captions_list = [] of Captions::Metadata
+        return captions_list if caption_tracks.nil?
 
-      tree.children.each do |item|
-        if item.name == "body"
-          item.children.each do |cue|
-            if cue.name == "p" && !(cue.children.size == 1 && cue.children[0].content == "\n")
-              cues << cue
+        caption_tracks.each do |caption|
+          name = caption["name"]["simpleText"]? || caption["name"]["runs"][0]["text"]
+          name = name.to_s.split(" - ")[0]
+
+          language_code = caption["languageCode"].to_s
+          base_url = caption["baseUrl"].to_s
+
+          auto_generated = false
+          if caption["kind"]? && caption["kind"] == "asr"
+            auto_generated = true
+          end
+
+          captions_list << Captions::Metadata.new(name, language_code, base_url, auto_generated)
+        end
+
+        return captions_list
+      end
+
+      def timedtext_to_vtt(timedtext : String, tlang = nil) : String
+        # In the future, we could just directly work with the url. This is more of a POC
+        cues = [] of XML::Node
+        tree = XML.parse(timedtext)
+        tree = tree.children.first
+
+        tree.children.each do |item|
+          if item.name == "body"
+            item.children.each do |cue|
+              if cue.name == "p" && !(cue.children.size == 1 && cue.children[0].content == "\n")
+                cues << cue
+              end
             end
+            break
           end
-          break
         end
-      end
-      result = String.build do |result|
-        result << <<-END_VTT
-        WEBVTT
-        Kind: captions
-        Language: #{tlang || @language_code}
+        result = String.build do |result|
+          result << <<-END_VTT
+          WEBVTT
+          Kind: captions
+          Language: #{tlang || @language_code}
 
 
-        END_VTT
+          END_VTT
 
-        result << "\n\n"
+          result << "\n\n"
 
-        cues.each_with_index do |node, i|
-          start_time = node["t"].to_f.milliseconds
+          cues.each_with_index do |node, i|
+            start_time = node["t"].to_f.milliseconds
 
-          duration = node["d"]?.try &.to_f.milliseconds
+            duration = node["d"]?.try &.to_f.milliseconds
 
-          duration ||= start_time
+            duration ||= start_time
 
-          if cues.size > i + 1
-            end_time = cues[i + 1]["t"].to_f.milliseconds
-          else
-            end_time = start_time + duration
+            if cues.size > i + 1
+              end_time = cues[i + 1]["t"].to_f.milliseconds
+            else
+              end_time = start_time + duration
+            end
+
+            # start_time
+            result << start_time.hours.to_s.rjust(2, '0')
+            result << ':' << start_time.minutes.to_s.rjust(2, '0')
+            result << ':' << start_time.seconds.to_s.rjust(2, '0')
+            result << '.' << start_time.milliseconds.to_s.rjust(3, '0')
+
+            result << " --> "
+
+            # end_time
+            result << end_time.hours.to_s.rjust(2, '0')
+            result << ':' << end_time.minutes.to_s.rjust(2, '0')
+            result << ':' << end_time.seconds.to_s.rjust(2, '0')
+            result << '.' << end_time.milliseconds.to_s.rjust(3, '0')
+
+            result << "\n"
+
+            node.children.each do |s|
+              result << s.content
+            end
+            result << "\n"
+            result << "\n"
           end
-
-          # start_time
-          result << start_time.hours.to_s.rjust(2, '0')
-          result << ':' << start_time.minutes.to_s.rjust(2, '0')
-          result << ':' << start_time.seconds.to_s.rjust(2, '0')
-          result << '.' << start_time.milliseconds.to_s.rjust(3, '0')
-
-          result << " --> "
-
-          # end_time
-          result << end_time.hours.to_s.rjust(2, '0')
-          result << ':' << end_time.minutes.to_s.rjust(2, '0')
-          result << ':' << end_time.seconds.to_s.rjust(2, '0')
-          result << '.' << end_time.milliseconds.to_s.rjust(3, '0')
-
-          result << "\n"
-
-          node.children.each do |s|
-            result << s.content
-          end
-          result << "\n"
-          result << "\n"
         end
+        return result
       end
-      return result
     end
 
     # List of all caption languages available on Youtube.

--- a/src/invidious/videos/caption.cr
+++ b/src/invidious/videos/caption.cr
@@ -28,10 +28,7 @@ module Invidious::Videos
           language_code = caption["languageCode"].to_s
           base_url = caption["baseUrl"].to_s
 
-          auto_generated = false
-          if caption["kind"]? && caption["kind"] == "asr"
-            auto_generated = true
-          end
+          auto_generated = (caption["kind"]? == "asr")
 
           captions_list << Captions::Metadata.new(name, language_code, base_url, auto_generated)
         end

--- a/src/invidious/videos/caption.cr
+++ b/src/invidious/videos/caption.cr
@@ -6,7 +6,9 @@ module Invidious::Videos
     property language_code : String
     property base_url : String
 
-    def initialize(@name, @language_code, @base_url)
+    property auto_generated : Bool
+
+    def initialize(@name, @language_code, @base_url, @auto_generated)
     end
 
     # Parse the JSON structure from Youtube
@@ -25,7 +27,12 @@ module Invidious::Videos
         language_code = caption["languageCode"].to_s
         base_url = caption["baseUrl"].to_s
 
-        captions_list << CaptionMetadata.new(name, language_code, base_url)
+        auto_generated = false
+        if caption["kind"]? && caption["kind"] == "asr"
+          auto_generated = true
+        end
+
+        captions_list << CaptionMetadata.new(name, language_code, base_url, auto_generated)
       end
 
       return captions_list

--- a/src/invidious/videos/transcript.cr
+++ b/src/invidious/videos/transcript.cr
@@ -1,0 +1,34 @@
+module Invidious::Videos
+  # Namespace for methods primarily relating to Transcripts
+  module Transcript
+    def self.generate_param(video_id : String, language_code : String, auto_generated : Bool) : String
+      if !auto_generated
+        is_auto_generated = ""
+      elsif is_auto_generated = "asr"
+      end
+
+      object = {
+        "1:0:string" => video_id,
+
+        "2:base64" => {
+          "1:string" => is_auto_generated,
+          "2:string" => language_code,
+          "3:string" => "",
+        },
+
+        "3:varint" => 1_i64,
+        "5:string" => "engagement-panel-searchable-transcript-search-panel",
+        "6:varint" => 1_i64,
+        "7:varint" => 1_i64,
+        "8:varint" => 1_i64,
+      }
+
+      params = object.try { |i| Protodec::Any.cast_json(i) }
+        .try { |i| Protodec::Any.from_json(i) }
+        .try { |i| Base64.urlsafe_encode(i) }
+        .try { |i| URI.encode_www_form(i) }
+
+      return params
+    end
+  end
+end

--- a/src/invidious/videos/transcript.cr
+++ b/src/invidious/videos/transcript.cr
@@ -4,16 +4,13 @@ module Invidious::Videos
     record TranscriptLine, start_ms : Time::Span, end_ms : Time::Span, line : String
 
     def self.generate_param(video_id : String, language_code : String, auto_generated : Bool) : String
-      if !auto_generated
-        is_auto_generated = ""
-      elsif is_auto_generated = "asr"
-      end
+      kind = auto_generated ? "asr" : ""
 
       object = {
         "1:0:string" => video_id,
 
         "2:base64" => {
-          "1:string" => is_auto_generated,
+          "1:string" => kind,
           "2:string" => language_code,
           "3:string" => "",
         },

--- a/src/invidious/videos/transcript.cr
+++ b/src/invidious/videos/transcript.cr
@@ -37,7 +37,7 @@ module Invidious::Videos
       # Convert into array of TranscriptLine
       lines = self.parse(initial_data)
 
-      # Taken from Invidious::Videos::CaptionMetadata.timedtext_to_vtt()
+      # Taken from Invidious::Videos::Captions::Metadata.timedtext_to_vtt()
       vtt = String.build do |vtt|
         vtt << <<-END_VTT
         WEBVTT

--- a/src/invidious/videos/transcript.cr
+++ b/src/invidious/videos/transcript.cr
@@ -1,6 +1,8 @@
 module Invidious::Videos
   # Namespace for methods primarily relating to Transcripts
   module Transcript
+    record TranscriptLine, start_ms : Time::Span, end_ms : Time::Span, line : String
+
     def self.generate_param(video_id : String, language_code : String, auto_generated : Bool) : String
       if !auto_generated
         is_auto_generated = ""
@@ -29,6 +31,41 @@ module Invidious::Videos
         .try { |i| URI.encode_www_form(i) }
 
       return params
+    end
+
+    def self.convert_transcripts_to_vtt(initial_data : JSON::Any, target_language : String) : String
+      # Convert into TranscriptLine
+
+      vtt = String.build do |vtt|
+        result << <<-END_VTT
+        WEBVTT
+        Kind: captions
+        Language: #{tlang}
+
+
+        END_VTT
+
+        vtt << "\n\n"
+      end
+    end
+
+    def self.parse(initial_data : Hash(String, JSON::Any))
+      body = initial_data.dig("actions", 0, "updateEngagementPanelAction", "content", "transcriptRenderer",
+        "content", "transcriptSearchPanelRenderer", "body", "transcriptSegmentListRenderer",
+        "initialSegments").as_a
+
+      lines = [] of TranscriptLine
+      body.each do |line|
+        line = line["transcriptSegmentRenderer"]
+        start_ms = line["startMs"].as_s.to_i.millisecond
+        end_ms = line["endMs"].as_s.to_i.millisecond
+
+        text = extract_text(line["snippet"]) || ""
+
+        lines << TranscriptLine.new(start_ms, end_ms, text)
+      end
+
+      return lines
     end
   end
 end

--- a/src/invidious/videos/transcript.cr
+++ b/src/invidious/videos/transcript.cr
@@ -85,7 +85,13 @@ module Invidious::Videos
 
       lines = [] of TranscriptLine
       body.each do |line|
+        # Transcript section headers. They are not apart of the captions and as such we can safely skip them.
+        if line.as_h.has_key?("transcriptSectionHeaderRenderer")
+          next
+        end
+
         line = line["transcriptSegmentRenderer"]
+
         start_ms = line["startMs"].as_s.to_i.millisecond
         end_ms = line["endMs"].as_s.to_i.millisecond
 

--- a/src/invidious/views/user/preferences.ecr
+++ b/src/invidious/views/user/preferences.ecr
@@ -89,7 +89,7 @@
                 <label for="captions[0]"><%= translate(locale, "preferences_captions_label") %></label>
                 <% preferences.captions.each_with_index do |caption, index| %>
                     <select class="pure-u-1-6" name="captions[<%= index %>]" id="captions[<%= index %>]">
-                        <% Invidious::Videos::CaptionMetadata::LANGUAGES.each do |option| %>
+                        <% Invidious::Videos::Captions::LANGUAGES.each do |option| %>
                             <option value="<%= option %>" <% if preferences.captions[index] == option %> selected <% end %>><%= translate(locale, option.blank? ? "none" : option) %></option>
                         <% end %>
                     </select>

--- a/src/invidious/views/user/preferences.ecr
+++ b/src/invidious/views/user/preferences.ecr
@@ -89,7 +89,7 @@
                 <label for="captions[0]"><%= translate(locale, "preferences_captions_label") %></label>
                 <% preferences.captions.each_with_index do |caption, index| %>
                     <select class="pure-u-1-6" name="captions[<%= index %>]" id="captions[<%= index %>]">
-                        <% Invidious::Videos::Caption::LANGUAGES.each do |option| %>
+                        <% Invidious::Videos::CaptionMetadata::LANGUAGES.each do |option| %>
                             <option value="<%= option %>" <% if preferences.captions[index] == option %> selected <% end %>><%= translate(locale, option.blank? ? "none" : option) %></option>
                         <% end %>
                     </select>

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -558,7 +558,7 @@ module YoutubeAPI
   end
 
   ####################################################################
-  # transcript(params)
+  # get_transcript(params, client_config?)
   #
   # Requests the youtubei/v1/get_transcript endpoint with the required headers
   # and POST data in order to get a JSON reply.
@@ -569,7 +569,7 @@ module YoutubeAPI
   # `struct ClientConfig` above for more details).
   #
 
-  def transcript(
+  def get_transcript(
     params : String,
     client_config : ClientConfig | Nil = nil
   ) : Hash(String, JSON::Any)

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -558,6 +558,30 @@ module YoutubeAPI
   end
 
   ####################################################################
+  # transcript(params)
+  #
+  # Requests the youtubei/v1/get_transcript endpoint with the required headers
+  # and POST data in order to get a JSON reply.
+  #
+  # The requested data is a specially encoded protobuf string that denotes the specific language requested.
+  #
+  # An optional ClientConfig parameter can be passed, too (see
+  # `struct ClientConfig` above for more details).
+  #
+
+  def transcript(
+    params : String,
+    client_config : ClientConfig | Nil = nil
+  ) : Hash(String, JSON::Any)
+    data = {
+      "context" => self.make_context(client_config),
+      "params"  => params,
+    }
+
+    return self._post_json("/youtubei/v1/get_transcript", data, client_config)
+  end
+
+  ####################################################################
   # _post_json(endpoint, data, client_config?)
   #
   # Internal function that does the actual request to youtube servers


### PR DESCRIPTION
Closes #2567

If applicable, I'll like to get the bounty. 

Theoretically, this should reenable closed captions support on larger instances that would otherwise be rate-limited by YouTube. 

There are some minor differences between the text received via transcripts and the regular timed text but nothing too major according to my testing. In addition, this will likely block us off implementing subtitle styling, animation, etc seen on YouTube until YT's timedtext API becomes an InnerTube endpoint. 

**To enable, simply set the `use_innertube_for_captions` to true within the config.**

