### PR TITLE
WIP: Add openssl_ca_certs_file and openssl_ca_certs_dir config options

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -140,6 +140,28 @@ https_only: false
 ##
 #pool_size: 100
 
+##
+## File containing the Certificate Authorities, in the PEM format
+## as expected by OpenSSL. For example, /etc/ssl1.1/certs.pem on Alpine.
+## By default, Invidious by using Crystal standard library will use
+## the default setting from the crystal binary it was compiled with.
+## This option is incompatible with openssl_ca_certs_dir.
+##
+## Default: <none>
+##
+#openssl_ca_certs_file:
+
+##
+## Folder containing the Certificate Authorities, in the PEM format
+## as expected by OpenSSL. For example, /etc/ssl/certs/ on Debian.
+## By default, Invidious by using Crystal standard library will use
+## the default setting from the crystal binary it was compiled with.
+## This option is incompatible with openssl_ca_certs_file.
+##
+## Default: <none>
+##
+#openssl_ca_certs_dir:
+
 
 ##
 ## Additional cookies to be sent when requesting the youtube API.

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -126,6 +126,10 @@ class Config
   property host_binding : String = "0.0.0.0"
   # Pool size for HTTP requests to youtube.com and ytimg.com (each domain has a separate pool of `pool_size`)
   property pool_size : Int32 = 100
+  # CA certificates file for OpenSSL
+  property openssl_ca_certs_file : String? = nil
+  # CA certificates folder for OpenSSL
+  property openssl_ca_certs_dir : String? = nil
 
   # Use Innertube's transcripts API instead of timedtext for closed captions
   property use_innertube_for_captions : Bool = false
@@ -230,6 +234,12 @@ class Config
         puts "Config: Either database_url or db.* is required"
         exit(1)
       end
+    end
+
+    # We can only have openssl_ca_certs_file or openssl_ca_certs_dir, not both
+    if !(config.openssl_ca_certs_file.nil? || config.openssl_ca_certs_dir.nil?)
+      puts "Config: You can't have both openssl_ca_certs_file and openssl_ca_certs_folder."
+      exit(1)
     end
 
     return config


### PR DESCRIPTION
Don't merge yet!

Hello, i want to be able to configure the CA certificates for invidious for statically-linked build running on another distro. First time writing Crystal so please say where i can improve.

One problem i have with this patch: video works but i don't have any images? They all return 200 with empty content and i dont see something strange in logs.

Before this patch i had :

```
Nov 05 20:36:15 nanopi.local invidious[83689]: 2023-11-05T19:36:15.448841Z  ERROR - http.server: Unhandled exception on HTTP::Handler
Nov 05 20:36:15 nanopi.local invidious[83689]: SSL_connect: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed (OpenSSL::SSL::Error)
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/openssl/ssl/socket.cr:34:11 in 'initialize'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/openssl/ssl/socket.cr:3:5 in 'new:context:sync_close:hostname'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /build/src/invidious/helpers/crystal_class_overrides.cr:34:5 in 'io'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/http/client.cr:678:19 in 'send_request'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/http/client.cr:610:37 in 'exec_internal_single'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/http/client.cr:592:18 in 'exec_internal'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/http/client.cr:585:7 in 'exec'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/http/client.cr:721:5 in 'exec'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/http/client.cr:410:3 in 'get'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /build/src/invidious/routes/errors.cr:12:35 in 'error_404'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /build/src/invidious.cr:203:3 in '->'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /build/lib/kemal/src/kemal/config.cr:96:102 in '->'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /build/src/invidious/helpers/handlers.cr:57:71 in 'call_exception_with_status_code'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /build/lib/kemal/src/kemal/exception_handler.cr:10:7 in 'call'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/http/server/handler.cr:30:7 in 'call_next'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /build/src/invidious/helpers/logger.cr:17:35 in 'call'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/http/server/handler.cr:30:7 in 'call_next'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /build/lib/kemal/src/kemal/init_handler.cr:12:7 in 'call'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/http/server/request_processor.cr:51:11 in 'process'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/http/server.cr:521:5 in 'handle_client'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/http/server.cr:451:5 in '->'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/fiber.cr:146:11 in 'run'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from /usr/share/crystal/src/fiber.cr:98:34 in '->'
Nov 05 20:36:15 nanopi.local invidious[83689]:   from ???
Nov 05 20:38:47 nanopi.local systemd[1]: Stopping Invidious: alternative YouTube front-end...
```

Maybe you have an idea?

Sidenote: images work in a specific setting (when invidious was built on the same distro) so i probably missed to set TLS settings somewhere. 