### PR TITLE
support for private instances

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -253,16 +253,6 @@ https_only: false
 #private_instance: false
 
 ##
-## Redirect request to the login page on private instances. Also requires
-## login_enabled to be 'true', otherwise the server sends status code 401
-## and closes the connection.
-##
-## Accepted values: true, false
-## Default: false
-##
-#redirect_login: false
-
-##
 ## Allow/Forbid Invidious (local) account creation. Invidious
 ## accounts allow users to subscribe to channels and to create
 ## playlists without a Google account.

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -237,6 +237,32 @@ https_only: false
 # -----------------------------
 
 ##
+## Allow/Forbid the usage of the Invidious Instance without an account.
+## Only /login and /privacy are accessible on such instances for unregistered
+## users on the web interface. Moreover, certain API endpoints are accessible,
+## to allow third-party clients to add the instance and login to an existing
+## account.
+##
+## To avoid any data leakage it is recommended to set popular_enabled and
+## statistics_enabled to 'false'. Furthermore, registration_enabled should be
+## set to 'false' to only allow existing users to access the instance.
+##
+## Accepted values: true, false
+## Default: false
+##
+#private_instance: false
+
+##
+## Redirect request to the login page on private instances. Also requires
+## login_enabled to be 'true', otherwise the server sends status code 401
+## and closes the connection.
+##
+## Accepted values: true, false
+## Default: false
+##
+#redirect_login: false
+
+##
 ## Allow/Forbid Invidious (local) account creation. Invidious
 ## accounts allow users to subscribe to channels and to create
 ## playlists without a Google account.
@@ -777,7 +803,7 @@ default_user_preferences:
   ##
   ## Default dash video quality.
   ##
-  ## Note: this setting only takes effet if the
+  ## Note: this setting only takes effect if the
   ## 'quality' parameter is set to "dash".
   ##
   ## Accepted values:
@@ -812,7 +838,7 @@ default_user_preferences:
   ## Default: true
   ##
   #vr_mode: true
-  
+
   ##
   ## Save the playback position
   ## Allow to continue watching at the previous position when

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -92,6 +92,10 @@ class Config
   property use_pubsub_feeds : Bool | Int32 = false
   property popular_enabled : Bool = true
   property captcha_enabled : Bool = true
+  # Only allow usage of the Invidious instance with an existing account
+  property private_instance : Bool = false
+  # Redirected requests to the login page on a private instance. Requires login_enabled: true
+  property redirect_login : Bool = false
   property login_enabled : Bool = true
   property registration_enabled : Bool = true
   property statistics_enabled : Bool = false

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -94,8 +94,6 @@ class Config
   property captcha_enabled : Bool = true
   # Only allow usage of the Invidious instance with an existing account
   property private_instance : Bool = false
-  # Redirected requests to the login page on a private instance. Requires login_enabled: true
-  property redirect_login : Bool = false
   property login_enabled : Bool = true
   property registration_enabled : Bool = true
   property statistics_enabled : Bool = false

--- a/src/invidious/routes/before_all.cr
+++ b/src/invidious/routes/before_all.cr
@@ -88,11 +88,11 @@ module Invidious::Routes::BeforeAll
       end
     end
 
-    # TODO: popular and trending are here for clients that require these endpoints to be accessible e.g. Clipious
+    # TODO: popular and trending are whitelisted for clients that require these endpoints to be accessible e.g. Clipious
     # can be removed as soon as those clients can handele these request on private instances
     unregistered_path_whitelist = {
       "/login",
-      "/privacy"
+      "/privacy",
       "/api/v1/stats",
       "/api/v1/popular",
       "/api/v1/trending",

--- a/src/invidious/routes/before_all.cr
+++ b/src/invidious/routes/before_all.cr
@@ -88,12 +88,12 @@ module Invidious::Routes::BeforeAll
       end
     end
 
+    # TODO: popular and trending are here for clients that require these endpoints to be accessible e.g. Clipious
+    # can be removed as soon as those clients can handele these request on private instances
     unregistered_path_whitelist = {
       "/login",
       "/privacy"
       "/api/v1/stats",
-      # TODO: popular and trending are here for clients that require these endpoints to be accessible e.g. Clipious
-      # can be removed as soon as those clients can handele these request on private instances
       "/api/v1/popular",
       "/api/v1/trending",
       "/feed/webhook/v1:",

--- a/src/invidious/routes/before_all.cr
+++ b/src/invidious/routes/before_all.cr
@@ -99,31 +99,26 @@ module Invidious::Routes::BeforeAll
       "/feed/webhook/v1:",
       "/api/v1/videos/dQw4w9WgXcQ",
       "/api/v1/comments/jNQXAC9IVRw",
-      }
+    }
 
     if CONFIG.private_instance && !env.get?("user") && !unregistered_path_whitelist.any? { |r| env.request.path.starts_with? r }
-      if CONFIG.redirect_login && CONFIG.login_enabled
-        env.response.headers["Location"] = "/login"
-        haltf env, status_code: 302
-      else
-        env.response.status_code = 401
-        env.response.close
-      end
+      env.response.headers["Location"] = "/login"
+      haltf env, status_code: 302
     end
 
     return if {
-      "/sb/",
-      "/vi/",
-      "/s_p/",
-      "/yts/",
-      "/ggpht/",
-      "/download",
-      "/licenses",
-      "/api/manifest/",
-      "/videoplayback",
-      "/latest_version",
-      "/opensearch.xml",
-    }.any? { |r| env.request.resource.starts_with? r }
+                "/sb/",
+                "/vi/",
+                "/s_p/",
+                "/yts/",
+                "/ggpht/",
+                "/download",
+                "/licenses",
+                "/api/manifest/",
+                "/videoplayback",
+                "/latest_version",
+                "/opensearch.xml",
+              }.any? { |r| env.request.resource.starts_with? r }
 
     dark_mode = convert_theme(env.params.query["dark_mode"]?) || preferences.dark_mode.to_s
     thin_mode = env.params.query["thin_mode"]? || preferences.thin_mode.to_s


### PR DESCRIPTION
This is a modification of PR #3728. And addresses #446

Server admins can set the instance to be private. Which means it is only accessible with a registered user account.

The endpoints `/api/v1/popular` and `/api/v1/trending` are whitelisted because some clients expect them to be open.