### PR TITLE
CI: Run Ameba

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -20,6 +20,9 @@ Lint/ShadowingOuterLocalVar:
   Excluded:
   - src/invidious/helpers/tokens.cr
 
+Lint/NotNil:
+  Enabled: false
+
 
 #
 # Style
@@ -31,6 +34,13 @@ Style/RedundantBegin:
 Style/RedundantReturn:
   Enabled: false
 
+Style/ParenthesesAroundCondition:
+  Enabled: false
+
+# This requires a rewrite of most data structs (and their usage) in Invidious.
+Style/QueryBoolMethods:
+  Enabled: false
+
 
 #
 # Metrics
@@ -39,50 +49,4 @@ Style/RedundantReturn:
 # Ignore function complexity (number of if/else & case/when branches)
 # For some functions that can hardly be simplified for now
 Metrics/CyclomaticComplexity:
-  Excluded:
-  # get_about_info(ucid, locale) => [17/10]
-  - src/invidious/channels/about.cr
-
-  # fetch_channel_community(ucid, continuation, ...) => [34/10]
-  - src/invidious/channels/community.cr
-
-  # create_notification_stream(env, topics, connection_channel) => [14/10]
-  - src/invidious/helpers/helpers.cr:84:5
-
-  # get_index(plural_form, count) => [25/10]
-  - src/invidious/helpers/i18next.cr
-
-  # call(context) => [18/10]
-  - src/invidious/helpers/static_file_handler.cr
-
-  # show(env) => [38/10]
-  - src/invidious/routes/embed.cr
-
-  # get_video_playback(env) => [45/10]
-  - src/invidious/routes/video_playback.cr
-
-  # handle(env) => [40/10]
-  - src/invidious/routes/watch.cr
-
-  # playlist_ajax(env) => [24/10]
-  - src/invidious/routes/playlists.cr
-
-  # fetch_youtube_comments(id, cursor, ....) => [40/10]
-  # template_youtube_comments(comments, locale, ...) => [16/10]
-  # content_to_comment_html(content) => [14/10]
-  - src/invidious/comments.cr
-
-  # to_json(locale, json) => [21/10]
-  # extract_video_info(video_id, ...) => [44/10]
-  # process_video_params(query, preferences) => [20/10]
-  - src/invidious/videos.cr
-
-
-
-#src/invidious/playlists.cr:327:5
-#[C] Metrics/CyclomaticComplexity: Cyclomatic complexity too high [19/10]
-# fetch_playlist(plid : String)
-
-#src/invidious/playlists.cr:436:5
-#[C] Metrics/CyclomaticComplexity: Cyclomatic complexity too high [11/10]
-# extract_playlist_videos(initial_data : Hash(String, JSON::Any))
+  Enabled: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,9 @@ jobs:
       - name: Cache Shards
         uses: actions/cache@v3
         with:
-          path: ./lib
+          path: |
+            ./lib
+            ./bin
           key: shards-${{ hashFiles('shard.lock') }}
 
       - name: Install Shards

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,4 +124,26 @@ jobs:
       - name: Test Docker
         run: while curl -Isf http://localhost:3000; do sleep 1; done
 
+  ameba_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1.8.0
+        with:
+          crystal: latest
+
+      - name: Cache Shards
+        uses: actions/cache@v3
+        with:
+          path: ./lib
+          key: shards-${{ hashFiles('shard.lock') }}
+
+      - name: Install Shards
+        run: shards install
+
+      - name: Run Ameba linter
+        run: bin/ameba

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.5.0
+    version: 1.6.1
 
   athena-negotiation:
     git: https://github.com/athena-framework/negotiation.git

--- a/shard.yml
+++ b/shard.yml
@@ -35,7 +35,7 @@ development_dependencies:
     version: ~> 0.10.4
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.5.0
+    version: ~> 1.6.1
 
 crystal: ">= 1.0.0, < 2.0.0"
 


### PR DESCRIPTION
Ameba has been technically apart of Invidious for a couple years now but its linting was never enforced. This PR changes that.

Following cases such as what was seen in #4709 it'd probably be a good idea to have Ameba check over everything, especially for basic mistakes.

And from the testing I've done its already been pretty helpful. For example a duplicated key in the i18next logic

https://github.com/iv-org/invidious/blob/1ae14cc22468ce6e0eb794752b113604b1d5582d/src/invidious/helpers/i18next.cr#L97-L98

This PR simply adds Ameba to the CI but doesn't actually fix any of the detected issues. I'd be opening more PRs in the near future to slowly address everything until Invidious is compliant. 