### PR TITLE
Fix proxying live DASH streams

### DIFF
--- a/src/invidious/routes/video_playback.cr
+++ b/src/invidious/routes/video_playback.cr
@@ -21,7 +21,7 @@ module Invidious::Routes::VideoPlayback
     end
 
     # Sanity check, to avoid being used as an open proxy
-    if !host.matches?(/[\w-]+.googlevideo.com/)
+    if !host.matches?(/[\w-]+\.(?:googlevideo|c\.youtube)\.com/)
       return error_template(400, "Invalid \"host\" parameter.")
     end
 
@@ -37,7 +37,8 @@ module Invidious::Routes::VideoPlayback
 
     # See: https://github.com/iv-org/invidious/issues/3302
     range_header = env.request.headers["Range"]?
-    if range_header.nil?
+    sq = query_params["sq"]?
+    if range_header.nil? && sq.nil?
       range_for_head = query_params["range"]? || "0-640"
       headers["Range"] = "bytes=#{range_for_head}"
     end


### PR DESCRIPTION
The live DASH manifests returned by Invidious use `.c.youtube.com` subdomains, not the usual `.googlevideo.com` ones, YouTube's live DASH also uses numbered sequences/segments with the `sq` parameter instead of byte ranges.

This pull request updates the domain check in the proxy to also support the `.c.youtube.com` domains and prevents Invidious adding a range header when it is missing but the `sq` parameter is present.