### PR TITLE
Add playback success rate to `/api/v1/stats`

### DIFF
--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -223,5 +223,5 @@ def get_playback_statistic
     Invidious::Jobs::StatisticsRefreshJob::STATISTICS["playback"] = tracker
   end
 
-  return tracker
+  return tracker.as(Hash(String, Int64 | Float64))
 end

--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -208,3 +208,20 @@ def proxy_file(response, env)
     IO.copy response.body_io, env.response
   end
 end
+
+# Fetch the playback requests tracker from the statistics endpoint.
+#
+# Creates a new tracker when unavailable.
+def get_playback_statistic
+  if (tracker = Invidious::Jobs::StatisticsRefreshJob::STATISTICS["playback"]) && tracker.as(Hash).empty?
+    tracker = {
+      "totalRequests"      => 0_i64,
+      "successfulRequests" => 0_i64,
+      "ratio"              => 0_f64,
+    }
+
+    Invidious::Jobs::StatisticsRefreshJob::STATISTICS["playback"] = tracker
+  end
+
+  return tracker
+end

--- a/src/invidious/jobs/statistics_refresh_job.cr
+++ b/src/invidious/jobs/statistics_refresh_job.cr
@@ -37,7 +37,7 @@ class Invidious::Jobs::StatisticsRefreshJob < Invidious::Jobs::BaseJob
 
     loop do
       refresh_stats
-      sleep 1.minute
+      sleep 10.minute
       Fiber.yield
     end
   end

--- a/src/invidious/jobs/statistics_refresh_job.cr
+++ b/src/invidious/jobs/statistics_refresh_job.cr
@@ -18,6 +18,13 @@ class Invidious::Jobs::StatisticsRefreshJob < Invidious::Jobs::BaseJob
       "updatedAt"              => Time.utc.to_unix,
       "lastChannelRefreshedAt" => 0_i64,
     },
+
+    #
+    #    "totalRequests" => 0_i64,
+    #    "successfulRequests" => 0_i64
+    #    "ratio"   => 0_i64
+    #
+    "playback" => {} of String => Int64 | Float64,
   }
 
   private getter db : DB::Database
@@ -56,5 +63,8 @@ class Invidious::Jobs::StatisticsRefreshJob < Invidious::Jobs::BaseJob
       "updatedAt"              => Time.utc.to_unix,
       "lastChannelRefreshedAt" => Invidious::Database::Statistics.channel_last_update.try &.to_unix || 0_i64,
     }
+
+    # Reset playback requests tracker
+    STATISTICS["playback"] = {} of String => Int64 | Float64
   end
 end

--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -6,6 +6,22 @@ module Invidious::Routes::API::V1::Misc
     if !CONFIG.statistics_enabled
       return {"software" => SOFTWARE}.to_json
     else
+      # Calculate playback success rate
+      if (tracker = Invidious::Jobs::StatisticsRefreshJob::STATISTICS["playback"]?)
+        tracker = tracker.as(Hash(String, Int64 | Float64))
+
+        if !tracker.empty?
+          total_requests = tracker["totalRequests"]
+          success_count = tracker["successfulRequests"]
+
+          if total_requests.zero?
+            tracker["ratio"] = 1_i64
+          else
+            tracker["ratio"] = (success_count / (total_requests)).round(2)
+          end
+        end
+      end
+
       return Invidious::Jobs::StatisticsRefreshJob::STATISTICS.to_json
     end
   end

--- a/src/invidious/routes/video_playback.cr
+++ b/src/invidious/routes/video_playback.cr
@@ -80,7 +80,7 @@ module Invidious::Routes::VideoPlayback
     # Remove the Range header added previously.
     headers.delete("Range") if range_header.nil?
 
-    playback_statistics = get_playback_statistic().as(Hash(String, Int64 | Float64))
+    playback_statistics = get_playback_statistic()
     playback_statistics["totalRequests"] += 1
 
     if response.status_code >= 400

--- a/src/invidious/routes/video_playback.cr
+++ b/src/invidious/routes/video_playback.cr
@@ -80,9 +80,14 @@ module Invidious::Routes::VideoPlayback
     # Remove the Range header added previously.
     headers.delete("Range") if range_header.nil?
 
+    playback_statistics = get_playback_statistic().as(Hash(String, Int64 | Float64))
+    playback_statistics["totalRequests"] += 1
+
     if response.status_code >= 400
       env.response.content_type = "text/plain"
       haltf env, response.status_code
+    else
+      playback_statistics["successfulRequests"] += 1
     end
 
     if url.includes? "&file=seg.ts"

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -81,7 +81,7 @@ def extract_video_info(video_id : String, proxy_region : String? = nil)
 
     # Although technically not a call to /videoplayback the fact that YouTube is returning the
     # wrong video means that we should count it as a failure.
-    get_playback_statistic().as(Hash(String, Int64 | Float64))["totalRequests"] += 1
+    get_playback_statistic()["totalRequests"] += 1
 
     return {
       "version" => JSON::Any.new(Video::SCHEMA_VERSION.to_i64),

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -78,6 +78,11 @@ def extract_video_info(video_id : String, proxy_region : String? = nil)
     # YouTube may return a different video player response than expected.
     # See: https://github.com/TeamNewPipe/NewPipe/issues/8713
     # Line to be reverted if one day we solve the video not available issue.
+
+    # Although technically not a call to /videoplayback the fact that YouTube is returning the
+    # wrong video means that we should count it as a failure.
+    get_playback_statistic().as(Hash(String, Int64 | Float64))["totalRequests"] += 1
+
     return {
       "version" => JSON::Any.new(Video::SCHEMA_VERSION.to_i64),
       "reason"  => JSON::Any.new("Can't load the video on this Invidious instance. YouTube is currently trying to block Invidious instances. <a href=\"https://github.com/iv-org/invidious/issues/3822\">Click here for more info about the issue.</a>"),


### PR DESCRIPTION
https://github.com/iv-org/invidious/pull/4083#issuecomment-1702660189

This PR tracks the total amount of `/videoplayback` requests and the ones that are successful in order to create a playback success rate in the `/api/v1/stats` endpoint. 

By default it is an empty object:
```json
"playback" : {}
```

But as soon as a video is played:

```json
"playback": {
    "totalRequests": 19,
    "successfulRequests": 19,
    "ratio": 1.0
}
```

The caveat however is that with the way I have it currently set up the playback object gets reset back to an empty object each time the stats is refreshed. This is to prevent a success rate so high that 403 requests won't be able to budge the ratio at all. A better solution is probably needed there. 

Closes #3957