### PR TITLE
HTML: Use full URL in the og:image property

### DIFF
--- a/src/invidious/views/channel.ecr
+++ b/src/invidious/views/channel.ecr
@@ -30,13 +30,13 @@
 <meta property="og:site_name" content="Invidious">
 <meta property="og:url" content="<%= HOST_URL %>/channel/<%= ucid %>">
 <meta property="og:title" content="<%= author %>">
-<meta property="og:image" content="/ggpht<%= channel_profile_pic %>">
+<meta property="og:image" content="<%= HOST_URL %>/ggpht<%= channel_profile_pic %>">
 <meta property="og:description" content="<%= channel.description %>">
 <meta name="twitter:card" content="summary">
 <meta name="twitter:url" content="<%= HOST_URL %>/channel/<%= ucid %>">
 <meta name="twitter:title" content="<%= author %>">
 <meta name="twitter:description" content="<%= channel.description %>">
-<meta name="twitter:image" content="/ggpht<%= channel_profile_pic %>">
+<meta name="twitter:image" content="<%= HOST_URL %>/ggpht<%= channel_profile_pic %>">
 <link rel="alternate" type="application/rss+xml" title="RSS" href="/feed/channel/<%= ucid %>" />
 <%- end -%>
 

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -10,7 +10,7 @@
 <meta property="og:site_name" content="<%= author %> | Invidious">
 <meta property="og:url" content="<%= HOST_URL %>/watch?v=<%= video.id %>">
 <meta property="og:title" content="<%= title %>">
-<meta property="og:image" content="/vi/<%= video.id %>/maxres.jpg">
+<meta property="og:image" content="<%= HOST_URL %>/vi/<%= video.id %>/maxres.jpg">
 <meta property="og:description" content="<%= HTML.escape(video.short_description) %>">
 <meta property="og:type" content="video.other">
 <meta property="og:video:url" content="<%= HOST_URL %>/embed/<%= video.id %>">


### PR DESCRIPTION
Some opengraph implementations don't support a URL without the domain therefore failing to fetch the video thumbnail and channel image. This pull request basically fixes that.
