### PR TITLE
update docker to crystal 1.12.1 and arm crystal 1.10.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:1.8.2-alpine AS builder
+FROM crystallang/crystal:1.12.1-alpine AS builder
 
 RUN apk add --no-cache sqlite-static yaml-static
 

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -1,5 +1,5 @@
-FROM alpine:3.18 AS builder
-RUN apk add --no-cache 'crystal=1.8.2-r0' shards sqlite-static yaml-static yaml-dev libxml2-static zlib-static openssl-libs-static openssl-dev musl-dev xz-static
+FROM alpine:3.19 AS builder
+RUN apk add --no-cache 'crystal=1.10.1-r0' shards sqlite-static yaml-static yaml-dev libxml2-static zlib-static openssl-libs-static openssl-dev musl-dev xz-static
 
 ARG release
 


### PR DESCRIPTION
Now that invidious support crystal 1.12.1, upgrading to latest version.
And for ARM trying to keep a stable version of alpine so upgrading only to crystal 1.10.1: https://pkgs.alpinelinux.org/packages?name=crystal&branch=v3.19&repo=&arch=&maintainer=