### PR TITLE
CSS: Fix thumbnails' aspect ratio to prevent CLS

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -197,6 +197,7 @@ img.thumbnail {
   display: block; /* See: https://stackoverflow.com/a/11635197 */
   width: 100%;
   object-fit: cover;
+  aspect-ratio: 16 / 9;
 }
 
 .thumbnail-placeholder {


### PR DESCRIPTION
Closes https://github.com/iv-org/invidious/issues/4002

Static fixed aspect ratio to prevent CLS when thumbnails load.

Old situation:

![Screen Recording 2023-11-21 at 08 17 41](https://github.com/cornedor/invidious/assets/570297/52e6ab72-161a-4719-bac1-de6764e6ae59)

New situation:

![Screen Recording 2023-11-21 at 08 16 57](https://github.com/cornedor/invidious/assets/570297/f3449464-10b6-422d-8e8c-702373259909)
