### PR TITLE
Rewrite transcript logic to be more generic

### DIFF
--- a/src/invidious/routes/api/v1/videos.cr
+++ b/src/invidious/routes/api/v1/videos.cr
@@ -89,9 +89,14 @@ module Invidious::Routes::API::V1::Videos
 
     if CONFIG.use_innertube_for_captions
       params = Invidious::Videos::Transcript.generate_param(id, caption.language_code, caption.auto_generated)
-      initial_data = YoutubeAPI.get_transcript(params)
 
-      webvtt = Invidious::Videos::Transcript.convert_transcripts_to_vtt(initial_data, caption.language_code)
+      transcript = Invidious::Videos::Transcript.from_raw(
+        YoutubeAPI.get_transcript(params),
+        caption.language_code,
+        caption.auto_generated
+      )
+
+      webvtt = transcript.to_vtt
     else
       # Timedtext API handling
       url = URI.parse("#{caption.base_url}&tlang=#{tlang}").request_target


### PR DESCRIPTION
The transcript logic in Invidious was written specifically as a workaround for captions, and not transcripts as a feature.

This PR genericises the logic as so it can be used for actually implementing transcripts within Invidious' as well.

The most notable change is the added parsing of section headings when it was previously skipped over in favor of regular lines.

The changes in `src/invidious/videos/transcript.cr` should be reviewed as more of a rewrite than just changes.