### PR TITLE
update the url_search_issues variable to include current error in search bar

### DIFF
--- a/src/invidious/helpers/errors.cr
+++ b/src/invidious/helpers/errors.cr
@@ -43,6 +43,8 @@ def error_template_helper(env : HTTP::Server::Context, status_code : Int32, exce
   # URLs for the error message below
   url_faq = "https://github.com/iv-org/documentation/blob/master/docs/faq.md"
   url_search_issues = "https://github.com/iv-org/invidious/issues"
+  url_search_issues += "?q=is:issue+is:open+"
+  url_search_issues += URI.encode_www_form("[Bug] " + issue_title)
 
   url_switch = "https://redirect.invidious.io" + env.request.resource
 


### PR DESCRIPTION
## Changes
-  Changes the crash page's Github issue search option to include the ``issue_title`` in the search bar when opening the issue search page.
---
As seen with #4584 and other critical problems, duplicate issues end up unnecessarily flooding the issue reports. While this change won't entirely stop this behavior, this will help the user to easily identify if the error they have received has been reported yet and discourage them from creating a duplicate (hopefully...)