### PR TITLE
Preferences: Fix handling of modified source code URL

### DIFF
--- a/src/invidious/routes/preferences.cr
+++ b/src/invidious/routes/preferences.cr
@@ -214,7 +214,7 @@ module Invidious::Routes::PreferencesRoute
         statistics_enabled ||= "off"
         CONFIG.statistics_enabled = statistics_enabled == "on"
 
-        CONFIG.modified_source_code_url = env.params.body["modified_source_code_url"]?.try &.as(String)
+        CONFIG.modified_source_code_url = env.params.body["modified_source_code_url"]?.presence
 
         File.write("config/config.yml", CONFIG.to_yaml)
       end

--- a/src/invidious/views/user/preferences.ecr
+++ b/src/invidious/views/user/preferences.ecr
@@ -310,7 +310,7 @@
 
                 <div class="pure-control-group">
                     <label for="modified_source_code_url"><%= translate(locale, "adminprefs_modified_source_code_url_label") %></label>
-                    <input name="modified_source_code_url" id="modified_source_code_url" type="input" <% if CONFIG.modified_source_code_url %>checked<% end %>>
+                    <input name="modified_source_code_url" id="modified_source_code_url" type="url" value="<%= CONFIG.modified_source_code_url %>">
                 </div>
             <% end %>
 


### PR DESCRIPTION
Currently, setting the modified code repo URL through the preferences page in Invidious is broken.

- the HTML input tag for this field has invalid type "input" (though browser falls back on text input)
- the URL is used to set the "checked" property and not as a plain value, which makes no sense for a text-based input (and results in a blank field)
- when the submitted field is empty, the retrieved value is an empty String instead of nil, causing the "modified source code URL" being an empty href link which just points to the current page