### PR TITLE
Channel: Fetch header informations from homepage

### DIFF
--- a/src/invidious/channels/about.cr
+++ b/src/invidious/channels/about.cr
@@ -18,8 +18,8 @@ record AboutChannel,
 
 def get_about_info(ucid, locale) : AboutChannel
   begin
-    # "EgVhYm91dA==" is the base64-encoded protobuf object {"2:string":"about"}
-    initdata = YoutubeAPI.browse(browse_id: ucid, params: "EgVhYm91dA==")
+    # "EgVhYm91dPIGBAoCEgA=" is the base64-encoded protobuf object {"2:0:string":"about","110:1:embedded":{"1:0:embedded":{"2:0:string":""}}}
+    initdata = YoutubeAPI.browse(browse_id: ucid, params: "EgVhYm91dPIGBAoCEgA=")
   rescue
     raise InfoException.new("Could not get channel info.")
   end

--- a/src/invidious/channels/about.cr
+++ b/src/invidious/channels/about.cr
@@ -18,8 +18,8 @@ record AboutChannel,
 
 def get_about_info(ucid, locale) : AboutChannel
   begin
-    # "EgVhYm91dPIGBAoCEgA=" is the base64-encoded protobuf object {"2:0:string":"about","110:1:embedded":{"1:0:embedded":{"2:0:string":""}}}
-    initdata = YoutubeAPI.browse(browse_id: ucid, params: "EgVhYm91dPIGBAoCEgA=")
+    # Fetch channel information from channel home page
+    initdata = YoutubeAPI.browse(browse_id: ucid, params: "")
   rescue
     raise InfoException.new("Could not get channel info.")
   end


### PR DESCRIPTION
Closes #4238

YouTube is removing the about tab from channels so Invidious can no longer utilize it to obtain basic channel information (title, banner, etc). This PR just switches the code to use the default homepage instead.

In the future we should try and look into a way to prevent making two requests to YouTube on the various pagination of the channel tabs. The simplest answer would probably be to just cache the results. But we should be able to optimize it  to a single request on the initial page as the initial request also contains basic channel information we need.   