### PR TITLE
Stats: Fix two swapped function names

### DIFF
--- a/src/invidious/database/statistics.cr
+++ b/src/invidious/database/statistics.cr
@@ -15,7 +15,7 @@ module Invidious::Database::Statistics
     PG_DB.query_one(request, as: Int64)
   end
 
-  def count_users_active_1m : Int64
+  def count_users_active_6m : Int64
     request = <<-SQL
       SELECT count(*) FROM users
       WHERE CURRENT_TIMESTAMP - updated < '6 months'
@@ -24,7 +24,7 @@ module Invidious::Database::Statistics
     PG_DB.query_one(request, as: Int64)
   end
 
-  def count_users_active_6m : Int64
+  def count_users_active_1m : Int64
     request = <<-SQL
       SELECT count(*) FROM users
       WHERE CURRENT_TIMESTAMP - updated < '1 month'

--- a/src/invidious/jobs/statistics_refresh_job.cr
+++ b/src/invidious/jobs/statistics_refresh_job.cr
@@ -56,8 +56,8 @@ class Invidious::Jobs::StatisticsRefreshJob < Invidious::Jobs::BaseJob
     users = STATISTICS.dig("usage", "users").as(Hash(String, Int64))
 
     users["total"] = Invidious::Database::Statistics.count_users_total
-    users["activeHalfyear"] = Invidious::Database::Statistics.count_users_active_1m
-    users["activeMonth"] = Invidious::Database::Statistics.count_users_active_6m
+    users["activeHalfyear"] = Invidious::Database::Statistics.count_users_active_6m
+    users["activeMonth"] = Invidious::Database::Statistics.count_users_active_1m
 
     STATISTICS["metadata"] = {
       "updatedAt"              => Time.utc.to_unix,


### PR DESCRIPTION
The function names 'count_users_active_6m' and 'count_users_active_1m' have been swapped.