### PR TITLE
Add more fields to PWA manifest

### DIFF
--- a/assets/site.webmanifest
+++ b/assets/site.webmanifest
@@ -17,15 +17,5 @@
     "background_color": "#575757",
     "display": "standalone",
     "description": "An alternative front-end to YouTube",
-    "start_url": "/",
-    "shortcuts": [
-        {
-            "name": "Popular",
-            "url": "/feed/popular"
-        },
-        {
-            "name": "Trending",
-            "url": "/feed/trending"
-        }
-    ]
+    "start_url": "/"
 }

--- a/assets/site.webmanifest
+++ b/assets/site.webmanifest
@@ -17,5 +17,15 @@
     "background_color": "#575757",
     "display": "standalone",
     "description": "An alternative front-end to YouTube",
-    "start_url": "/"
+    "start_url": "/",
+    "shortcuts": [
+        {
+            "name": "Popular",
+            "url": "/feed/popular"
+        },
+        {
+            "name": "Trending",
+            "url": "/feed/trending"
+        }
+    ]
 }

--- a/assets/site.webmanifest
+++ b/assets/site.webmanifest
@@ -15,5 +15,6 @@
     ],
     "theme_color": "#575757",
     "background_color": "#575757",
-    "display": "standalone"
+    "display": "standalone",
+    "description": "An alternative front-end to YouTube"
 }

--- a/assets/site.webmanifest
+++ b/assets/site.webmanifest
@@ -16,5 +16,6 @@
     "theme_color": "#575757",
     "background_color": "#575757",
     "display": "standalone",
-    "description": "An alternative front-end to YouTube"
+    "description": "An alternative front-end to YouTube",
+    "start_url": "/"
 }


### PR DESCRIPTION
Added `description`, `start_url`, and `shortcuts` properties to PWA manifest.

#### MDN links

- [`description`](https://developer.mozilla.org/en-US/docs/Web/Manifest/description)
- [`start_url`](https://developer.mozilla.org/en-US/docs/Web/Manifest/start_url)
- [`shortcuts`](https://developer.mozilla.org/en-US/docs/Web/Manifest/shortcuts)