### PR TITLE
add a refresh param to /api/v1/videos/:id

### DIFF
--- a/src/invidious/routes/api/v1/videos.cr
+++ b/src/invidious/routes/api/v1/videos.cr
@@ -8,8 +8,12 @@ module Invidious::Routes::API::V1::Videos
     region = env.params.query["region"]?
     proxy = {"1", "true"}.any? &.== env.params.query["local"]?
 
+    refresh = env.params.query["refresh"]?
+    refresh ||= "1"
+    refresh = refresh == "1" || refresh == "true"
+
     begin
-      video = get_video(id, region: region)
+      video = get_video(id, refresh: refresh, region: region)
     rescue ex : NotFoundException
       return error_json(404, ex)
     rescue ex


### PR DESCRIPTION
I found myself needing to fetch video info without caring about the freshness of the details.

Use cases are many, but includes casting from YouTube app (Lounge) https://github.com/iBicha/playlet/pull/276
When user adds a video to the queue, only the video id(s) are sent, so we'd need to make a request to be able to display the video queue.

It would be nice to have an API endpoint (perhaps in v2) where the caller can indicate the details and/or accuracy is not needed, so in that case, older cached videos in the DB are fine, and also, there would be no need to hit the `next` endpoint. So fetching would need a single request when calling `fetch_video`

But until then, I thought adding a `refresh` arg to to the endpoint would be already an improvement and should save processing time and bandwidth.

PS: ~~I haven't tested this (yet)~~ yes I did