### PR TITLE
force resolve for everything

### DIFF
--- a/src/invidious/yt_backend/connection_pool.cr
+++ b/src/invidious/yt_backend/connection_pool.cr
@@ -37,7 +37,7 @@ struct YoutubeConnectionPool
         conn.close
         conn = HTTP::Client.new(url)
 
-        conn.family = (url.host == "www.youtube.com") ? CONFIG.force_resolve : Socket::Family::INET
+        conn.family = CONFIG.force_resolve
         conn.family = Socket::Family::INET if conn.family == Socket::Family::UNSPEC
         conn.before_request { |r| add_yt_headers(r) } if url.host == "www.youtube.com"
         response = yield conn
@@ -52,7 +52,7 @@ struct YoutubeConnectionPool
   private def build_pool
     DB::Pool(HTTP::Client).new(initial_pool_size: 0, max_pool_size: capacity, max_idle_pool_size: capacity, checkout_timeout: timeout) do
       conn = HTTP::Client.new(url)
-      conn.family = (url.host == "www.youtube.com") ? CONFIG.force_resolve : Socket::Family::INET
+      conn.family = CONFIG.force_resolve
       conn.family = Socket::Family::INET if conn.family == Socket::Family::UNSPEC
       conn.before_request { |r| add_yt_headers(r) } if url.host == "www.youtube.com"
       conn
@@ -62,7 +62,7 @@ end
 
 def make_client(url : URI, region = nil)
   client = HTTPClient.new(url, OpenSSL::SSL::Context::Client.insecure)
-  client.family = (url.host == "www.youtube.com") ? CONFIG.force_resolve : Socket::Family::UNSPEC
+  client.family = CONFIG.force_resolve
   client.before_request { |r| add_yt_headers(r) } if url.host == "www.youtube.com"
   client.read_timeout = 10.seconds
   client.connect_timeout = 10.seconds


### PR DESCRIPTION
Previously, only www.youtube.com was forced resolved, but now all the traffic will be force resolved to whatever IP version the user specify.

This is for being sure that all the proxy to googlevideo.com is being sent in the correct specified IP version. This will help for the issue https://github.com/iv-org/invidious/issues/4045

I did test and this doesn't break anything. When nothing is forced, the default value is used: https://github.com/iv-org/invidious/blob/master/src/invidious/config.cr#L122