### PR TITLE
Fix iOS screen timeout on video playback

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -219,6 +219,7 @@ if (video_data.params.video_start > 0 || video_data.params.video_end > 0) {
 }
 
 player.volume(video_data.params.volume / 100);
+player.muted(video_data.params.volume === 0);
 player.playbackRate(video_data.params.speed);
 
 /**


### PR DESCRIPTION
Fixes: https://github.com/iv-org/invidious/issues/4074

After declaring player.muted,
If player volume is set to greater than 0, the screen stays on and will not timeout.
If player volume is set to 0, the screen will not stay on until user press the speaker icon to unmute the video.

Setting player volume to 0 also allows video autoplay in muted on iOS.