### PR TITLE
Proxy: Handle non-200 HTTP codes on DASH manifests

### DIFF
--- a/src/invidious/routes/api/manifest.cr
+++ b/src/invidious/routes/api/manifest.cr
@@ -21,7 +21,13 @@ module Invidious::Routes::API::Manifest
     end
 
     if dashmpd = video.dash_manifest_url
-      manifest = YT_POOL.client &.get(URI.parse(dashmpd).request_target).body
+      response = YT_POOL.client &.get(URI.parse(dashmpd).request_target)
+
+      if response.status_code != 200
+        haltf env, status_code: response.status_code
+      end
+
+      manifest = response.body
 
       manifest = manifest.gsub(/<BaseURL>[^<]+<\/BaseURL>/) do |baseurl|
         url = baseurl.lchop("<BaseURL>")


### PR DESCRIPTION
Currently Invidious assumes that fetching the DASH manifest from YouTube will always be successful and doesn't check the status code. That means that if it gets YouTube's ratelimiting page, it returns a response with a HTTP 200 status code, `application/dash+xml` Content-Type header and the response body being the HTML for YouTube ratelimiting page.

Real world example: https://invidious.nerdvpn.de/api/manifest/dash/id/jfKfPfyJRdk

Copied from the checks that are done for the HLS manifests:
https://github.com/iv-org/invidious/blob/cf686202e05cfdce708a4d0d37a18a055f43a1df/src/invidious/routes/api/manifest.cr#L217-L219
https://github.com/iv-org/invidious/blob/cf686202e05cfdce708a4d0d37a18a055f43a1df/src/invidious/routes/api/manifest.cr#L162-L164