### PR TITLE
Install rsvg-convert on docker images (#4230)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN if [[ "${release}" == 1 ]] ; then \
     fi
 
 FROM alpine:3.18
-RUN apk add --no-cache librsvg ttf-opensans tini
+RUN apk add --no-cache rsvg-convert ttf-opensans tini
 WORKDIR /invidious
 RUN addgroup -g 1000 -S invidious && \
     adduser -u 1000 -S invidious -G invidious

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -33,7 +33,7 @@ RUN if [[ "${release}" == 1 ]] ; then \
     fi
 
 FROM alpine:3.18
-RUN apk add --no-cache librsvg ttf-opensans tini
+RUN apk add --no-cache rsvg-convert ttf-opensans tini
 WORKDIR /invidious
 RUN addgroup -g 1000 -S invidious && \
     adduser -u 1000 -S invidious -G invidious


### PR DESCRIPTION
In #4103 alpine was updated from 3.16 to 3.18, but in 3.17 librsvg packages was splitted and rsvg-convert is on his own package.