### PR TITLE
Makefile: Add player dependency fetching as separate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,14 +35,17 @@ endif
 #  Main
 # -----------------------
 
-all: invidious
+all: get-player-dependencies invidious
 
 get-libs:
 	shards install --production
 
+get-player-dependencies:
+	crystal run scripts/fetch-player-dependencies.cr
+
 # TODO: add support for ARM64 via cross-compilation
 invidious: get-libs
-	crystal build src/invidious.cr $(FLAGS) --progress --stats --error-trace
+	crystal build src/invidious.cr $(FLAGS) --progress --stats --error-trace -Dskip_videojs_download
 
 
 run: invidious


### PR DESCRIPTION
This PR really isn't necessary but it'll allow simultaneously fetching the player dependencies and compiling Invidious when using Make's job feature.

I find that it improves Invidious's _initial_ compile speed by a couple seconds 