### PR TITLE
Enable authenticating via reverse proxy headers

### DIFF
--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -113,6 +113,13 @@ class Config
   # Enable the user notifications for all users
   property enable_user_notifications : Bool = true
 
+  # Enable logging in via headers that are set by your reverse proxy
+  property reverse_proxy_auth_enabled : Bool = false
+  # Enable auto-registration when logging in with reverse proxy auth
+  property reverse_proxy_registration_enabled : Bool = false
+  # Header that will contain the username, email address,
+  property reverse_proxy_auth_header : String = "Remote-User"
+
   # URL to the modified source code to be easily AGPL compliant
   # Will display in the footer, next to the main source code link
   property modified_source_code_url : String? = nil

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -118,7 +118,20 @@ class Config
   # Enable auto-registration when logging in with reverse proxy auth
   property reverse_proxy_registration_enabled : Bool = false
   # Header that will contain the username, email address,
-  property reverse_proxy_auth_header : String = "Remote-User"
+  property reverse_proxy_auth_user_header : String = "Remote-User"
+  property reverse_proxy_auth_email_header : String = "Remote-Email"
+  # If set to false, ignore the User header and only use the Email header.
+  # If set to a string, then this behavior will be used:
+  # if the email is blank, the email will instead be set to ${User}@${Domain}, where
+  # ${User} is the value in the Remote-User header and ${Domain} is the value of this property.
+  property reverse_proxy_auth_domain : Bool | String = false
+  # Does nothing if the reverse_proxy_auth_domain property is false.
+  # Does nothing if the reverse_proxy_auth_require_user property is true.
+  # If set to true, then the User header is preferred over the Email header.
+  property reverse_proxy_auth_prefer_user : Bool = false
+  # Does nothing if the reverse_proxy_auth_domain property is false.
+  # If set to true, then the Email header is ignored.
+  property reverse_proxy_auth_require_user : Bool = false
 
   # URL to the modified source code to be easily AGPL compliant
   # Will display in the footer, next to the main source code link


### PR DESCRIPTION
This feature allows an instance to be configured such that, if Reverse Proxy Auth is present, the user will be logged into the account matching the email address present in the configured header (by default, `'Remote-Email'`, which is used by Authelia) upon navigating to the `/login` page.

It also supports automatically registering users who don't yet have accounts, as well as using the username and a supplied domain to build an email instead of using the email header. For example, if you configured it as follows:

```yaml
        reverse_proxy_auth_enabled: true
        reverse_proxy_registration_enabled: true
        reverse_proxy_auth_header: Remote-User
        reverse_proxy_email_header: Remote-Email
        reverse_proxy_auth_domain: noreply.github.com
        reverse_proxy_auth_prefer_user: true
```

and the request had the following headers:

```json
{
  "Remote-User": "corvec"
  "Remote-Email": ""
}
```

then it would log me in as `"corvec@noreply.github.com"`. If that account didn't exist, it would create it, setting my password to a randomly generated max-length string.

I've tested this with Traefik and Authelia using the above config (with my own domain) using Docker Compose as part of an existing stack. It works well for me but I haven't tested it with other configurations - e.g., KeyCloak, Authentik, nginx, Caddy, etc..