### PR TITLE
Player: Fix a bug where menus were hard to open

### DIFF
--- a/assets/css/player.css
+++ b/assets/css/player.css
@@ -68,6 +68,7 @@
 
 .video-js.player-style-youtube .vjs-menu-button-popup .vjs-menu {
   margin-bottom: 2em;
+  padding-top: 2em
 }
 
 .video-js.player-style-youtube .vjs-progress-control .vjs-progress-holder, .video-js.player-style-youtube .vjs-progress-control {height: 5px;


### PR DESCRIPTION
closes #4749 

The fix basically enlarges the hoverable area in order to avoid getting the menu closed if the mouse isn't moved fast enough.

Video of the fix:

https://www.loom.com/share/36494a3653984650aea3eaa2af276a35