### PR TITLE
Fix CORS on /latest_version

### DIFF
--- a/src/invidious/routes/video_playback.cr
+++ b/src/invidious/routes/video_playback.cr
@@ -298,6 +298,7 @@ module Invidious::Routes::VideoPlayback
       url += "&title=#{URI.encode_www_form(title, space_to_plus: false)}" if title
     end
 
+    env.response.headers["Access-Control-Allow-Origin"] = "*"
     return env.redirect url
   end
 end


### PR DESCRIPTION
I noticed that `/latest_version` is missing `["Access-Control-Allow-Origin"] = "*"`
While other endpoints after the redirect (like `/videoplayback`) have the right header, this one is missing

Tested the endpoint before and after the change (before the change blocked, after the change, video plays)