### PR TITLE
API: convey info "is post live" from Youtube response

### DIFF
--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -62,6 +62,7 @@ module Invidious::JSONify::APIv1
       json.field "rating", 0_i64
       json.field "isListed", video.is_listed
       json.field "liveNow", video.live_now
+      json.field "isPostLiveDvr", video.post_live_dvr
       json.field "isUpcoming", video.is_upcoming
 
       if video.premiere_timestamp

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -82,6 +82,10 @@ struct Video
     return (self.video_type == VideoType::Livestream)
   end
 
+  def post_live_dvr
+    return info["isPostLiveDvr"].as_bool
+  end
+
   def premiere_timestamp : Time?
     info
       .dig?("microformat", "playerMicroformatRenderer", "liveBroadcastDetails", "startTimestamp")

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -216,6 +216,9 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
   live_now = microformat.dig?("liveBroadcastDetails", "isLiveNow")
     .try &.as_bool || false
 
+  post_live_dvr = video_details.dig?("isPostLiveDvr")
+    .try &.as_bool || false
+
   # Extra video infos
 
   allowed_regions = microformat["availableCountries"]?
@@ -405,6 +408,7 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
     "isListed"         => JSON::Any.new(is_listed || false),
     "isUpcoming"       => JSON::Any.new(is_upcoming || false),
     "keywords"         => JSON::Any.new(keywords.map { |v| JSON::Any.new(v) }),
+    "isPostLiveDvr"    => JSON::Any.new(post_live_dvr),
     # Related videos
     "relatedVideos" => JSON::Any.new(related),
     # Description


### PR DESCRIPTION
This PR addresses the API side of https://github.com/iv-org/invidious/issues/4421

(isPostLiveDvr is the second last JSON property in this screenshot)
![image](https://github.com/iv-org/invidious/assets/78101139/4087e3fc-9b48-4eee-8fa0-20b2c872f017)
