### PR TITLE
Use workaround for fetching streaming URLs

### DIFF
--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -55,8 +55,9 @@ def extract_video_info(video_id : String, proxy_region : String? = nil)
   client_config = YoutubeAPI::ClientConfig.new(proxy_region: proxy_region)
 
   # Fetch data from the player endpoint
-  # 8AEB param is used to fetch YouTube stories
-  player_response = YoutubeAPI.player(video_id: video_id, params: "8AEB", client_config: client_config)
+  # CgIQBg is a workaround for streaming URLs that returns a 403.
+  # See https://github.com/iv-org/invidious/issues/4027#issuecomment-1666944520
+  player_response = YoutubeAPI.player(video_id: video_id, params: "CgIQBg", client_config: client_config)
 
   playability_status = player_response.dig?("playabilityStatus", "status").try &.as_s
 
@@ -135,8 +136,9 @@ end
 
 def try_fetch_streaming_data(id : String, client_config : YoutubeAPI::ClientConfig) : Hash(String, JSON::Any)?
   LOGGER.debug("try_fetch_streaming_data: [#{id}] Using #{client_config.client_type} client.")
-  # 8AEB param is used to fetch YouTube stories
-  response = YoutubeAPI.player(video_id: id, params: "8AEB", client_config: client_config)
+  # CgIQBg is a workaround for streaming URLs that returns a 403.
+  # See https://github.com/iv-org/invidious/issues/4027#issuecomment-1666944520
+  response = YoutubeAPI.player(video_id: id, params: "CgIQBg", client_config: client_config)
 
   playability_status = response["playabilityStatus"]["status"]
   LOGGER.debug("try_fetch_streaming_data: [#{id}] Got playabilityStatus == #{playability_status}.")


### PR DESCRIPTION
Closes #4027

YouTube appears to be A/B testing some new integrity checks. Adding the parameter "CgIQBg" to InnerTube player requests appears to workaround the problem

See https://github.com/TeamNewPipe/NewPipeExtractor/pull/1084