### PR TITLE
Listen to '::' instead of '0.0.0.0'

### DIFF
--- a/invidious.service
+++ b/invidious.service
@@ -11,7 +11,7 @@ User=invidious
 Group=invidious
 
 WorkingDirectory=/home/invidious/invidious
-ExecStart=/home/invidious/invidious/invidious -o invidious.log
+ExecStart=/home/invidious/invidious/invidious -b :: -o invidious.log
 
 Restart=always
 


### PR DESCRIPTION
Ensure invidious process listens to '::' (IPv6+IPv4) instead of '0.0.0.0' (IPv4-only), allowing every host on every Internet protocol (current or jurassic a.k.a IPv6 or IPv4, respectively) to reach the service.


Documentation still needs to be updated but function-wise this is enough to make it work correctly.