### PR TITLE
Carry over audio-only mode in playlist links

### DIFF
--- a/assets/js/watch.js
+++ b/assets/js/watch.js
@@ -67,6 +67,10 @@ function get_playlist(plid) {
             '&format=html&hl=' + video_data.preferences.locale;
     }
 
+    if (video_data.params.listen) {
+        plid_url += '&listen=1'
+    }
+
     helpers.xhr('GET', plid_url, {retries: 5, entity_name: 'playlist'}, {
         on200: function (response) {
             playlist.innerHTML = response.playlistHtml;

--- a/src/invidious/mixes.cr
+++ b/src/invidious/mixes.cr
@@ -81,7 +81,7 @@ def fetch_mix(rdid, video_id, cookies = nil, locale = nil)
   })
 end
 
-def template_mix(mix)
+def template_mix(mix, listen)
   html = <<-END_HTML
   <h3>
     <a href="/mix?list=#{mix["mixId"]}">
@@ -95,7 +95,7 @@ def template_mix(mix)
   mix["videos"].as_a.each do |video|
     html += <<-END_HTML
       <li class="pure-menu-item">
-        <a href="/watch?v=#{video["videoId"]}&list=#{mix["mixId"]}">
+        <a href="/watch?v=#{video["videoId"]}&list=#{mix["mixId"]}#{listen ? "&listen=1" : ""}">
           <div class="thumbnail">
               <img loading="lazy" class="thumbnail" src="/vi/#{video["videoId"]}/mqdefault.jpg" alt="" />
               <p class="length">#{recode_length_seconds(video["lengthSeconds"].as_i)}</p>

--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -498,7 +498,7 @@ def extract_playlist_videos(initial_data : Hash(String, JSON::Any))
   return videos
 end
 
-def template_playlist(playlist)
+def template_playlist(playlist, listen)
   html = <<-END_HTML
   <h3>
     <a href="/playlist?list=#{playlist["playlistId"]}">
@@ -512,7 +512,7 @@ def template_playlist(playlist)
   playlist["videos"].as_a.each do |video|
     html += <<-END_HTML
       <li class="pure-menu-item" id="#{video["videoId"]}">
-        <a href="/watch?v=#{video["videoId"]}&list=#{playlist["playlistId"]}&index=#{video["index"]}">
+        <a href="/watch?v=#{video["videoId"]}&list=#{playlist["playlistId"]}&index=#{video["index"]}#{listen ? "&listen=1" : ""}">
           <div class="thumbnail">
               <img loading="lazy" class="thumbnail" src="/vi/#{video["videoId"]}/mqdefault.jpg" alt="" />
               <p class="length">#{recode_length_seconds(video["lengthSeconds"].as_i)}</p>

--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -42,8 +42,8 @@ module Invidious::Routes::API::V1::Misc
     format = env.params.query["format"]?
     format ||= "json"
 
-    listenParam = env.params.query["listen"]?
-    listen = (listenParam == "true" || listenParam == "1")
+    listen_param = env.params.query["listen"]?
+    listen = (listen_param == "true" || listen_param == "1")
 
     if plid.starts_with? "RD"
       return env.redirect "/api/v1/mixes/#{plid}"
@@ -114,8 +114,8 @@ module Invidious::Routes::API::V1::Misc
     format = env.params.query["format"]?
     format ||= "json"
 
-    listenParam = env.params.query["listen"]?
-    listen = (listenParam == "true" || listenParam == "1")
+    listen_param = env.params.query["listen"]?
+    listen = (listen_param == "true" || listen_param == "1")
 
     begin
       mix = fetch_mix(rdid, continuation, locale: locale)

--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -42,6 +42,9 @@ module Invidious::Routes::API::V1::Misc
     format = env.params.query["format"]?
     format ||= "json"
 
+    listenParam = env.params.query["listen"]?
+    listen = (listenParam == "true" || listenParam == "1")
+
     if plid.starts_with? "RD"
       return env.redirect "/api/v1/mixes/#{plid}"
     end
@@ -85,7 +88,7 @@ module Invidious::Routes::API::V1::Misc
     end
 
     if format == "html"
-      playlist_html = template_playlist(json_response)
+      playlist_html = template_playlist(json_response, listen)
       index, next_video = json_response["videos"].as_a.skip(1 + lookback).select { |video| !video["author"].as_s.empty? }[0]?.try { |v| {v["index"], v["videoId"]} } || {nil, nil}
 
       response = {
@@ -110,6 +113,9 @@ module Invidious::Routes::API::V1::Misc
 
     format = env.params.query["format"]?
     format ||= "json"
+
+    listenParam = env.params.query["listen"]?
+    listen = (listenParam == "true" || listenParam == "1")
 
     begin
       mix = fetch_mix(rdid, continuation, locale: locale)
@@ -157,7 +163,7 @@ module Invidious::Routes::API::V1::Misc
 
     if format == "html"
       response = JSON.parse(response)
-      playlist_html = template_mix(response)
+      playlist_html = template_mix(response, listen)
       next_video = response["videos"].as_a.select { |video| !video["author"].as_s.empty? }[0]?.try &.["videoId"]
 
       response = {


### PR DESCRIPTION
Currently, when a video is viewed in audio-only mode (/watch?listen=1...), the 'related video' links shown on the video include listen=true in the URL parameters, but if the video was opened as part of the playlist, the links to other videos in that playlist don't include it. This PR changes it such that the links have '&listen=1' appended to them when the user is watching a video in audio-only mode.

I made the same change for mixes, and from a cursory look, it seems to me as though it's working (but I personally don't use mixes, so I can't say for sure).