### PR TITLE
API: Fix duplicated query parameters in proxied video URLs

### DIFF
--- a/src/invidious/http_server/utils.cr
+++ b/src/invidious/http_server/utils.cr
@@ -11,11 +11,12 @@ module Invidious::HttpServer
       params = url.query_params
       params["host"] = url.host.not_nil! # Should never be nil, in theory
       params["region"] = region if !region.nil?
+      url.query_params = params
 
       if absolute
-        return "#{HOST_URL}#{url.request_target}?#{params}"
+        return "#{HOST_URL}#{url.request_target}"
       else
-        return "#{url.request_target}?#{params}"
+        return url.request_target
       end
     end
 


### PR DESCRIPTION
This pull request fixes that bug that was causing the query parameters to get doubled in the streaming URLs when `?local=true` is passed to the `/api/v1/videos/{id}` API endpoint.

Before: `host/path?parameters?parameters`
After: `host/path?parameters`