### PR TITLE
Handle playlists cataloged as Podcast

### DIFF
--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -366,6 +366,8 @@ def fetch_playlist(plid : String)
 
     if text.includes? "video"
       video_count = text.gsub(/\D/, "").to_i? || 0
+    elsif text.includes? "episode"
+      video_count = text.gsub(/\D/, "").to_i? || 0
     elsif text.includes? "view"
       views = text.gsub(/\D/, "").to_i64? || 0_i64
     else


### PR DESCRIPTION
Videos of a playlist cataloged as podcast are called episodes therefore Invidious was not able to find `video` in the `text` value inside the `stats` array.

This can be tested in my Debug Instance: https://debuginv.nadeko.net/playlist?list=PLDu-Eh5lUs1a4irCbnxMIB6FrUMaTXgVF

Fixes #4688 