### PR TITLE
Videos: Use start time and end time for clips

### DIFF
--- a/src/invidious/routes/api/v1/videos.cr
+++ b/src/invidious/routes/api/v1/videos.cr
@@ -397,8 +397,8 @@ module Invidious::Routes::API::V1::Videos
 
     return JSON.build do |json|
       json.object do
-        json.field "startTime", start_time
-        json.field "endTime", end_time
+        json.field "startTimeSeconds", start_time
+        json.field "endTimeSeconds", end_time
         json.field "clipTitle", clip_title
         json.field "video" do
           Invidious::JSONify::APIv1.video(video, json, locale: locale, proxy: proxy)

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -276,19 +276,9 @@ module Invidious::Routes::Watch
 
     if video_id = response.dig?("endpoint", "watchEndpoint", "videoId")
       if params = response.dig?("endpoint", "watchEndpoint", "params").try &.as_s
-        decoded_protobuf = params.try { |i| URI.decode_www_form(i) }
-          .try { |i| Base64.decode(i) }
-          .try { |i| IO::Memory.new(i) }
-          .try { |i| Protodec::Any.parse(i) }
-
-        start_time = decoded_protobuf
-          .try(&.["50:0:embedded"]["2:1:varint"].as_i64)
-
-        end_time = decoded_protobuf
-          .try(&.["50:0:embedded"]["3:2:varint"].as_i64)
-
-        env.params.query["start"] = (start_time / 1000).to_s
-        env.params.query["end"] = (end_time / 1000).to_s
+        start_time, end_time, _ = parse_clip_parameters(params)
+        env.params.query["start"] = start_time.to_s
+        env.params.query["end"] = end_time.to_s
       end
 
       return env.redirect "/watch?v=#{video_id}&#{env.params.query}"

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -277,8 +277,8 @@ module Invidious::Routes::Watch
     if video_id = response.dig?("endpoint", "watchEndpoint", "videoId")
       if params = response.dig?("endpoint", "watchEndpoint", "params").try &.as_s
         start_time, end_time, _ = parse_clip_parameters(params)
-        env.params.query["start"] = start_time.to_s
-        env.params.query["end"] = end_time.to_s
+        env.params.query["start"] = start_time.to_s if start_time != nil
+        env.params.query["end"] = end_time.to_s if end_time != nil
       end
 
       return env.redirect "/watch?v=#{video_id}&#{env.params.query}"

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -235,6 +235,7 @@ module Invidious::Routing
       get "/api/v1/captions/:id", {{namespace}}::Videos, :captions
       get "/api/v1/annotations/:id", {{namespace}}::Videos, :annotations
       get "/api/v1/comments/:id", {{namespace}}::Videos, :comments
+      get "/api/v1/clips/:id", {{namespace}}::Videos, :clips
 
       # Feeds
       get "/api/v1/trending", {{namespace}}::Feeds, :trending

--- a/src/invidious/videos/clip.cr
+++ b/src/invidious/videos/clip.cr
@@ -1,0 +1,20 @@
+require "json"
+
+# returns start_time, end_time and clip_title
+def parse_clip_parameters(params) : {Float64, Float64, String}
+  decoded_protobuf = params.try { |i| URI.decode_www_form(i) }
+    .try { |i| Base64.decode(i) }
+    .try { |i| IO::Memory.new(i) }
+    .try { |i| Protodec::Any.parse(i) }
+
+  start_time = decoded_protobuf
+    .try(&.["50:0:embedded"]["2:1:varint"].as_i64)
+
+  end_time = decoded_protobuf
+    .try(&.["50:0:embedded"]["3:2:varint"].as_i64)
+
+  clip_title = decoded_protobuf
+    .try(&.["50:0:embedded"]["4:3:string"].as_s)
+
+  return (start_time / 1000), (end_time / 1000), clip_title
+end

--- a/src/invidious/videos/clip.cr
+++ b/src/invidious/videos/clip.cr
@@ -1,7 +1,7 @@
 require "json"
 
 # returns start_time, end_time and clip_title
-def parse_clip_parameters(params) : {Float64, Float64, String}
+def parse_clip_parameters(params) : {Float64?, Float64?, String?}
   decoded_protobuf = params.try { |i| URI.decode_www_form(i) }
     .try { |i| Base64.decode(i) }
     .try { |i| IO::Memory.new(i) }
@@ -9,12 +9,14 @@ def parse_clip_parameters(params) : {Float64, Float64, String}
 
   start_time = decoded_protobuf
     .try(&.["50:0:embedded"]["2:1:varint"].as_i64)
+    .try { |i| i/1000 }
 
   end_time = decoded_protobuf
     .try(&.["50:0:embedded"]["3:2:varint"].as_i64)
+    .try { |i| i/1000 }
 
   clip_title = decoded_protobuf
     .try(&.["50:0:embedded"]["4:3:string"].as_s)
 
-  return (start_time / 1000), (end_time / 1000), clip_title
+  return start_time, end_time, clip_title
 end


### PR DESCRIPTION
This PR parses the start and end time for clips. 
closes https://github.com/iv-org/invidious/issues/3921
https://github.com/FreeTubeApp/FreeTube/issues/4323

Ex url: [https://www.youtube.com/clip/UgkxxPM3BRphCAPLP88YoUGuj79KXPfpNNO_](https://www.youtube.com/clip/UgkxxPM3BRphCAPLP88YoUGuj79KXPfpNNO_)
API url: `/api/v1/clips/UgkxxPM3BRphCAPLP88YoUGuj79KXPfpNNO_?pretty=1`

API Response:

```typescript
{
  "startTime": 8842.645,
  "endTime": 8855.856,
  "clipTitle": "✂️ Kirby is pink!",
  "video": [Video Object](https://docs.invidious.io/api/common_types/#videoobject)
}
```