### PR TITLE
Add ability to set po_token and visitor data

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -173,6 +173,18 @@ https_only: false
 ##
 # use_innertube_for_captions: false
 
+##
+## Send Google session informations. This is useful when Invidious is blocked
+## by the message "This helps protect our community."
+## See https://github.com/iv-org/invidious/issues/4734.
+##
+## Warning: These strings gives much more identifiable information to Google!
+##
+## Accepted values: String
+## Default: <none>
+##
+# po_token: ""
+# visitor_data: ""
 
 # -----------------------------
 #  Logging

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -130,6 +130,11 @@ class Config
   # Use Innertube's transcripts API instead of timedtext for closed captions
   property use_innertube_for_captions : Bool = false
 
+  # visitor data ID for Google session
+  property visitor_data : String? = nil
+  # poToken for passing bot attestation
+  property po_token : String? = nil
+
   # Saved cookies in "name1=value1; name2=value2..." format
   @[YAML::Field(converter: Preferences::StringToCookies)]
   property cookies : HTTP::Cookies = HTTP::Cookies.new

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -110,7 +110,7 @@ struct Video
         fmt["url"] = JSON::Any.new("#{fmt["url"]}#{DECRYPT_FUNCTION.decrypt_signature(fmt)}")
       end
 
-      fmt["url"] = JSON::Any.new("#{fmt["url"]}&host=#{URI.parse(fmt["url"].as_s).host}")
+      fmt["url"] = JSON::Any.new("#{fmt["url"]}&host=#{URI.parse(fmt["url"].as_s).host}&pot=#{CONFIG.po_token}")
       fmt["url"] = JSON::Any.new("#{fmt["url"]}&region=#{self.info["region"]}") if self.info["region"]?
     end
 
@@ -130,7 +130,7 @@ struct Video
         fmt["url"] = JSON::Any.new("#{fmt["url"]}#{DECRYPT_FUNCTION.decrypt_signature(fmt)}")
       end
 
-      fmt["url"] = JSON::Any.new("#{fmt["url"]}&host=#{URI.parse(fmt["url"].as_s).host}")
+      fmt["url"] = JSON::Any.new("#{fmt["url"]}&host=#{URI.parse(fmt["url"].as_s).host}&pot=#{CONFIG.po_token}")
       fmt["url"] = JSON::Any.new("#{fmt["url"]}&region=#{self.info["region"]}") if self.info["region"]?
     end
 

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -320,6 +320,10 @@ module YoutubeAPI
       client_context["client"]["platform"] = platform
     end
 
+    if CONFIG.visitor_data.is_a?(String)
+      client_context["client"]["visitorData"] = CONFIG.visitor_data.as(String)
+    end
+
     return client_context
   end
 
@@ -467,6 +471,9 @@ module YoutubeAPI
           "html5Preference": "HTML5_PREF_WANTS",
         },
       },
+      "serviceIntegrityDimensions" => {
+        "poToken" => CONFIG.po_token,
+      },
     }
 
     # Append the additional parameters if those were provided
@@ -597,6 +604,10 @@ module YoutubeAPI
 
     if user_agent = client_config.user_agent
       headers["User-Agent"] = user_agent
+    end
+
+    if CONFIG.visitor_data.is_a?(String)
+      headers["X-Goog-Visitor-Id"] = CONFIG.visitor_data.as(String)
     end
 
     # Logging


### PR DESCRIPTION
Helps with https://github.com/iv-org/invidious/issues/4734

This adds the ability to set po_token and visitordata ID statically in the config.yaml

Also, if `po_token` parameter is passed, then WEB client is used, if not Android client is used. `TvHtml5ScreenEmbed` will still be used as a fallback.

Script for generating po_token and visitor_data: https://github.com/iv-org/youtube-trusted-session-generator

There are plans to automate the tokens creation: https://github.com/iv-org/youtube-trusted-session-generator/issues/1 but not yet implemented. At least this unlocks people for keep using invidious.