### PR TITLE
Add workaround for storyboards on local instances

### DIFF
--- a/src/invidious/routes/errors.cr
+++ b/src/invidious/routes/errors.cr
@@ -1,6 +1,6 @@
 module Invidious::Routes::ErrorRoutes
   def self.error_404(env)
-    # Workaround for # 3117
+    # Workaround for #3117
     if HOST_URL.empty? && env.request.path.starts_with?("/v1/storyboards/sb")
       return env.redirect "#{env.request.path[15..]}?#{env.params.query}"
     end

--- a/src/invidious/routes/errors.cr
+++ b/src/invidious/routes/errors.cr
@@ -1,5 +1,10 @@
 module Invidious::Routes::ErrorRoutes
   def self.error_404(env)
+    # Workaround for # 3117
+    if HOST_URL.empty? && env.request.path.starts_with?("/v1/storyboards/sb")
+      return env.redirect "#{env.request.path[15..]}?#{env.params.query}"
+    end
+
     if md = env.request.path.match(/^\/(?<id>([a-zA-Z0-9_-]{11})|(\w+))$/)
       item = md["id"]
 

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -55,9 +55,7 @@ def extract_video_info(video_id : String, proxy_region : String? = nil)
   client_config = YoutubeAPI::ClientConfig.new(proxy_region: proxy_region)
 
   # Fetch data from the player endpoint
-  # CgIQBg is a workaround for streaming URLs that returns a 403.
-  # See https://github.com/iv-org/invidious/issues/4027#issuecomment-1666944520
-  player_response = YoutubeAPI.player(video_id: video_id, params: "CgIQBg", client_config: client_config)
+  player_response = YoutubeAPI.player(video_id: video_id, params: "", client_config: client_config)
 
   playability_status = player_response.dig?("playabilityStatus", "status").try &.as_s
 
@@ -120,6 +118,9 @@ def extract_video_info(video_id : String, proxy_region : String? = nil)
 
   # Replace player response and reset reason
   if !new_player_response.nil?
+    # Preserve storyboard data before replacement
+    new_player_response["storyboards"] = player_response["storyboards"] if player_response["storyboards"]?
+
     player_response = new_player_response
     params.delete("reason")
   end


### PR DESCRIPTION
Closes #3117

Also fixes a regression from #4037 that broke storyboards for everyone. 

-----

![workaround](https://github.com/iv-org/invidious/assets/70992037/ad313896-27a7-49f9-a54b-35a66962b0cb)


This PR adds a quick workaround within the 404 handler to allow storyboards to function on instances without `domain`, `external_port` and `https_only` set.

We should probably consider switching to [the freetube fork here](https://github.com/FreeTubeApp/videojs-vtt-thumbnails)