### PR TITLE
Fix to internal changes in HTTP::Client

### DIFF
--- a/src/invidious/yt_backend/proxy.cr
+++ b/src/invidious/yt_backend/proxy.cr
@@ -84,9 +84,9 @@ class HTTPClient < HTTP::Client
   def proxy_connection_options
     opts = {} of Symbol => Float64 | Nil
 
-    opts[:dns_timeout] = @dns_timeout
-    opts[:connect_timeout] = @connect_timeout
-    opts[:read_timeout] = @read_timeout
+    opts[:dns_timeout] = @dns_timeout.try &.to_f
+    opts[:connect_timeout] = @connect_timeout.try &.to_f
+    opts[:read_timeout] = @read_timeout.try &.to_f
 
     return opts
   end


### PR DESCRIPTION
Crystal 1.12 changed the way timeouts are stored in `HTTP::Client`. Accessing the fields directly is a bad idea, but the interface doesn't provide getters.

Ref: https://github.com/crystal-lang/crystal/pull/14371

EDIT: This is PR to fix the problem in CI, but with no consideration to possible better alternatives.