### PR TITLE
API: Add APIHandler back

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -217,6 +217,7 @@ public_folder "assets"
 
 Kemal.config.powered_by_header = false
 add_handler FilteredCompressHandler.new
+add_handler APIHandler.new
 add_handler AuthHandler.new
 add_handler DenyFrame.new
 add_context_storage_type(Array(String))

--- a/src/invidious/helpers/handlers.cr
+++ b/src/invidious/helpers/handlers.cr
@@ -134,6 +134,19 @@ class AuthHandler < Kemal::Handler
   end
 end
 
+class APIHandler < Kemal::Handler
+  {% for method in %w(GET POST PUT HEAD DELETE PATCH OPTIONS) %}
+  only ["/api/v1/*"], {{method}}
+  {% end %}
+  exclude ["/api/v1/auth/notifications"], "GET"
+  exclude ["/api/v1/auth/notifications"], "POST"
+
+  def call(env)
+    env.response.headers["Access-Control-Allow-Origin"] = "*" if only_match?(env)
+    call_next env
+  end
+end
+
 class DenyFrame < Kemal::Handler
   exclude ["/embed/*"]
 


### PR DESCRIPTION
This handler should no have been removed in #4276, as it adds the required CORS header (Access-Control-Allow-Origin) for public acces to the API.

[Thanks to @iBicha for noticing this!](https://github.com/iv-org/invidious/pull/4276/files#r1487086161)