### PR TITLE
Improve playback statistics

### DIFF
--- a/src/invidious/jobs/statistics_refresh_job.cr
+++ b/src/invidious/jobs/statistics_refresh_job.cr
@@ -27,6 +27,12 @@ class Invidious::Jobs::StatisticsRefreshJob < Invidious::Jobs::BaseJob
     "playback" => {} of String => Int64 | Float64,
   }
 
+  # Latches the playback success stats from before statistics gets refreshed
+  # Used to ensure that the object won't get reset back to an empty object
+  LATCHED_PLAYBACK_STATS = {
+    "playback" => {} of String => Int64 | Float64,
+  }
+
   private getter db : DB::Database
 
   def initialize(@db, @software_config : Hash(String, String))
@@ -65,6 +71,7 @@ class Invidious::Jobs::StatisticsRefreshJob < Invidious::Jobs::BaseJob
     }
 
     # Reset playback requests tracker
+    LATCHED_PLAYBACK_STATS["playback"] = STATISTICS["playback"].as(Hash(String, Int64 | Float64))
     STATISTICS["playback"] = {} of String => Int64 | Float64
   end
 end

--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -19,6 +19,8 @@ module Invidious::Routes::API::V1::Misc
           else
             tracker["ratio"] = (success_count / (total_requests)).round(2)
           end
+        else
+          return (Invidious::Jobs::StatisticsRefreshJob::STATISTICS.merge Invidious::Jobs::StatisticsRefreshJob::LATCHED_PLAYBACK_STATS).to_json
         end
       end
 

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -89,6 +89,14 @@ def extract_video_info(video_id : String, proxy_region : String? = nil)
     }
   else
     reason = nil
+
+    # Although technically not a call to /videoplayback, because we are counting requests
+    # in which YouTube returned a "this content is not available" video as a failure,
+    # we should also count requests that returned the correct video as a success
+    # in order to ensure a correct and accurate ratio
+    playback_stats = get_playback_statistic()
+    playback_stats["totalRequests"] += 1
+    playback_stats["successfulRequests"] += 1
   end
 
   # Don't fetch the next endpoint if the video is unavailable.


### PR DESCRIPTION
 - Latches previous playback stats object to ensure that Invidious won't ever return an empty object for that endpoint (unless the process has just started)
 - Increment `successfulRequests` when YouTube returns the correct video in InnerTube