### PR TITLE
Use Trending API for health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
         # statistics_enabled: false
         hmac_key: "CHANGE_ME!!"
     healthcheck:
-      test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
+      test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/trending || exit 1
       interval: 30s
       timeout: 5s
       retries: 2


### PR DESCRIPTION
Using the Trending API by default for health checks is a nice workaround for heath checks failing due to the new comment format. I also imagine that going to the Trending API every 30 seconds might appear to be more normal than getting comments from a specific video every 30 seconds (even if that video is very popular).
