### PR TITLE
API: Add a 'published' video parameter for related videos

### DIFF
--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -246,7 +246,11 @@ module Invidious::JSONify::APIv1
                 json.field "viewCountText", rv["short_view_count"]?
                 json.field "viewCount", rv["view_count"]?.try &.empty? ? nil : rv["view_count"].to_i64
                 json.field "published", rv["published"]?
-                json.field "publishedTimeText", translate(locale, "`x` ago", rv["publishedText"].to_s.gsub(" ago", ""))
+                if !rv[published].nil?
+                  json.field "publishedText", translate(locale, "`x` ago", recode_date(rv[published], locale))
+                else
+                  json.field "publishedText", translate(locale, "`x` ago", "NaN")
+                end
               end
             end
           end

--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -246,7 +246,7 @@ module Invidious::JSONify::APIv1
                 json.field "viewCountText", rv["short_view_count"]?
                 json.field "viewCount", rv["view_count"]?.try &.empty? ? nil : rv["view_count"].to_i64
                 json.field "published", rv["published"]?
-                if !rv["published"].nil?
+                if !rv["published"]?.nil?
                   json.field "publishedText", translate(locale, "`x` ago", recode_date(Time.parse_rfc3339(rv["published"].to_s), locale))
                 else
                   json.field "publishedText", ""

--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -245,7 +245,7 @@ module Invidious::JSONify::APIv1
                 json.field "lengthSeconds", rv["length_seconds"]?.try &.to_i
                 json.field "viewCountText", rv["short_view_count"]?
                 json.field "viewCount", rv["view_count"]?.try &.empty? ? nil : rv["view_count"].to_i64
-                json.field "published", rv["published"]?.try { |t| Time.parse(t, "%Y-%m-%d", Time::Location::UTC).to_unix } || Time.utc
+                json.field "published", rv["published"]?
               end
             end
           end

--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -247,9 +247,9 @@ module Invidious::JSONify::APIv1
                 json.field "viewCount", rv["view_count"]?.try &.empty? ? nil : rv["view_count"].to_i64
                 json.field "published", rv["published"]?
                 if !rv["published"].nil?
-                  json.field "publishedText", translate(locale, "`x` ago", recode_date(Time.unix(rv["published"].to_i), locale))
+                  json.field "publishedText", translate(locale, "`x` ago", recode_date(Time.parse_rfc3339(rv["published"].to_s), locale))
                 else
-                  json.field "publishedText", translate(locale, "`x` ago", "NaN")
+                  json.field "publishedText", ""
                 end
               end
             end

--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -246,8 +246,8 @@ module Invidious::JSONify::APIv1
                 json.field "viewCountText", rv["short_view_count"]?
                 json.field "viewCount", rv["view_count"]?.try &.empty? ? nil : rv["view_count"].to_i64
                 json.field "published", rv["published"]?
-                if !rv[published].nil?
-                  json.field "publishedText", translate(locale, "`x` ago", recode_date(rv[published], locale))
+                if !rv["published"].nil?
+                  json.field "publishedText", translate(locale, "`x` ago", recode_date(rv["published"], locale))
                 else
                   json.field "publishedText", translate(locale, "`x` ago", "NaN")
                 end

--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -246,7 +246,7 @@ module Invidious::JSONify::APIv1
                 json.field "viewCountText", rv["short_view_count"]?
                 json.field "viewCount", rv["view_count"]?.try &.empty? ? nil : rv["view_count"].to_i64
                 json.field "published", rv["published"]?
-                json.field "publishedTimeText", rv["publishedText"]?
+                json.field "publishedTimeText", translate(locale, "`x` ago", rv["publishedText"].to_s)
               end
             end
           end

--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -247,7 +247,7 @@ module Invidious::JSONify::APIv1
                 json.field "viewCount", rv["view_count"]?.try &.empty? ? nil : rv["view_count"].to_i64
                 json.field "published", rv["published"]?
                 if !rv["published"].nil?
-                  json.field "publishedText", translate(locale, "`x` ago", recode_date(rv["published"], locale))
+                  json.field "publishedText", translate(locale, "`x` ago", recode_date(Time.unix(rv["published"].to_i), locale))
                 else
                   json.field "publishedText", translate(locale, "`x` ago", "NaN")
                 end

--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -246,6 +246,7 @@ module Invidious::JSONify::APIv1
                 json.field "viewCountText", rv["short_view_count"]?
                 json.field "viewCount", rv["view_count"]?.try &.empty? ? nil : rv["view_count"].to_i64
                 json.field "published", rv["published"]?
+                json.field "publishedTimeText", rv["publishedText"]?
               end
             end
           end

--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -246,7 +246,7 @@ module Invidious::JSONify::APIv1
                 json.field "viewCountText", rv["short_view_count"]?
                 json.field "viewCount", rv["view_count"]?.try &.empty? ? nil : rv["view_count"].to_i64
                 json.field "published", rv["published"]?
-                json.field "publishedTimeText", translate(locale, "`x` ago", rv["publishedText"].to_s)
+                json.field "publishedTimeText", translate(locale, "`x` ago", rv["publishedText"].to_s.gsub(" ago", ""))
               end
             end
           end

--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -245,6 +245,7 @@ module Invidious::JSONify::APIv1
                 json.field "lengthSeconds", rv["length_seconds"]?.try &.to_i
                 json.field "viewCountText", rv["short_view_count"]?
                 json.field "viewCount", rv["view_count"]?.try &.empty? ? nil : rv["view_count"].to_i64
+                json.field "published", rv["published"]?.try { |t| Time.parse(t, "%Y-%m-%d", Time::Location::UTC).to_unix } || Time.utc
               end
             end
           end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -236,14 +236,13 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
     .dig?("secondaryResults", "secondaryResults", "results")
   secondary_results.try &.as_a.each do |element|
     if item = element["compactVideoRenderer"]?
-      time_text = item["publishedTimeText"]?
-      if !time_text.nil?
-        time = decode_date(item["publishedTimeText"].to_s)
-        published1 = JSON::Any.new(time.to_unix.to_s)
+      if item["publishedTimeText"]?
+        rv_decoded_time = decode_date(item["publishedTimeText"].to_s)
+        rv_published_timestamp = JSON::Any.new(rv_decoded_time.to_unix.to_s)
       else
-        published1 = JSON::Any.new("")
+        rv_published_timestamp = JSON::Any.new("")
       end
-      related_video = parse_related_video(item, published1)
+      related_video = parse_related_video(item, rv_published_timestamp)
       related << JSON::Any.new(related_video) if related_video
     end
   end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -241,6 +241,17 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
       if !time_text.nil?
         time_string = time_text["simpleText"]?
       end
+      if !time_string.nil? && time_string.to_s.ends_with?("minute ago")
+        time = Time.utc.to_unix - 60
+      end
+      if !time_string.nil? && time_string.to_s.ends_with?("minutes ago") && !time_string.to_s.starts_with?("Streamed")
+        minutes = time_string.to_s.rchop(" minutes ago").to_i
+        time = Time.utc.to_unix - 60*minutes
+      end
+      if !time_string.nil? && time_string.to_s.ends_with?("minutes ago") && time_string.to_s.starts_with?("Streamed")
+        minutes = time_string.to_s.lchop("Streamed ").rchop(" minutes ago").to_i
+        time = Time.utc.to_unix - 60*minutes
+      end
       if !time_string.nil? && time_string.to_s.ends_with?("hour ago")
         time = Time.utc.to_unix - 3600
       end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -48,7 +48,7 @@ def parse_related_video(related : JSON::Any, published : String? = nil, publishe
     "short_view_count" => JSON::Any.new(short_view_count || "0"),
     "author_verified"  => JSON::Any.new(author_verified),
     "published"        => JSON::Any.new(published || ""),
-    "publishedText"    => JSON::Any.new(publishedText || ""),
+    "publishedText"    => JSON::Any.new(translate(locale, "`x` ago", recode_date(video.published, locale)) || ""),
   }
 end
 

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -236,8 +236,13 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
     .dig?("secondaryResults", "secondaryResults", "results")
   secondary_results.try &.as_a.each do |element|
     if item = element["compactVideoRenderer"]?
-		 time = decode_date(item["publishedTimeText"].to_s)
-		published1 = JSON::Any.new(time.to_unix.to_s)
+      time_text = item["publishedTimeText"]?
+      if !time_text.nil?
+        time = decode_date(item["publishedTimeText"].to_s)
+        published1 = JSON::Any.new(time.to_unix.to_s)
+      else
+        published1 = JSON::Any.new("")
+      end
       related_video = parse_related_video(item, published1)
       related << JSON::Any.new(related_video) if related_video
     end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -56,7 +56,6 @@ def parse_related_video(related : JSON::Any) : Hash(String, JSON::Any)?
     "short_view_count" => JSON::Any.new(short_view_count || "0"),
     "author_verified"  => JSON::Any.new(author_verified),
     "published"        => JSON::Any.new(published || ""),
-    "publishedText"    => JSON::Any.new(published_time_text || ""),
   }
 end
 

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -6,7 +6,7 @@ require "json"
 #
 # TODO: "compactRadioRenderer" (Mix) and
 # TODO: Use a proper struct/class instead of a hacky JSON object
-def parse_related_video(related : JSON::Any, published : String? = nil) : Hash(String, JSON::Any)?
+def parse_related_video(related : JSON::Any, published : String? = nil, publishedText : String? = nil) : Hash(String, JSON::Any)?
   return nil if !related["videoId"]?
 
   # The compact renderer has video length in seconds, where the end
@@ -48,6 +48,7 @@ def parse_related_video(related : JSON::Any, published : String? = nil) : Hash(S
     "short_view_count" => JSON::Any.new(short_view_count || "0"),
     "author_verified"  => JSON::Any.new(author_verified),
     "published"        => JSON::Any.new(published || ""),
+    "publishedText"    => JSON::Any.new(publishedText || ""),
   }
 end
 
@@ -237,12 +238,13 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
   secondary_results.try &.as_a.each do |element|
     if item = element["compactVideoRenderer"]?
       if item["publishedTimeText"]?
+        rv_published_time_text = item["publishedTimeText"].to_s
         rv_decoded_time = decode_date(item["publishedTimeText"].to_s)
         rv_published_timestamp = rv_decoded_time.to_unix.to_s
       else
         rv_published_timestamp = nil
       end
-      related_video = parse_related_video(item, published: rv_published_timestamp)
+      related_video = parse_related_video(item, published: rv_published_timestamp, publishedText: rv_published_time_text)
       related << JSON::Any.new(related_video) if related_video
     end
   end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -239,8 +239,8 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
     .dig?("secondaryResults", "secondaryResults", "results")
   secondary_results.try &.as_a.each do |element|
     if item = element["compactVideoRenderer"]?
-      if rv_published_time_text = item["publishedTimeText"]["simpleText"]?
-        rv_decoded_time = decode_date(rv_published_time_text.to_s)
+      if rv_published_time_text = item["publishedTimeText"]?
+        rv_decoded_time = decode_date(rv_published_time_text["simpleText"].to_s)
         rv_published_timestamp = rv_decoded_time.to_unix.to_s
       else
         rv_published_timestamp = nil

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -36,7 +36,7 @@ def parse_related_video(related : JSON::Any, published : String? = nil) : Hash(S
 
   LOGGER.trace("parse_related_video: Found \"watchNextEndScreenRenderer\" container")
 
-  publishedText = related["publishedTimeText"]["simpleText"].to_s
+  publishedText = related["publishedTimeText"]?
 
   # TODO: when refactoring video types, make a struct for related videos
   # or reuse an existing type, if that fits.
@@ -50,7 +50,7 @@ def parse_related_video(related : JSON::Any, published : String? = nil) : Hash(S
     "short_view_count" => JSON::Any.new(short_view_count || "0"),
     "author_verified"  => JSON::Any.new(author_verified),
     "published"        => JSON::Any.new(published || ""),
-    "publishedText"    => JSON::Any.new(publishedText || ""),
+	 "publishedText"    => JSON::Any.new(publishedText["simpleText"]?.to_s || ""),
   }
 end
 

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -158,6 +158,85 @@ def try_fetch_streaming_data(id : String, client_config : YoutubeAPI::ClientConf
   end
 end
 
+def parse_published_string(item)
+  time_text = item["publishedTimeText"]?
+  time_string = nil
+  if !time_text.nil?
+    time_string = time_text["simpleText"]?
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("minute ago")
+    time = Time.utc.to_unix - 60
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("minutes ago") && !time_string.to_s.starts_with?("Streamed")
+    minutes = time_string.to_s.rchop(" minutes ago").to_i
+    time = Time.utc.to_unix - 60*minutes
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("minutes ago") && time_string.to_s.starts_with?("Streamed")
+    minutes = time_string.to_s.lchop("Streamed ").rchop(" minutes ago").to_i
+    time = Time.utc.to_unix - 60*minutes
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("hour ago")
+    time = Time.utc.to_unix - 3600
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("hours ago") && !time_string.to_s.starts_with?("Streamed")
+    hours = time_string.to_s.rchop(" hours ago").to_i
+    time = Time.utc.to_unix - 3600*hours
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("hours ago") && time_string.to_s.starts_with?("Streamed")
+    hours = time_string.to_s.lchop("Streamed ").rchop(" hours ago").to_i
+    time = Time.utc.to_unix - 3600*hours
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("day ago")
+    time = Time.utc.to_unix - 86400
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("days ago") && !time_string.to_s.starts_with?("Streamed")
+    days = time_string.to_s.rchop(" days ago").to_i
+    time = Time.utc.to_unix - 86400*days
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("days ago") && time_string.to_s.starts_with?("Streamed")
+    days = time_string.to_s.lchop("Streamed ").rchop(" days ago").to_i
+    time = Time.utc.to_unix - 86400*days
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("week ago")
+    time = Time.utc.to_unix - 604800
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("weeks ago") && !time_string.to_s.starts_with?("Streamed")
+    weeks = time_string.to_s.rchop(" weeks ago").to_i
+    time = Time.utc.to_unix - 604800*weeks
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("weeks ago") && time_string.to_s.starts_with?("Streamed")
+    weeks = time_string.to_s.lchop("Streamed ").rchop(" weeks ago").to_i
+    time = Time.utc.to_unix - 604800*weeks
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("month ago")
+    time = Time.utc.to_unix - 2629743
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("months ago") && !time_string.to_s.starts_with?("Streamed")
+    months = time_string.to_s.rchop(" months ago").to_i
+    time = Time.utc.to_unix - 2629743*months
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("months ago") && time_string.to_s.starts_with?("Streamed")
+    months = time_string.to_s.lchop("Streamed ").rchop(" months ago").to_i
+    time = Time.utc.to_unix - 2629743*months
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("year ago")
+    time = Time.utc.to_unix - 31556926
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("years ago") && !time_string.to_s.starts_with?("Streamed")
+    years = time_string.to_s.rchop(" years ago").to_i
+    time = Time.utc.to_unix - 31556926*years
+  end
+  if !time_string.nil? && time_string.to_s.ends_with?("years ago") && time_string.to_s.starts_with?("Streamed")
+    years = time_string.to_s.lchop("Streamed ").rchop(" years ago").to_i
+    time = Time.utc.to_unix - 31556926*years
+  end
+  if time_string.nil?
+    time = nil
+  end
+
+  return time
+end
+
 def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any), proxy_region : String? = nil) : Hash(String, JSON::Any)
   # Top level elements
 
@@ -236,77 +315,7 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
     .dig?("secondaryResults", "secondaryResults", "results")
   secondary_results.try &.as_a.each do |element|
     if item = element["compactVideoRenderer"]?
-      time_text = item["publishedTimeText"]?
-      time_string = nil
-      if !time_text.nil?
-        time_string = time_text["simpleText"]?
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("minute ago")
-        time = Time.utc.to_unix - 60
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("minutes ago") && !time_string.to_s.starts_with?("Streamed")
-        minutes = time_string.to_s.rchop(" minutes ago").to_i
-        time = Time.utc.to_unix - 60*minutes
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("minutes ago") && time_string.to_s.starts_with?("Streamed")
-        minutes = time_string.to_s.lchop("Streamed ").rchop(" minutes ago").to_i
-        time = Time.utc.to_unix - 60*minutes
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("hour ago")
-        time = Time.utc.to_unix - 3600
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("hours ago") && !time_string.to_s.starts_with?("Streamed")
-        hours = time_string.to_s.rchop(" hours ago").to_i
-        time = Time.utc.to_unix - 3600*hours
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("hours ago") && time_string.to_s.starts_with?("Streamed")
-        hours = time_string.to_s.lchop("Streamed ").rchop(" hours ago").to_i
-        time = Time.utc.to_unix - 3600*hours
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("day ago")
-        time = Time.utc.to_unix - 86400
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("days ago") && !time_string.to_s.starts_with?("Streamed")
-        days = time_string.to_s.rchop(" days ago").to_i
-        time = Time.utc.to_unix - 86400*days
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("days ago") && time_string.to_s.starts_with?("Streamed")
-        days = time_string.to_s.lchop("Streamed ").rchop(" days ago").to_i
-        time = Time.utc.to_unix - 86400*days
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("week ago")
-        time = Time.utc.to_unix - 604800
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("weeks ago") && !time_string.to_s.starts_with?("Streamed")
-        weeks = time_string.to_s.rchop(" weeks ago").to_i
-        time = Time.utc.to_unix - 604800*weeks
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("weeks ago") && time_string.to_s.starts_with?("Streamed")
-        weeks = time_string.to_s.lchop("Streamed ").rchop(" weeks ago").to_i
-        time = Time.utc.to_unix - 604800*weeks
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("month ago")
-        time = Time.utc.to_unix - 2629743
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("months ago") && !time_string.to_s.starts_with?("Streamed")
-        months = time_string.to_s.rchop(" months ago").to_i
-        time = Time.utc.to_unix - 2629743*months
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("months ago") && time_string.to_s.starts_with?("Streamed")
-        months = time_string.to_s.lchop("Streamed ").rchop(" months ago").to_i
-        time = Time.utc.to_unix - 2629743*months
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("year ago")
-        time = Time.utc.to_unix - 31556926
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("years ago") && !time_string.to_s.starts_with?("Streamed")
-        years = time_string.to_s.rchop(" years ago").to_i
-        time = Time.utc.to_unix - 31556926*years
-      end
-      if !time_string.nil? && time_string.to_s.ends_with?("years ago") && time_string.to_s.starts_with?("Streamed")
-        years = time_string.to_s.lchop("Streamed ").rchop(" years ago").to_i
-        time = Time.utc.to_unix - 31556926*years
-      end
+      time = parse_published_string(item)
       published1 = JSON::Any.new(time.to_s)
       related_video = parse_related_video(item, published1)
       related << JSON::Any.new(related_video) if related_video

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -6,7 +6,7 @@ require "json"
 #
 # TODO: "compactRadioRenderer" (Mix) and
 # TODO: Use a proper struct/class instead of a hacky JSON object
-def parse_related_video(related : JSON::Any, published) : Hash(String, JSON::Any)?
+def parse_related_video(related : JSON::Any, published : String? = nil) : Hash(String, JSON::Any)?
   return nil if !related["videoId"]?
 
   # The compact renderer has video length in seconds, where the end
@@ -47,7 +47,7 @@ def parse_related_video(related : JSON::Any, published) : Hash(String, JSON::Any
     "view_count"       => JSON::Any.new(view_count || "0"),
     "short_view_count" => JSON::Any.new(short_view_count || "0"),
     "author_verified"  => JSON::Any.new(author_verified),
-    "published"        => published,
+    "published"        => JSON::Any.new(published || ""),
   }
 end
 
@@ -238,11 +238,11 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
     if item = element["compactVideoRenderer"]?
       if item["publishedTimeText"]?
         rv_decoded_time = decode_date(item["publishedTimeText"].to_s)
-        rv_published_timestamp = JSON::Any.new(rv_decoded_time.to_unix.to_s)
+        rv_published_timestamp = rv_decoded_time.to_unix.to_s
       else
-        rv_published_timestamp = JSON::Any.new("")
+        rv_published_timestamp = nil
       end
-      related_video = parse_related_video(item, rv_published_timestamp)
+      related_video = parse_related_video(item, published: rv_published_timestamp)
       related << JSON::Any.new(related_video) if related_video
     end
   end
@@ -257,7 +257,7 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
 
     player_overlays.try &.as_a.each do |element|
       if item = element["endScreenVideoRenderer"]?
-        related_video = parse_related_video(item, JSON::Any.new(""))
+        related_video = parse_related_video(item)
         related << JSON::Any.new(related_video) if related_video
       end
     end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -37,6 +37,11 @@ def parse_related_video(related : JSON::Any, published : String? = nil) : Hash(S
   LOGGER.trace("parse_related_video: Found \"watchNextEndScreenRenderer\" container")
 
   publishedText = related["publishedTimeText"]?
+  if !publishedText.nil?
+    publishedSimpleText = publishedText["simpleText"]
+  else
+    publishedSimpleText = nil
+  end
 
   # TODO: when refactoring video types, make a struct for related videos
   # or reuse an existing type, if that fits.
@@ -50,7 +55,7 @@ def parse_related_video(related : JSON::Any, published : String? = nil) : Hash(S
     "short_view_count" => JSON::Any.new(short_view_count || "0"),
     "author_verified"  => JSON::Any.new(author_verified),
     "published"        => JSON::Any.new(published || ""),
-	 "publishedText"    => JSON::Any.new(publishedText["simpleText"]?.to_s || ""),
+	 "publishedText"    => JSON::Any.new(publishedSimpleText || ""),
   }
 end
 

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -38,8 +38,7 @@ def parse_related_video(related : JSON::Any) : Hash(String, JSON::Any)?
 
   if published_time_text = related["publishedTimeText"]?
     decoded_time = decode_date(published_time_text["simpleText"].to_s)
-    published = decoded_time.to_unix.to_s
-    published_time_text = published_time_text["simpleText"].to_s
+    published = decoded_time.to_unix.to_s 
   else
     published = nil
   end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -38,7 +38,7 @@ def parse_related_video(related : JSON::Any) : Hash(String, JSON::Any)?
 
   if published_time_text = related["publishedTimeText"]?
     decoded_time = decode_date(published_time_text["simpleText"].to_s)
-    published = decoded_time.to_unix.to_s
+    published = decoded_time.to_rfc3339.to_s
   else
     published = nil
   end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -93,7 +93,7 @@ def extract_video_info(video_id : String, proxy_region : String? = nil)
     player_response = player_response.merge(next_response)
   end
 
-  params = parse_video_info(video_id, player_response, proxy_region)
+  params = parse_video_info(video_id, player_response)
   params["reason"] = JSON::Any.new(reason) if reason
 
   new_player_response = nil
@@ -158,7 +158,7 @@ def try_fetch_streaming_data(id : String, client_config : YoutubeAPI::ClientConf
   end
 end
 
-def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any), proxy_region : String? = nil) : Hash(String, JSON::Any)
+def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any)) : Hash(String, JSON::Any)
   # Top level elements
 
   main_results = player_response.dig?("contents", "twoColumnWatchNextResults")

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -158,85 +158,6 @@ def try_fetch_streaming_data(id : String, client_config : YoutubeAPI::ClientConf
   end
 end
 
-def parse_published_string(item)
-  time_text = item["publishedTimeText"]?
-  time_string = nil
-  if !time_text.nil?
-    time_string = time_text["simpleText"]?
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("minute ago")
-    time = Time.utc.to_unix - 60
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("minutes ago") && !time_string.to_s.starts_with?("Streamed")
-    minutes = time_string.to_s.rchop(" minutes ago").to_i
-    time = Time.utc.to_unix - 60*minutes
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("minutes ago") && time_string.to_s.starts_with?("Streamed")
-    minutes = time_string.to_s.lchop("Streamed ").rchop(" minutes ago").to_i
-    time = Time.utc.to_unix - 60*minutes
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("hour ago")
-    time = Time.utc.to_unix - 3600
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("hours ago") && !time_string.to_s.starts_with?("Streamed")
-    hours = time_string.to_s.rchop(" hours ago").to_i
-    time = Time.utc.to_unix - 3600*hours
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("hours ago") && time_string.to_s.starts_with?("Streamed")
-    hours = time_string.to_s.lchop("Streamed ").rchop(" hours ago").to_i
-    time = Time.utc.to_unix - 3600*hours
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("day ago")
-    time = Time.utc.to_unix - 86400
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("days ago") && !time_string.to_s.starts_with?("Streamed")
-    days = time_string.to_s.rchop(" days ago").to_i
-    time = Time.utc.to_unix - 86400*days
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("days ago") && time_string.to_s.starts_with?("Streamed")
-    days = time_string.to_s.lchop("Streamed ").rchop(" days ago").to_i
-    time = Time.utc.to_unix - 86400*days
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("week ago")
-    time = Time.utc.to_unix - 604800
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("weeks ago") && !time_string.to_s.starts_with?("Streamed")
-    weeks = time_string.to_s.rchop(" weeks ago").to_i
-    time = Time.utc.to_unix - 604800*weeks
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("weeks ago") && time_string.to_s.starts_with?("Streamed")
-    weeks = time_string.to_s.lchop("Streamed ").rchop(" weeks ago").to_i
-    time = Time.utc.to_unix - 604800*weeks
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("month ago")
-    time = Time.utc.to_unix - 2629743
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("months ago") && !time_string.to_s.starts_with?("Streamed")
-    months = time_string.to_s.rchop(" months ago").to_i
-    time = Time.utc.to_unix - 2629743*months
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("months ago") && time_string.to_s.starts_with?("Streamed")
-    months = time_string.to_s.lchop("Streamed ").rchop(" months ago").to_i
-    time = Time.utc.to_unix - 2629743*months
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("year ago")
-    time = Time.utc.to_unix - 31556926
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("years ago") && !time_string.to_s.starts_with?("Streamed")
-    years = time_string.to_s.rchop(" years ago").to_i
-    time = Time.utc.to_unix - 31556926*years
-  end
-  if !time_string.nil? && time_string.to_s.ends_with?("years ago") && time_string.to_s.starts_with?("Streamed")
-    years = time_string.to_s.lchop("Streamed ").rchop(" years ago").to_i
-    time = Time.utc.to_unix - 31556926*years
-  end
-  if time_string.nil?
-    time = nil
-  end
-
-  return time
-end
-
 def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any), proxy_region : String? = nil) : Hash(String, JSON::Any)
   # Top level elements
 
@@ -315,8 +236,8 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
     .dig?("secondaryResults", "secondaryResults", "results")
   secondary_results.try &.as_a.each do |element|
     if item = element["compactVideoRenderer"]?
-      time = parse_published_string(item)
-      published1 = JSON::Any.new(time.to_s)
+		 time = decode_date(item["publishedTimeText"].to_s)
+		published1 = JSON::Any.new(time.to_unix.to_s)
       related_video = parse_related_video(item, published1)
       related << JSON::Any.new(related_video) if related_video
     end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -237,9 +237,9 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
     .dig?("secondaryResults", "secondaryResults", "results")
   secondary_results.try &.as_a.each do |element|
     if item = element["compactVideoRenderer"]?
-      if item["publishedTimeText"]?
-        rv_published_time_text = item["publishedTimeText"].to_s
-        rv_decoded_time = decode_date(item["publishedTimeText"].to_s)
+      if rv_published_time_text = item["publishedTimeText"]?
+        rv_published_time_text = rv_published_time_text.as_s
+        rv_decoded_time = decode_date(rv_published_time_text)
         rv_published_timestamp = rv_decoded_time.to_unix.to_s
       else
         rv_published_timestamp = nil

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -38,7 +38,7 @@ def parse_related_video(related : JSON::Any, published : String? = nil) : Hash(S
 
   publishedText = related["publishedTimeText"]?
   if !publishedText.nil?
-	  publishedSimpleText = publishedText["simpleText"].to_s
+    publishedSimpleText = publishedText["simpleText"].to_s
   else
     publishedSimpleText = nil
   end
@@ -55,7 +55,7 @@ def parse_related_video(related : JSON::Any, published : String? = nil) : Hash(S
     "short_view_count" => JSON::Any.new(short_view_count || "0"),
     "author_verified"  => JSON::Any.new(author_verified),
     "published"        => JSON::Any.new(published || ""),
-	 "publishedText"    => JSON::Any.new(publishedSimpleText || ""),
+    "publishedText"    => JSON::Any.new(publishedSimpleText || ""),
   }
 end
 

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -38,7 +38,7 @@ def parse_related_video(related : JSON::Any) : Hash(String, JSON::Any)?
 
   if published_time_text = related["publishedTimeText"]?
     decoded_time = decode_date(published_time_text["simpleText"].to_s)
-    published = decoded_time.to_unix.to_s 
+    published = decoded_time.to_unix.to_s
   else
     published = nil
   end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -236,7 +236,11 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
     .dig?("secondaryResults", "secondaryResults", "results")
   secondary_results.try &.as_a.each do |element|
     if item = element["compactVideoRenderer"]?
-      time_string = item["publishedTimeText"]["simpleText"]?
+      time_text = item["publishedTimeText"]?
+      time_string = nil
+      if !time_text.nil?
+        time_string = time_text["simpleText"]?
+      end
       if !time_string.nil? && time_string.to_s.ends_with?("hour ago")
         time = Time.utc.to_unix - 3600
       end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -38,7 +38,7 @@ def parse_related_video(related : JSON::Any, published : String? = nil) : Hash(S
 
   publishedText = related["publishedTimeText"]?
   if !publishedText.nil?
-    publishedSimpleText = publishedText["simpleText"]
+	  publishedSimpleText = publishedText["simpleText"].to_s
   else
     publishedSimpleText = nil
   end


### PR DESCRIPTION
This closes #3058.

It could also allow recommended videos to have their upload date shown on the `/watch` route. Let me know if you want me to add that as well.

Important thing to note - this way of adding the parameter wouldn't be very precise for old videos. New videos may show up as "1 hour ago" and when that happens, the date would be accurate to the hours. Old videos may show up as "1 year ago" and that would mean that the date would only be accurate to the years. The month and day would just be chosen to be the current time's month and day, so it wouldn't even be close. But without making more API requests I don't see how this can work more accurately.