### PR TITLE
Improve depends_on docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,9 @@ services:
       timeout: 5s
       retries: 2
     depends_on:
-      - invidious-db
+      invidious-db:
+        condition: service_healthy
+        restart: true
 
   invidious-db:
     image: docker.io/library/postgres:14

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,6 @@ services:
     depends_on:
       invidious-db:
         condition: service_healthy
-        restart: true
 
   invidious-db:
     image: docker.io/library/postgres:14


### PR DESCRIPTION
Checking the service is up and healthy before start the service to avoid issue first boot.