### PR TITLE
API: Add bitrate to formatStreams too

### DIFF
--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -160,6 +160,8 @@ module Invidious::JSONify::APIv1
               json.field "type", fmt["mimeType"]
               json.field "quality", fmt["quality"]
 
+              json.field "bitrate", fmt["bitrate"].as_i.to_s if fmt["bitrate"]?
+
               fmt_info = Invidious::Videos::Formats.itag_to_metadata?(fmt["itag"])
               if fmt_info
                 fps = fmt_info["fps"]?.try &.to_i || fmt["fps"]?.try &.as_i || 30


### PR DESCRIPTION
At the moment the bitrate is only returned for the adaptiveFormats, this pull request returns them for the formatStreams too.