### PR TITLE
Trending: Un-nest category if this is the only one

### DIFF
--- a/src/invidious/trending.cr
+++ b/src/invidious/trending.cr
@@ -22,12 +22,14 @@ def fetch_trending(trending_type, region, locale)
 
   extracted = [] of SearchItem
 
+  deduplicate = items.size > 1
+
   items.each do |itm|
     if itm.is_a?(Category)
       # Ignore the smaller categories, as they generally contain a sponsored
       # channel, which brings a lot of noise on the trending page.
       # See: https://github.com/iv-org/invidious/issues/2989
-      next if itm.contents.size < 24
+      next if (itm.contents.size < 24 && deduplicate)
 
       extracted.concat extract_category(itm)
     else


### PR DESCRIPTION
Don't get rid of category when there's only one. Trending music was returning less than 24 videos which was getting filtered out. Since multiple categories only appears on the default trending page, we don't need to do that filtering for Music, Gaming or movies.

closes https://github.com/iv-org/invidious/issues/4596