### PR TITLE
JS: Update timeupdate event making it more defensive to prevent errors

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -135,26 +135,32 @@ player.on('timeupdate', function () {
     // YouTube links
 
     let elem_yt_watch = document.getElementById('link-yt-watch');
+    if (elem_yt_watch) {
+        let base_url_yt_watch = elem_yt_watch.getAttribute('data-base-url');
+        elem_yt_watch.href = addCurrentTimeToURL(base_url_yt_watch);
+    }
+    
     let elem_yt_embed = document.getElementById('link-yt-embed');
-
-    let base_url_yt_watch = elem_yt_watch.getAttribute('data-base-url');
-    let base_url_yt_embed = elem_yt_embed.getAttribute('data-base-url');
-
-    elem_yt_watch.href = addCurrentTimeToURL(base_url_yt_watch);
-    elem_yt_embed.href = addCurrentTimeToURL(base_url_yt_embed);
+    if (elem_yt_embed) {
+        let base_url_yt_embed = elem_yt_embed.getAttribute('data-base-url');
+        elem_yt_embed.href = addCurrentTimeToURL(base_url_yt_embed);
+    }
 
     // Invidious links
 
     let domain = window.location.origin;
 
     let elem_iv_embed = document.getElementById('link-iv-embed');
+    if (elem_iv_embed) {
+        let base_url_iv_embed = elem_iv_embed.getAttribute('data-base-url');
+        elem_iv_embed.href = addCurrentTimeToURL(base_url_iv_embed, domain);
+    }
+    
     let elem_iv_other = document.getElementById('link-iv-other');
-
-    let base_url_iv_embed = elem_iv_embed.getAttribute('data-base-url');
-    let base_url_iv_other = elem_iv_other.getAttribute('data-base-url');
-
-    elem_iv_embed.href = addCurrentTimeToURL(base_url_iv_embed, domain);
-    elem_iv_other.href = addCurrentTimeToURL(base_url_iv_other, domain);
+    if (elem_iv_other) {
+        let base_url_iv_other = elem_iv_other.getAttribute('data-base-url');
+        elem_iv_other.href = addCurrentTimeToURL(base_url_iv_other, domain);
+    }
 });
 
 


### PR DESCRIPTION
Hi,

This will fix errors in timeupdate event when you're using an iframe to embed a video and append playsinline=1 and controls=0 in the url.
It can be the case that the element with id=link-yt-watch (and the other three) does not exist.

<img width="626" alt="Screenshot 2024-07-06 at 13 35 20" src="https://github.com/iv-org/invidious/assets/355176/c5375138-85d5-4503-8dc1-b2744f68ae8e">
