### PR TITLE
Allow embedding videos in local HTML files

### DIFF
--- a/src/invidious/routes/before_all.cr
+++ b/src/invidious/routes/before_all.cr
@@ -30,7 +30,7 @@ module Invidious::Routes::BeforeAll
 
     # Only allow the pages at /embed/* to be embedded
     if env.request.resource.starts_with?("/embed")
-      frame_ancestors = "'self' http: https:"
+      frame_ancestors = "'self' file: http: https:"
     else
       frame_ancestors = "'none'"
     end


### PR DESCRIPTION
routes: Allow embedding videos in local HTML files (fixes #4448)

The current Content Security Policy does not allow to embed videos
inside local HTML files which are viewed in the browser via the file
protocol. This commit adds the file protocol to the allowed frame
ancestors, so that the embedded videos load correctly in local HTML
files.

This behaviour is consistent which how the official YouTube website
allows to embed videos from itself.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>