### PR TITLE
API: Add playlist and start time to resolve_url

### DIFF
--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -163,7 +163,7 @@ module Invidious::Routes::API::V1::Misc
       if head_response.headers["location"]?
         url = head_response.headers["location"]
       end
-    
+
       resolved_url = YoutubeAPI.resolve_url(url.as(String))
       endpoint = resolved_url["endpoint"]
       pageType = endpoint.dig?("commandMetadata", "webCommandMetadata", "webPageType").try &.as_s || ""

--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -175,6 +175,8 @@ module Invidious::Routes::API::V1::Misc
       json.object do
         json.field "ucid", sub_endpoint["browseId"].as_s if sub_endpoint["browseId"]?
         json.field "videoId", sub_endpoint["videoId"].as_s if sub_endpoint["videoId"]?
+        json.field "playlistId", sub_endpoint["playlistId"].as_s if sub_endpoint["playlistId"]?
+        json.field "startTimeSeconds", sub_endpoint["startTimeSeconds"].as_s if sub_endpoint["startTimeSeconds"]?
         json.field "params", params.try &.as_s
         json.field "pageType", pageType
       end

--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -159,6 +159,11 @@ module Invidious::Routes::API::V1::Misc
     return error_json(400, "Missing URL to resolve") if !url
 
     begin
+      head_response = HTTP::Client.head url.as(String)
+      if head_response.headers["location"]?
+        url = head_response.headers["location"]
+      end
+    
       resolved_url = YoutubeAPI.resolve_url(url.as(String))
       endpoint = resolved_url["endpoint"]
       pageType = endpoint.dig?("commandMetadata", "webCommandMetadata", "webPageType").try &.as_s || ""

--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -159,11 +159,6 @@ module Invidious::Routes::API::V1::Misc
     return error_json(400, "Missing URL to resolve") if !url
 
     begin
-      head_response = HTTP::Client.head url.as(String)
-      if head_response.headers["location"]?
-        url = head_response.headers["location"]
-      end
-
       resolved_url = YoutubeAPI.resolve_url(url.as(String))
       endpoint = resolved_url["endpoint"]
       pageType = endpoint.dig?("commandMetadata", "webCommandMetadata", "webPageType").try &.as_s || ""

--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -176,7 +176,7 @@ module Invidious::Routes::API::V1::Misc
         json.field "ucid", sub_endpoint["browseId"].as_s if sub_endpoint["browseId"]?
         json.field "videoId", sub_endpoint["videoId"].as_s if sub_endpoint["videoId"]?
         json.field "playlistId", sub_endpoint["playlistId"].as_s if sub_endpoint["playlistId"]?
-        json.field "startTimeSeconds", sub_endpoint["startTimeSeconds"].as_s if sub_endpoint["startTimeSeconds"]?
+        json.field "startTimeSeconds", sub_endpoint["startTimeSeconds"].as_i if sub_endpoint["startTimeSeconds"]?
         json.field "params", params.try &.as_s
         json.field "pageType", pageType
       end


### PR DESCRIPTION
Captures the start time and the playlist id (if any) of the resolved url.

Also, make a head request to check for redirects. This is to resolve short urls (`https://youtu.be/<videoId>?t=60`)