### PR TITLE
Add support for displaying channel watermark/favicon on videos

### DIFF
--- a/assets/css/player.css
+++ b/assets/css/player.css
@@ -269,7 +269,7 @@ video.video-js {
 }
 
 .channel-watermark-container {
-  margin: 5px;
+  margin: 0 35px;
   opacity: 0.7;
   transition: opacity .25s cubic-bezier(0,0,.2,1);
 }

--- a/assets/css/player.css
+++ b/assets/css/player.css
@@ -262,3 +262,23 @@ video.video-js {
     overflow-x: hidden;
   }
 }
+
+
+.video-js div.channel-watermark-container {
+  background-color: transparent !important;
+}
+
+.channel-watermark-container {
+  margin: 5px;
+  opacity: 0.7;
+  transition: opacity .25s cubic-bezier(0,0,.2,1);
+}
+
+.channel-watermark-container:hover {
+  opacity: 1
+}
+
+.channel-watermark {
+  width: 40px;
+  height: 40px;
+}

--- a/assets/css/player.css
+++ b/assets/css/player.css
@@ -264,21 +264,16 @@ video.video-js {
 }
 
 
-.video-js div.channel-watermark-container {
+.video-js div.channel-watermark {
   background-color: transparent !important;
 }
 
-.channel-watermark-container {
+.channel-watermark {
   margin: 0 35px;
   opacity: 0.7;
   transition: opacity .25s cubic-bezier(0,0,.2,1);
 }
 
-.channel-watermark-container:hover {
+.channel-watermark:hover {
   opacity: 1
-}
-
-.channel-watermark {
-  width: 40px;
-  height: 40px;
 }

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -764,6 +764,24 @@ if (location.pathname.startsWith('/embed/')) {
     cb.addChild(watch_on_invidious_button);
 }
 
+// Channel watermark
+if (video_data.watermark) {
+    const watermark_html = `<a href="/channel/${video_data.ucid}"><img class="channel-watermark" src="${video_data.watermark.thumbnailURL}"/></a>`;
+    
+    player.overlay({
+        overlays: [
+            { 
+                start: Math.round(parseInt(video_data.watermark.startTimeMs) / 1000), 
+                content: watermark_html, 
+                end: Math.round(parseInt(video_data.watermark.endTimeMs) / 1000), 
+                align: 'bottom-right',
+                showBackground: false,
+                class: "channel-watermark-container"
+            },
+        ]
+    });
+};
+
 addEventListener('DOMContentLoaded', function () {
     // Save time during redirection on another instance
     const changeInstanceLink = document.querySelector('#watch-on-another-invidious-instance > a');

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -766,7 +766,7 @@ if (location.pathname.startsWith('/embed/')) {
 
 // Channel watermark
 if (video_data.watermark && video_data.preferences.show_channel_watermark) {
-    const watermark_html = `<a href="/channel/${video_data.ucid}"><img class="channel-watermark" src="${video_data.watermark.thumbnailUrl}"/></a>`;
+    const watermark_html = `<a href="/channel/${video_data.ucid}"><img src="${video_data.watermark.thumbnailUrl}" height="${video_data.watermark.thumbnailHeight}" width="${video_data.watermark.thumbnailWidth}"/></a>`;
     
     player.overlay({
         overlays: [
@@ -776,7 +776,7 @@ if (video_data.watermark && video_data.preferences.show_channel_watermark) {
                 end: Math.round(parseInt(video_data.watermark.endTimeMs) / 1000), 
                 align: 'bottom-right',
                 showBackground: false,
-                class: "channel-watermark-container"
+                class: "channel-watermark"
             },
         ]
     });

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -766,7 +766,7 @@ if (location.pathname.startsWith('/embed/')) {
 
 // Channel watermark
 if (video_data.watermark) {
-    const watermark_html = `<a href="/channel/${video_data.ucid}"><img class="channel-watermark" src="${video_data.watermark.thumbnailURL}"/></a>`;
+    const watermark_html = `<a href="/channel/${video_data.ucid}"><img class="channel-watermark" src="${video_data.watermark.thumbnailUrl}"/></a>`;
     
     player.overlay({
         overlays: [

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -765,7 +765,7 @@ if (location.pathname.startsWith('/embed/')) {
 }
 
 // Channel watermark
-if (video_data.watermark) {
+if (video_data.watermark && video_data.preferences.show_channel_watermark) {
     const watermark_html = `<a href="/channel/${video_data.ucid}"><img class="channel-watermark" src="${video_data.watermark.thumbnailUrl}"/></a>`;
     
     player.overlay({

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -824,7 +824,7 @@ default_user_preferences:
   #save_player_pos: false
 
   ##
-  ## Show the channel's watermark on the bottom-rght corner of videos
+  ## Show the channel's watermark on the bottom-right corner of videos
   ##
   ## Accepted values: true, false
   ## Default: false

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -823,6 +823,15 @@ default_user_preferences:
   ##
   #save_player_pos: false
 
+  ##
+  ## Show the channel's watermark on the bottom-rght corner of videos
+  ##
+  ## Accepted values: true, false
+  ## Default: false
+  ##
+  #show_channel_watermark: true
+
+
   # -----------------------------
   #  Subscription feed
   # -----------------------------

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -827,7 +827,7 @@ default_user_preferences:
   ## Show the channel's watermark on the bottom-right corner of videos
   ##
   ## Accepted values: true, false
-  ## Default: false
+  ## Default: true
   ##
   #show_channel_watermark: true
 

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -472,6 +472,7 @@
     "user_saved_playlists": "`x` saved playlists",
     "Video unavailable": "Video unavailable",
     "preferences_save_player_pos_label": "Save playback position: ",
+    "preferences_show_channel_watermark_label": "Show channel watermark: ",
     "crash_page_you_found_a_bug": "It looks like you found a bug in Invidious!",
     "crash_page_before_reporting": "Before reporting a bug, make sure that you have:",
     "crash_page_refresh": "tried to <a href=\"`x`\">refresh the page</a>",

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -44,6 +44,7 @@ struct ConfigPreferences
   property vr_mode : Bool = true
   property show_nick : Bool = true
   property save_player_pos : Bool = false
+  property show_channel_watermark : Bool = true
 
   def to_tuple
     {% begin %}

--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -55,6 +55,10 @@ module Invidious::JSONify::APIv1
         end
       end
 
+      if watermark = video.watermark?
+        json.field "authorWatermark", watermark
+      end
+
       json.field "subCountText", video.sub_count_text
 
       json.field "lengthSeconds", video.length_seconds

--- a/src/invidious/routes/preferences.cr
+++ b/src/invidious/routes/preferences.cr
@@ -78,6 +78,10 @@ module Invidious::Routes::PreferencesRoute
     save_player_pos ||= "off"
     save_player_pos = save_player_pos == "on"
 
+    show_channel_watermark = env.params.body["show_channel_watermark"]?.try &.as(String)
+    show_channel_watermark ||= "off"
+    show_channel_watermark = show_channel_watermark == "on"
+
     show_nick = env.params.body["show_nick"]?.try &.as(String)
     show_nick ||= "off"
     show_nick = show_nick == "on"
@@ -175,6 +179,7 @@ module Invidious::Routes::PreferencesRoute
       vr_mode:                     vr_mode,
       show_nick:                   show_nick,
       save_player_pos:             save_player_pos,
+      show_channel_watermark:      show_channel_watermark,
     }.to_json)
 
     if user = env.get? "user"

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -219,6 +219,7 @@ module Invidious::Routing
     get "/s_p/:id/:name", Routes::Images, :s_p_image
     get "/yts/img/:name", Routes::Images, :yts_image
     get "/vi/:id/:name", Routes::Images, :thumbnails
+    get "/an/:id/:name", Routes::Images, :yt_an_image
   end
 
   # -------------------

--- a/src/invidious/user/preferences.cr
+++ b/src/invidious/user/preferences.cr
@@ -55,6 +55,7 @@ struct Preferences
   property extend_desc : Bool = CONFIG.default_user_preferences.extend_desc
   property volume : Int32 = CONFIG.default_user_preferences.volume
   property save_player_pos : Bool = CONFIG.default_user_preferences.save_player_pos
+  property show_channel_watermark : Bool = CONFIG.default_user_preferences.show_channel_watermark
 
   module BoolToString
     def self.to_json(value : String, json : JSON::Builder)

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -15,7 +15,7 @@ struct Video
   # NOTE: don't forget to bump this number if any change is made to
   # the `params` structure in videos/parser.cr!!!
   #
-  SCHEMA_VERSION = 2
+  SCHEMA_VERSION = 3
 
   property id : String
 
@@ -256,6 +256,10 @@ struct Video
         music_json["license"].as_s
       )
     }
+  end
+
+  def watermark?
+    return info["watermark"]?
   end
 
   # Macros defining getters/setters for various types of data

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -381,10 +381,14 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
   # Channel watermark
   # Annotations is different from legacy annotations
   if watermark = player_response.dig?("annotations", 0, "playerAnnotationsExpandedRenderer", "featuredChannel")
+    watermark_thumbnail = watermark["watermark"]["thumbnails"][0]
+
     watermark_data = {
-      "startTimeMs"  => watermark["startTimeMs"],
-      "endTimeMs"    => watermark["endTimeMs"],
-      "thumbnailUrl" => JSON::Any.new(URI.parse(watermark["watermark"]["thumbnails"][0]["url"].as_s).request_target),
+      "startTimeMs"     => watermark["startTimeMs"],
+      "endTimeMs"       => watermark["endTimeMs"],
+      "thumbnailWidth"  => watermark_thumbnail["width"],
+      "thumbnailHeight" => watermark_thumbnail["height"],
+      "thumbnailUrl"    => JSON::Any.new(URI.parse(watermark_thumbnail["url"].as_s).request_target),
     }
   else
     watermark_data = {} of String => JSON::Any

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -383,8 +383,8 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
   if watermark = player_response.dig?("annotations", 0, "playerAnnotationsExpandedRenderer", "featuredChannel")
     watermark_data = {
       "startTimeMs"  => watermark["startTimeMs"],
-      "endTimeMS"    => watermark["endTimeMs"],
-      "thumbnailURL" => watermark["watermark"]["thumbnails"][0]["url"],
+      "endTimeMs"    => watermark["endTimeMs"],
+      "thumbnailURL" => JSON::Any.new(URI.parse(watermark["watermark"]["thumbnails"][0]["url"].as_s).request_target),
     }
   else
     watermark_data = {} of String => JSON::Any

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -384,7 +384,7 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
     watermark_data = {
       "startTimeMs"  => watermark["startTimeMs"],
       "endTimeMs"    => watermark["endTimeMs"],
-      "thumbnailURL" => JSON::Any.new(URI.parse(watermark["watermark"]["thumbnails"][0]["url"].as_s).request_target),
+      "thumbnailUrl" => JSON::Any.new(URI.parse(watermark["watermark"]["thumbnails"][0]["url"].as_s).request_target),
     }
   else
     watermark_data = {} of String => JSON::Any

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -378,6 +378,18 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
       .try &.as_s.split(" ", 2)[0]
   end
 
+  # Channel watermark
+  # Annotations is different from legacy annotations
+  if watermark = player_response.dig?("annotations", 0, "playerAnnotationsExpandedRenderer", "featuredChannel")
+    watermark_data = {
+      "startTimeMs"  => watermark["startTimeMs"],
+      "endTimeMS"    => watermark["endTimeMs"],
+      "thumbnailURL" => watermark["watermark"]["thumbnails"][0]["url"],
+    }
+  else
+    watermark_data = {} of String => JSON::Any
+  end
+
   # Return data
 
   if live_now
@@ -422,6 +434,7 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
     "authorThumbnail" => JSON::Any.new(author_thumbnail.try &.as_s || ""),
     "authorVerified"  => JSON::Any.new(author_verified || false),
     "subCountText"    => JSON::Any.new(subs_text || "-"),
+    "watermark"       => JSON::Any.new(watermark_data),
   }
 
   return params

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -15,7 +15,7 @@
                  if (fmt["mimeType"].as_s.starts_with?("audio/mp4") && bandwidth > best_m4a_stream_bitrate)
                    best_m4a_stream_bitrate = bandwidth
                    best_m4a_stream_index = i
-                 end
+                end
                end
 
                audio_streams.each_with_index do |fmt, i|

--- a/src/invidious/views/user/preferences.ecr
+++ b/src/invidious/views/user/preferences.ecr
@@ -117,7 +117,7 @@
             </div>
 
             <div class="pure-control-group">
-                <label for="show_"><%= translate(locale, "preferences_save_player_pos_label") %></label>
+                <label for="save_player_pos"><%= translate(locale, "preferences_save_player_pos_label") %></label>
                 <input name="save_player_pos" id="save_player_pos" type="checkbox" <% if preferences.save_player_pos %>checked<% end %>>
             </div>
 

--- a/src/invidious/views/user/preferences.ecr
+++ b/src/invidious/views/user/preferences.ecr
@@ -117,8 +117,13 @@
             </div>
 
             <div class="pure-control-group">
-                <label for="save_player_pos"><%= translate(locale, "preferences_save_player_pos_label") %></label>
+                <label for="show_"><%= translate(locale, "preferences_save_player_pos_label") %></label>
                 <input name="save_player_pos" id="save_player_pos" type="checkbox" <% if preferences.save_player_pos %>checked<% end %>>
+            </div>
+
+            <div class="pure-control-group">
+                <label for="show_channel_watermark"><%= translate(locale, "preferences_show_channel_watermark_label") %></label>
+                <input name="show_channel_watermark" id="show_channel_watermark" type="checkbox" <% if preferences.show_channel_watermark %>checked<% end %>>
             </div>
 
             <legend><%= translate(locale, "preferences_category_visual") %></legend>

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -28,6 +28,12 @@
 <meta name="twitter:player:height" content="720">
 <link rel="alternate" href="https://www.youtube.com/watch?v=<%= video.id %>">
 <%= rendered "components/player_sources" %>
+
+<% if video.watermark? %>
+    <link rel="stylesheet" href="/videojs/videojs-overlay/videojs-overlay.css?v=<%= ASSET_COMMIT %>">
+    <script src="/videojs/videojs-overlay/videojs-overlay.js?v=<%= ASSET_COMMIT %>"></script>
+<% end %>
+
 <title><%= title %> - Invidious</title>
 
 <!-- Description expansion also updates the 'Show more' button to 'Show less' so
@@ -48,6 +54,7 @@ we're going to need to do it here in order to allow for translations.
 <%=
 {
     "id" => video.id,
+    "ucid" => video.ucid,
     "index" => continuation,
     "plid" => plid,
     "length_seconds" => video.length_seconds.to_f,
@@ -63,6 +70,7 @@ we're going to need to do it here in order to allow for translations.
     "preferences" => preferences,
     "premiere_timestamp" => video.premiere_timestamp.try &.to_unix,
     "vr" => video.is_vr,
+    "watermark" => video.watermark?,
     "projection_type" => video.projection_type,
     "local_disabled" => CONFIG.disabled?("local"),
     "support_reddit" => true


### PR DESCRIPTION
![watermark](https://github.com/iv-org/invidious/assets/70992037/3d823378-3263-495a-ad22-03b222113fd0)

Since this can be considered a user hostile feature, the icon is fully togglable within the preferences. 

Closes channel favicon component of #2395