### PR TITLE
Remove usage of depends_on

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,9 +36,6 @@ services:
       interval: 30s
       timeout: 5s
       retries: 2
-    depends_on:
-      invidious-db:
-        condition: service_healthy
 
   invidious-db:
     image: docker.io/library/postgres:14


### PR DESCRIPTION
First introduced in #4249, reverting this change.

Remove the usage of this parameter as the `docker-compose.yml` in the repository is just for development and there is no need to make it production ready.

Waiting on the database is something that is a must in production, but in development one can just restart the containers if there is really an issue.

This option is causing too many issues. And this option has a place instead in the install guide: https://github.com/iv-org/documentation/blob/master/docs/installation.md

Close https://github.com/iv-org/invidious/issues/4369