### PR TITLE
CSS: expand #contents width on small screens

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -13,6 +13,7 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  margin: auto;
 }
 
 .h-box {

--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -28,8 +28,7 @@
 <body class="<%= dark_mode.blank? ? "no" : dark_mode %>-theme">
     <span style="display:none" id="dark_mode_pref"><%= env.get("preferences").as(Preferences).dark_mode %></span>
     <div class="pure-g">
-        <div class="pure-u-1 pure-u-md-2-24"></div>
-        <div class="pure-u-1 pure-u-md-20-24" id="contents">
+        <div class="pure-u-1 pure-u-xl-20-24" id="contents">
             <div class="pure-g navbar h-box">
                 <% if navbar_search %>
                     <div class="pure-u-1 pure-u-md-4-24">
@@ -156,7 +155,6 @@
             </footer>
 
         </div>
-        <div class="pure-u-1 pure-u-md-2-24"></div>
     </div>
     <script src="/js/handlers.js?v=<%= ASSET_COMMIT %>"></script>
     <script src="/js/themes.js?v=<%= ASSET_COMMIT %>"></script>


### PR DESCRIPTION
Hi there, i made the **#contents** div take the full width on small screens less than 1280px, so all page elements have a little more room especially the video titles.

original | improved
--- | ---
![invidious_narrow](https://github.com/iv-org/invidious/assets/25079664/8f35c8ef-f842-4990-b564-c1ece95ce83c) | ![invidious_wide](https://github.com/iv-org/invidious/assets/25079664/76112612-0ea6-460a-84ac-43d5dda22ad5)