### PR TITLE
update params for fetching stream data

### DIFF
--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -137,9 +137,9 @@ end
 
 def try_fetch_streaming_data(id : String, client_config : YoutubeAPI::ClientConfig) : Hash(String, JSON::Any)?
   LOGGER.debug("try_fetch_streaming_data: [#{id}] Using #{client_config.client_type} client.")
-  # CgIQBg is a workaround for streaming URLs that returns a 403.
+  # 2AMBCgIQBg is a workaround for streaming URLs that returns a 403.
   # See https://github.com/iv-org/invidious/issues/4027#issuecomment-1666944520
-  response = YoutubeAPI.player(video_id: id, params: "CgIQBg", client_config: client_config)
+  response = YoutubeAPI.player(video_id: id, params: "2AMBCgIQBg", client_config: client_config)
 
   playability_status = response["playabilityStatus"]["status"]
   LOGGER.debug("try_fetch_streaming_data: [#{id}] Got playabilityStatus == #{playability_status}.")

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -138,7 +138,6 @@ end
 def try_fetch_streaming_data(id : String, client_config : YoutubeAPI::ClientConfig) : Hash(String, JSON::Any)?
   LOGGER.debug("try_fetch_streaming_data: [#{id}] Using #{client_config.client_type} client.")
   # 2AMBCgIQBg is a workaround for streaming URLs that returns a 403.
-  # See https://github.com/iv-org/invidious/issues/4027#issuecomment-1666944520
   response = YoutubeAPI.player(video_id: id, params: "2AMBCgIQBg", client_config: client_config)
 
   playability_status = response["playabilityStatus"]["status"]


### PR DESCRIPTION
the param has changed and it's now this value that is used by all the alternative clients to youtube.

example in youtube js: https://github.com/LuanRT/YouTube.js/blob/main/src/core/endpoints/PlayerEndpoint.ts#L46