### PR TITLE
Enchanced audio selection

### DIFF
--- a/src/invidious/frontend/watch_page.cr
+++ b/src/invidious/frontend/watch_page.cr
@@ -74,6 +74,9 @@ module Invidious::Frontend::WatchPage
 
       video_assets.audio_streams.each do |option|
         mimetype = option["mimeType"].as_s.split(";")[0]
+        if mimetype == "audio/webm"
+          mimetype = "audio/opus"
+        end
 
         value = {"itag": option["itag"], "ext": mimetype.split("/")[1]}.to_json
 

--- a/src/invidious/routes/api/manifest.cr
+++ b/src/invidious/routes/api/manifest.cr
@@ -68,7 +68,9 @@ module Invidious::Routes::API::Manifest
               # However, most players don't support auto quality switching, so we have to trick them
               # into providing a quality selector.
               # See https://github.com/iv-org/invidious/issues/3074 for more details.
-              xml.element("AdaptationSet", id: i, mimeType: mime_type, startWithSAP: 1, subsegmentAlignment: true, label: fmt["bitrate"].to_s + "k") do
+              bitrate = ( fmt["bitrate"].as_i / 1000 ).round(0).to_i.to_s + "k"
+
+              xml.element("AdaptationSet", id: i, mimeType: mime_type, startWithSAP: 1, subsegmentAlignment: true, label: bitrate) do
                 codecs = fmt["mimeType"].as_s.split("codecs=")[1].strip('"')
                 bandwidth = fmt["bitrate"].as_i
                 itag = fmt["itag"].as_i

--- a/src/invidious/routes/api/manifest.cr
+++ b/src/invidious/routes/api/manifest.cr
@@ -68,7 +68,7 @@ module Invidious::Routes::API::Manifest
               # However, most players don't support auto quality switching, so we have to trick them
               # into providing a quality selector.
               # See https://github.com/iv-org/invidious/issues/3074 for more details.
-              bitrate = ( fmt["bitrate"].as_i / 1000 ).round(0).to_i.to_s + "k"
+              bitrate = (fmt["bitrate"].as_i / 1000).round(0).to_i.to_s + "k"
 
               xml.element("AdaptationSet", id: i, mimeType: mime_type, startWithSAP: 1, subsegmentAlignment: true, label: bitrate) do
                 codecs = fmt["mimeType"].as_s.split("codecs=")[1].strip('"')

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -22,12 +22,16 @@
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
 
-                bitrate = fmt["bitrate"]
+                codec = fmt["mimeType"].as_s.split(";")[0].split("/")[1]
+                codec = codec == "webm" ? "opus" : codec
+
+                bitrate = ( fmt["bitrate"].as_i / 1000 ).round(0).to_i.to_s
+                quality_audio = "#{codec} @ #{bitrate}k"
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)
             %>
-                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>k" selected="<%= selected %>">
+                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= quality_audio %>" selected="<%= selected %>">
                 <% if !params.local && !CONFIG.disabled?("local") %>
                 <source src="<%= src_url %>&local=true" type='<%= mimetype %>' hidequalityoption="true">
                 <% end %>


### PR DESCRIPTION
This change should address issues #4235 and #2513 

To be exact:

- When listening to audio in listening mode, codec and quality are specified in the list (i.e. "opus @ 64k", "mp4 @ 128k")
- When viewing video in DASH mode, audio quality can be selected based on the bitrate (it's not necessary to have codec listed, as, at least for now, support for Opus is not enabled) (i.e. "64k", "128k", etc.)