### PR TITLE
API: Fix out of bound error on empty playlists

### DIFF
--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -74,7 +74,9 @@ module Invidious::Routes::API::V1::Misc
       response = playlist.to_json(offset, video_id: video_id)
       json_response = JSON.parse(response)
 
-      if json_response["videos"].as_a[0]["index"] != offset
+      if json_response["videos"].as_a.empty?
+        json_response = JSON.parse(response)
+      elsif json_response["videos"].as_a[0]["index"] != offset
         offset = json_response["videos"].as_a[0]["index"].as_i
         lookback = offset < 50 ? offset : 50
         response = playlist.to_json(offset - lookback)


### PR DESCRIPTION
Invidious assumes that every playlist will have at least one video because it needs to check for the `index` key. So if there is no videos on a playlist, there is no `index` key and Invidious throws `Index out of bounds`

This fixes this API endpoints when there is no videos in a playlist:
```
api/v1/playlists/:plid
api/v1/auth/playlists/:plid
```
*For some weird reason, the `api/v1/auth/playlists/:plid` endpoint was able the return the error `Index out of bounds` as said in #4679 but `api/v1/playlists/:plid` did not return anything. Weird*

Fixes #4679