### PR TITLE
Player: Fix iOS screen timeout in loop mode

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -701,6 +701,21 @@ if (navigator.vendor === 'Apple Computer, Inc.' && video_data.params.listen) {
     });
 }
 
+// Safari screen timeout on looped video playback fix
+if (navigator.vendor === 'Apple Computer, Inc.' && !video_data.params.listen && video_data.params.video_loop) {
+    player.loop(false);
+    player.on('loadedmetadata', function () {
+        player.on('timeupdate', function () {
+            if (player.remainingTime() < 2) {
+                player.loop(true);
+                setTimeout(() => {
+                    player.loop(false);
+                }, 2000 / player.playbackRate());
+            }
+        });
+    });
+}
+
 // Watch on Invidious link
 if (location.pathname.startsWith('/embed/')) {
     const Button = videojs.getComponent('Button');

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -704,14 +704,10 @@ if (navigator.vendor === 'Apple Computer, Inc.' && video_data.params.listen) {
 // Safari screen timeout on looped video playback fix
 if (navigator.vendor === 'Apple Computer, Inc.' && !video_data.params.listen && video_data.params.video_loop) {
     player.loop(false);
-    player.on('loadedmetadata', function () {
-        player.on('timeupdate', function () {
-            if (player.remainingTime() < 2) {
-                player.loop(true);
-                setTimeout(() => {
-                    player.loop(false);
-                }, 2000 / player.playbackRate());
-            }
+    player.ready(function () {
+        player.on('ended', function () {
+            player.currentTime(0);
+            player.play();
         });
     });
 }


### PR DESCRIPTION
Fixes: https://github.com/iv-org/invidious/issues/4074

iOS seems to turn off the screen when video is in loop mode.
This workaround turns off builtin loop, and set position to 0 when video ends.