### PR TITLE
Use `make_client` instead of calling `HTTP::Client`

### DIFF
--- a/src/invidious/routes/api/v1/search.cr
+++ b/src/invidious/routes/api/v1/search.cr
@@ -31,7 +31,7 @@ module Invidious::Routes::API::V1::Search
     query = env.params.query["q"]? || ""
 
     begin
-      client = make_client(URI.parse("https://suggestqueries-clients6.youtube.com"), force_youtube_headers = true)
+      client = make_client(URI.parse("https://suggestqueries-clients6.youtube.com"), force_youtube_headers: true)
       url = "/complete/search?client=youtube&hl=en&gl=#{region}&q=#{URI.encode_www_form(query)}&gs_ri=youtube&ds=yt"
 
       response = client.get(url).body

--- a/src/invidious/routes/api/v1/search.cr
+++ b/src/invidious/routes/api/v1/search.cr
@@ -31,9 +31,7 @@ module Invidious::Routes::API::V1::Search
     query = env.params.query["q"]? || ""
 
     begin
-      client = HTTP::Client.new("suggestqueries-clients6.youtube.com")
-      client.before_request { |r| add_yt_headers(r) }
-
+      client = make_client(URI.parse("https://suggestqueries-clients6.youtube.com"), force_youtube_headers = true)
       url = "/complete/search?client=youtube&hl=en&gl=#{region}&q=#{URI.encode_www_form(query)}&gs_ri=youtube&ds=yt"
 
       response = client.get(url).body

--- a/src/invidious/yt_backend/connection_pool.cr
+++ b/src/invidious/yt_backend/connection_pool.cr
@@ -42,7 +42,7 @@ struct YoutubeConnectionPool
 
   private def build_pool
     DB::Pool(HTTP::Client).new(initial_pool_size: 0, max_pool_size: capacity, max_idle_pool_size: capacity, checkout_timeout: timeout) do
-      conn = make_client(url, force_resolve = true)
+      conn = make_client(url, force_resolve: true)
       conn.family = Socket::Family::INET if conn.family == Socket::Family::UNSPEC
       conn
     end

--- a/src/invidious/yt_backend/connection_pool.cr
+++ b/src/invidious/yt_backend/connection_pool.cr
@@ -55,7 +55,7 @@ def make_client(url : URI, region = nil, force_resolve : Bool = false, force_you
     client.family = Socket::Family::INET if client.family == Socket::Family::UNSPEC
   end
 
-  client.before_request { |r| add_yt_headers(r) } if url.host == "www.youtube.com" || force_youtube_headers
+  client.before_request { |r| add_yt_headers(r) } if url.host.try &.ends_with?("youtube.com") || force_youtube_headers
   client.read_timeout = 10.seconds
   client.connect_timeout = 10.seconds
 

--- a/src/invidious/yt_backend/connection_pool.cr
+++ b/src/invidious/yt_backend/connection_pool.cr
@@ -42,7 +42,7 @@ struct YoutubeConnectionPool
 
   private def build_pool
     DB::Pool(HTTP::Client).new(initial_pool_size: 0, max_pool_size: capacity, max_idle_pool_size: capacity, checkout_timeout: timeout) do
-      conn = make_client(url, force_solve = true)
+      conn = make_client(url, force_resolve = true)
       conn.family = Socket::Family::INET if conn.family == Socket::Family::UNSPEC
       conn
     end

--- a/src/invidious/yt_backend/connection_pool.cr
+++ b/src/invidious/yt_backend/connection_pool.cr
@@ -49,7 +49,7 @@ struct YoutubeConnectionPool
   end
 end
 
-def make_client(url : URI, region = nil, force_resolve : Bool = false, force_youtube_header : Bool = false)
+def make_client(url : URI, region = nil, force_resolve : Bool = false, force_youtube_headers : Bool = false)
   client = HTTP::Client.new(url)
 
   # Force the usage of a specific configured IP Family
@@ -57,7 +57,7 @@ def make_client(url : URI, region = nil, force_resolve : Bool = false, force_you
     client.family = CONFIG.force_resolve
   end
 
-  client.before_request { |r| add_yt_headers(r) } if url.host == "www.youtube.com" || force_youtube_header
+  client.before_request { |r| add_yt_headers(r) } if url.host == "www.youtube.com" || force_youtube_headers
   client.read_timeout = 10.seconds
   client.connect_timeout = 10.seconds
 

--- a/src/invidious/yt_backend/connection_pool.cr
+++ b/src/invidious/yt_backend/connection_pool.cr
@@ -30,7 +30,7 @@ struct YoutubeConnectionPool
       response = yield conn
     rescue ex
       conn.close
-      conn = make_client(url)
+      conn = make_client(url, force_resolve: true)
       response = yield conn
     ensure
       pool.release(conn)


### PR DESCRIPTION
This PR is mostly so that we can customize the client Invidious uses for all HTTP requests. For example, to config a HTTP proxy to use. 

I left `images.cr` untouched as to not conflict with #4326