### PR TITLE
Use HTTP::Client directly for automatic redirects

### DIFF
--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -325,7 +325,7 @@ end
 
 def fetch_random_instance
   begin
-    instance_api_client = make_client(URI.parse("https://api.invidious.io"))
+    instance_api_client = HTTP::Client.new(URI.parse("https://api.invidious.io"))
 
     # Timeouts
     instance_api_client.connect_timeout = 10.seconds


### PR DESCRIPTION
The client created by `make_client` is affected by the `force_resolve` configuration option. However, as `api.invidious.io` does not support ipv6, it leads to an error whenever `force_resolve` is set to only use ipv6.

The normal `HTTP::Client` however is not affected by the force_resolve configuration and therefore remains unaffected