### PR TITLE
Playlists: Use subtitle when author is missing

### DIFF
--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -89,6 +89,7 @@ struct Playlist
   property views : Int64
   property updated : Time
   property thumbnail : String?
+  property subtitle : String?
 
   def to_json(offset, json : JSON::Builder, video_id : String? = nil)
     json.object do
@@ -100,6 +101,7 @@ struct Playlist
       json.field "author", self.author
       json.field "authorId", self.ucid
       json.field "authorUrl", "/channel/#{self.ucid}"
+      json.field "subtitle", self.subtitle
 
       json.field "authorThumbnails" do
         json.array do
@@ -356,6 +358,8 @@ def fetch_playlist(plid : String)
   updated = Time.utc
   video_count = 0
 
+  subtitle = extract_text(initial_data.dig?("header", "playlistHeaderRenderer", "subtitle"))
+
   playlist_info["stats"]?.try &.as_a.each do |stat|
     text = stat["runs"]?.try &.as_a.map(&.["text"].as_s).join("") || stat["simpleText"]?.try &.as_s
     next if !text
@@ -397,6 +401,7 @@ def fetch_playlist(plid : String)
     views:            views,
     updated:          updated,
     thumbnail:        thumbnail,
+    subtitle:         subtitle,
   })
 end
 

--- a/src/invidious/views/playlist.ecr
+++ b/src/invidious/views/playlist.ecr
@@ -73,7 +73,8 @@
                 <% if !author.empty? %>
                     <a href="/channel/<%= playlist.ucid %>"><%= author %></a> |
                 <% elsif !playlist.subtitle.nil? %>
-                    <span><%= playlist.subtitle.try &.split(" • ")[0] %></span> |
+                    <% subtitle = playlist.subtitle || "" %>
+                    <span><%= HTML.escape(subtitle[0..subtitle.rindex(" • ") || subtitle.size]) %></span> |
                 <% end %>
                 <%= translate_count(locale, "generic_videos_count", playlist.video_count) %> |
                 <%= translate(locale, "Updated `x` ago", recode_date(playlist.updated, locale)) %>

--- a/src/invidious/views/playlist.ecr
+++ b/src/invidious/views/playlist.ecr
@@ -70,7 +70,11 @@
             </b>
         <% else %>
             <b>
-                <a href="/channel/<%= playlist.ucid %>"><%= author %></a> |
+                <% if !author.empty? %>
+                    <a href="/channel/<%= playlist.ucid %>"><%= author %></a> |
+                <% elsif !playlist.subtitle.nil? %>
+                    <span><%= playlist.subtitle.try &.split(" • ")[0] %></span> |
+                <% end %>
                 <%= translate_count(locale, "generic_videos_count", playlist.video_count) %> |
                 <%= translate(locale, "Updated `x` ago", recode_date(playlist.updated, locale)) %>
             </b>


### PR DESCRIPTION
Example playlists:
One artist: https://www.youtube.com/playlist?list=OLAK5uy_lM3m05hKVY9vbzZH5lJpVKZKUQ-v_iTz4
Two artists: https://www.youtube.com/playlist?list=OLAK5uy_mYnfMbIG74obySLdWtKKGj_MJ-YZqVTu0

Related:
https://github.com/LuanRT/YouTube.js/pull/458

Screenshots:

<details>
<summary>Without this PR (Artist not displayed)</summary>
<img alt="Empty artist field" src="https://github.com/iv-org/invidious/assets/78101139/060553bd-028e-4591-a4c9-66358631c229">
</details>

<details>
<summary>With this PR (one artist displayed):</summary>
<img alt="SIA as the artist" src="https://github.com/iv-org/invidious/assets/78101139/d53fb754-815d-41b8-9fab-4138d5c2eac7">
</details>

<details>
<summary>With this PR (two artists displayed)</summary>
<img alt="SIA and David Guetta as the artist" src="https://github.com/iv-org/invidious/assets/78101139/0e483bcf-36b1-451f-95d0-2c31c8b2cf77">
</details>
