### PR TITLE
Shards: Update ameba version and fix typo

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -1,5 +1,9 @@
 version: 2.0
 shards:
+  ameba:
+    git: https://github.com/crystal-ameba/ameba.git
+    version: 1.5.0
+
   athena-negotiation:
     git: https://github.com/athena-framework/negotiation.git
     version: 0.1.1
@@ -44,6 +48,3 @@ shards:
     git: https://github.com/crystal-lang/crystal-sqlite3.git
     version: 0.18.0
 
-  ameba:
-    git: https://github.com/crystal-ameba/ameba.git
-    version: 0.14.3

--- a/shard.yml
+++ b/shard.yml
@@ -3,7 +3,7 @@ version: 0.20.1
 
 authors:
   - Omar Roth <omarroth@protonmail.com>
-  - Invidous team
+  - Invidious team
 
 targets:
   invidious:
@@ -35,7 +35,7 @@ development_dependencies:
     version: ~> 0.10.4
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.3
+    version: ~> 1.5.0
 
 crystal: ">= 1.0.0, < 2.0.0"
 


### PR DESCRIPTION
a bug when using recent versions of the crystal language may appear when building with ameba as described in:
https://github.com/crystal-ameba/ameba/issues/371
https://github.com/crystal-ameba/ameba/issues/372

this is fixed in version 1.5.0 by:
https://github.com/crystal-ameba/ameba/pull/373