### PR TITLE
Player: Fix playback position of already watched videos

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -351,7 +351,12 @@ if (video_data.params.save_player_pos) {
     const rememberedTime = get_video_time();
     let lastUpdated = 0;
 
-    if(!hasTimeParam) set_seconds_after_start(rememberedTime);
+    if(!hasTimeParam) {
+      if (rememberedTime >= video_data.length_seconds - 20)
+        set_seconds_after_start(0);
+      else
+        set_seconds_after_start(rememberedTime);
+    }
 
     player.on('timeupdate', function () {
         const raw = player.currentTime();


### PR DESCRIPTION
Closes #3976

Trying to watch an already watched video will make the video start 15 seconds before the end of the video. This is not very comfortable when listening to music or watching/listening playlists over and over. This can be easily tested on any instance with the "Save playback position" enabled on Preferences.