### PR TITLE
Fix: Search not showing next page button when a next page exists

### DIFF
--- a/src/invidious/routes/api/v1/channels.cr
+++ b/src/invidious/routes/api/v1/channels.cr
@@ -440,7 +440,7 @@ module Invidious::Routes::API::V1::Channels
     query.channel = env.params.url["ucid"]
 
     begin
-      search_results = query.process
+      search_results, _ = query.process
     rescue ex
       return error_json(400, ex)
     end

--- a/src/invidious/routes/api/v1/search.cr
+++ b/src/invidious/routes/api/v1/search.cr
@@ -8,7 +8,7 @@ module Invidious::Routes::API::V1::Search
     query = Invidious::Search::Query.new(env.params.query, :regular, region)
 
     begin
-      search_results = query.process
+      search_results, _ = query.process
     rescue ex
       return error_json(400, ex)
     end

--- a/src/invidious/routes/playlists.cr
+++ b/src/invidious/routes/playlists.cr
@@ -254,9 +254,11 @@ module Invidious::Routes::Playlists
 
     begin
       query = Invidious::Search::Query.new(env.params.query, :playlist, region)
-      items = query.process.select(SearchVideo).map(&.as(SearchVideo))
+      processed_query, has_continuation = query.process
+      items = processed_query.select(SearchVideo).map(&.as(SearchVideo))
     rescue ex
       items = [] of SearchVideo
+      has_continuation = false
     end
 
     # Pagination
@@ -264,7 +266,7 @@ module Invidious::Routes::Playlists
     page_nav_html = Frontend::Pagination.nav_numeric(locale,
       base_url: "/add_playlist_items?list=#{playlist.id}&q=#{query_encoded}",
       current_page: page,
-      show_next: (items.size >= 20)
+      show_next: has_continuation
     )
 
     env.set "add_playlist_items", plid

--- a/src/invidious/routes/search.cr
+++ b/src/invidious/routes/search.cr
@@ -52,7 +52,7 @@ module Invidious::Routes::Search
       user = env.get? "user"
 
       begin
-        items = query.process
+        items, has_continuation = query.process
       rescue ex : ChannelSearchException
         return error_template(404, "Unable to find channel with id of '#{HTML.escape(ex.channel)}'. Are you sure that's an actual channel id? It should look like 'UC4QobU6STFB0P71PMvOGN5A'.")
       rescue ex
@@ -65,7 +65,7 @@ module Invidious::Routes::Search
       page_nav_html = Frontend::Pagination.nav_numeric(locale,
         base_url: "/search?#{query.to_http_params}",
         current_page: query.page,
-        show_next: (items.size >= 20)
+        show_next: has_continuation
       )
 
       if query.type == Invidious::Search::Query::Type::Channel

--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -717,14 +717,14 @@ private module Extractors
     end
 
     private def self.extract(target)
-      raw_items = [] of Array(JSON::Any)
+      raw_items = [] of JSON::Any
 
       target.dig("primaryContents", "sectionListRenderer", "contents").as_a.each do |node|
         if new_node = node["itemSectionRenderer"]?
-          raw_items << new_node["contents"].as_a
-        end
-        if node["continuationItemRenderer"]?
-          raw_items.push([node])
+          raw_items += new_node["contents"].as_a
+        elsif node["continuationItemRenderer"]?
+          # we put the node in an array so the ContinuationItemRendererParser is able to parse it
+          raw_items << node
         end
       end
 

--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -720,8 +720,11 @@ private module Extractors
       raw_items = [] of Array(JSON::Any)
 
       target.dig("primaryContents", "sectionListRenderer", "contents").as_a.each do |node|
-        if node = node["itemSectionRenderer"]?
-          raw_items << node["contents"].as_a
+        if new_node = node["itemSectionRenderer"]?
+          raw_items << new_node["contents"].as_a
+        end
+        if node["continuationItemRenderer"]?
+          raw_items.push([node])
         end
       end
 


### PR DESCRIPTION
closes https://github.com/iv-org/invidious/issues/1708

Similar to (part of): https://github.com/iv-org/invidious/pull/3864

This PR checks for a continuation token to determine whether a next page button should be shown. A good example to test this with is when adding videos to a playlist.

Test case:
- create a playlist
- go to page to add videos to playlist
- search "yo mama"
- See next page button if using this PR, don't see it if not using this pr


Whether there's a next page or not is not included in the api as it would have to be a breaking change
