### PR TITLE
Pending migrations check on startup. Includes index change migration

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -135,6 +135,9 @@ end
 OUTPUT = CONFIG.output.upcase == "STDOUT" ? STDOUT : File.open(CONFIG.output, mode: "a")
 LOGGER = Invidious::LogHandler.new(OUTPUT, CONFIG.log_level)
 
+# Check pending migrations
+Invidious::Database::Migrator.new(PG_DB).check_pending_migrations
+
 # Check table integrity
 Invidious::Database.check_integrity(CONFIG)
 

--- a/src/invidious/database/migration.cr
+++ b/src/invidious/database/migration.cr
@@ -4,9 +4,14 @@ abstract class Invidious::Database::Migration
   end
 
   @@version : Int64?
+  @@required : Bool = false
 
   def self.version(version : Int32 | Int64)
     @@version = version.to_i64
+  end
+
+  def self.required(required : Bool)
+    @@required = required
   end
 
   getter? completed = false
@@ -30,6 +35,10 @@ abstract class Invidious::Database::Migration
 
   def version : Int64
     @@version.not_nil!
+  end
+
+  def required? : Bool
+    @@required
   end
 
   private def track(conn : DB::Connection)

--- a/src/invidious/database/migrations/0011_limit_channel_videos_index.cr
+++ b/src/invidious/database/migrations/0011_limit_channel_videos_index.cr
@@ -1,0 +1,18 @@
+module Invidious::Database::Migrations
+  class LimitChannelVideosIndex < Migration
+    version 11
+
+    def up(conn : DB::Connection)
+      conn.exec <<-SQL
+        CREATE INDEX IF NOT EXISTS channel_videos_ucid_published_idx
+            ON public.channel_videos
+            USING btree
+            (ucid COLLATE pg_catalog."default", published);
+      SQL
+
+      conn.exec <<-SQL
+        DROP INDEX IF EXISTS channel_videos_ucid_idx;
+      SQL
+    end
+  end
+end

--- a/src/invidious/database/migrator.cr
+++ b/src/invidious/database/migrator.cr
@@ -1,5 +1,6 @@
 class Invidious::Database::Migrator
   MIGRATIONS_TABLE = "public.invidious_migrations"
+  MIGRATE_INSTRUCTION = "Run `invidious --migrate` to apply the migration(s)."
 
   class_getter migrations = [] of Invidious::Database::Migration.class
 
@@ -22,11 +23,20 @@ class Invidious::Database::Migrator
     puts "No migrations to run." unless ran_migration
   end
 
-  def pending_migrations? : Bool
+  def check_pending_migrations
     versions = load_versions
 
-    load_migrations.sort_by(&.version)
-      .any? { |migration| !versions.includes?(migration.version) }
+    pending_migrations = load_migrations.sort_by(&.version)
+      .select { |migration| !versions.includes?(migration.version) }
+
+    return if pending_migrations.empty?
+
+    if pending_migrations.any?(&.required?)
+      LOGGER.error("There are pending migrations and the application is unable to continue. #{MIGRATE_INSTRUCTION}")
+      exit 1
+    else
+      LOGGER.warn("There are pending migrations. #{MIGRATE_INSTRUCTION}")
+    end
   end
 
   private def load_migrations : Array(Invidious::Database::Migration)


### PR DESCRIPTION
When the app starts, it will check for any pending migrations and issue a warning (but allow the app to continue). Adds new functionality to migrations to mark them as required which, during the pending migration check, will cause the app to fail to start.

To test this, I took the migration from https://github.com/iv-org/invidious/pull/2469 and included it here. It will not break anything if the migration is not run and seems useful for performance issues.

I know some are pushing towards automatically running migrations, but I am not. Feel free to push back