### PR TITLE
Downgrade docker-compose because v3 cannot conditionally depends_on.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 # If you want to use Invidious in production, see the docker-compose.yml file provided
 # in the installation documentation: https://docs.invidious.io/installation/
 
-version: "3"
+version: "2.2"
 services:
 
   invidious:


### PR DESCRIPTION
In compose file version 3, docker-compose lost the capability for `depends_on: …: condition: service_healthy`, so `docker-compose` fails with

> services.invidious.depends_on contains an invalid type, it should be an array

The feature was restored in compose file version 3.9, but that requires docker's new mainline `docker compose` feature which is not yet available on some LTS distros like Ubuntu focal.

Thus for now I recommend we use v2.2.

https://stackoverflow.com/a/71060072
https://github.com/moby/moby/issues/30404