### PR TITLE
Fix referer decoding

### DIFF
--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -262,7 +262,7 @@ def get_referer(env, fallback = "/", unroll = true)
   end
 
   referer = referer.request_target
-  referer = "/" + referer.gsub(/[^\/?@&%=\-_.:,0-9a-zA-Z]/, "").lstrip("/\\")
+  referer = "/" + referer.gsub(/[^\/?@&%=\-_.:\*,0-9a-zA-Z]/, "").lstrip("/\\")
 
   if referer == env.request.path
     referer = fallback


### PR DESCRIPTION
This fixes an issue where
- User is redirected from Playlet to `/authorize_token`
- User is not logged in, so they are redirected again to `/login`
- The token scope has the `*` char

The token would lose scope in this case, see https://github.com/iBicha/playlet/issues/277#issuecomment-1925001220

Kinda related to https://github.com/iv-org/invidious/pull/3556, but I didn't have scope with `*` at the time, so I didn't detect this issue until now.

This is causing people to be logged out (since we're verifying the scope, and we're detecting that it's missing permissions)