### PR TITLE
Beautify 404 page

### DIFF
--- a/assets/404_tv_box_dark_theme.svg
+++ b/assets/404_tv_box_dark_theme.svg
@@ -1,0 +1,1261 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="293"
+   height="285"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="404_tv_box_dark_theme.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#cccccc"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="1"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5481496"
+     inkscape:cx="88.169773"
+     inkscape:cy="114.97597"
+     inkscape:window-width="1680"
+     inkscape:window-height="997"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g22" />
+  <g
+     id="iteration1-hide-me"
+     style="display:inline">
+    <title
+       id="title1">Layer 1</title>
+    <g
+       id="g20"
+       inkscape:label="background"
+       style="display:none">
+      <rect
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         x="26.40877"
+         y="85.812943"
+         width="83.182457"
+         height="29.374121"
+         id="svg_41"
+         transform="rotate(-15.5424,68,100.5)" />
+      <rect
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         x="177.76955"
+         y="205.15295"
+         width="84.960922"
+         height="48.69408"
+         id="svg_38"
+         transform="rotate(-15.8743,220.25,229.5)" />
+      <rect
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         x="100"
+         y="93.5"
+         width="160.5"
+         height="29"
+         id="svg_39"
+         transform="rotate(13.2636,180.25,108)"
+         style="display:inline" />
+      <rect
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         x="27.81702"
+         y="177.55167"
+         width="167.84125"
+         height="68"
+         id="svg_37"
+         transform="rotate(13.4509,111.738,211.552)"
+         style="display:inline" />
+      <rect
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         x="104.5"
+         y="113.5"
+         width="164.5"
+         height="131"
+         id="svg_36"
+         style="display:inline" />
+      <rect
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         x="19"
+         y="100.5"
+         width="194.5"
+         height="126"
+         id="svg_35"
+         style="display:inline" />
+    </g>
+    <g
+       id="g19"
+       inkscape:label="misc-hidden"
+       style="display:none">
+      <path
+         id="svg_45"
+         d="m -221.41847,-369.62391 -15.05659,4.86339 c 0.0666,0.13328 30.0466,-9.86006 15.05659,-4.86339 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_47"
+         d="m -168.40183,-372.2921 -27.71482,9.52694 c 0.0666,0.13328 55.36305,-19.18717 27.71482,-9.52694 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_48"
+         d="m -178.39315,-372.6232 -28.38104,9.19383 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_49"
+         d="m -171.40115,-370.95834 -27.38171,9.52694 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_50"
+         d="m -183.05871,-375.95499 -28.71415,9.19383 c 0.0666,0.13328 57.36172,-18.52095 28.71415,-9.19383 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_52"
+         d="m -188.72294,-375.95568 -27.04859,9.52694 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_53"
+         d="m -193.05806,-379.95236 -24.71682,9.52694 32.31179,8.994 -7.59498,-18.52095 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_55"
+         d="m -205.72561,-370.29142 c -16.98868,6.32911 -35.97602,-0.99933 -16.98868,6.32911 18.98734,7.32845 33.97735,-12.65823 16.98868,-6.32911 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_56"
+         d="m -141.72493,-295.82575 -41.03927,22.18518 40.30646,31.64557 0.7328,-53.83075 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_62"
+         d="m -169.71226,-278.47334 -36.0426,22.51829 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_80"
+         d="m 36.18251,206.31413 c 0.34038,10.55191 15.65768,13.27499 15.58963,13.1388"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_81"
+         d="m 35.8494,134.43226 c 0,-13.89386 16.32529,-10.76774 16.25585,-10.90671"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_83"
+         d="m 167.76147,231.57832 c 0,15.32312 -17.98801,11.6589 -18.05461,11.52561"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_84"
+         d="m 168.09458,165.28917 c 0,-13.32445 -16.65556,-17.6549 -16.72216,-17.78817"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+    </g>
+    <g
+       id="g16"
+       inkscape:label="color-sec-F"
+       style="display:none">
+      <rect
+         id="svg_173"
+         height="7.1655502"
+         width="0.49991"
+         y="228.08191"
+         x="149.57083"
+         stroke-width="2"
+         stroke="#56ff56"
+         fill="#56ff56" />
+      <rect
+         id="svg_172"
+         height="7.9987402"
+         width="15.66568"
+         y="232.74783"
+         x="150.57066"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="#56ff56"
+         style="display:inline" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_171"
+         y2="233.24931"
+         x2="170.0927"
+         y1="228.27557"
+         x1="149.32738"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="none" />
+    </g>
+    <g
+       id="g6"
+       inkscape:label="color-sec-E"
+       style="display:none">
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_174"
+         y2="239.18797"
+         x2="148.36562"
+         y1="234.77303"
+         x1="129.93324"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_175"
+         y2="227.68977"
+         x2="148.03233"
+         y1="222.71603"
+         x1="127.267"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="none" />
+      <rect
+         id="svg_176"
+         height="7.9987402"
+         width="18.163811"
+         y="227.18829"
+         x="128.5103"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="#56ffff"
+         style="display:inline" />
+      <rect
+         id="svg_177"
+         height="7.1655502"
+         width="0.49991"
+         y="222.52237"
+         x="127.51046"
+         stroke-width="2"
+         stroke="#56ffff"
+         fill="#56ffff" />
+    </g>
+    <g
+       id="g7"
+       inkscape:label="color-sec-D"
+       style="display:none">
+      <rect
+         id="svg_161"
+         height="7.1655502"
+         width="0.49991"
+         y="217.06941"
+         x="105.70813"
+         stroke-width="2"
+         stroke="#ffff56"
+         fill="#ffff56" />
+      <rect
+         id="svg_160"
+         height="7.9987402"
+         width="18.163811"
+         y="221.73534"
+         x="106.70796"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="#ffff56"
+         style="display:inline" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_158"
+         y2="233.735"
+         x2="126.56328"
+         y1="229.32007"
+         x1="108.13091"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_159"
+         y2="222.23682"
+         x2="126.23"
+         y1="217.26308"
+         x1="105.46467"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="none" />
+    </g>
+    <g
+       id="g9"
+       inkscape:label="color-sec-C"
+       style="display:none">
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_154"
+         y2="229.90228"
+         x2="104.90002"
+         y1="225.48734"
+         x1="86.467659"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_155"
+         y2="218.40408"
+         x2="104.56675"
+         y1="213.43034"
+         x1="83.801407"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="none" />
+      <rect
+         id="svg_157"
+         height="7.1655502"
+         width="0.49991"
+         y="213.23668"
+         x="84.044868"
+         stroke-width="2"
+         stroke="#ff56ff"
+         fill="#ff56ff" />
+      <rect
+         id="svg_156"
+         height="7.9987402"
+         width="18.163811"
+         y="217.9026"
+         x="85.044708"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="#ff56ff"
+         style="display:inline" />
+    </g>
+    <g
+       id="g10"
+       inkscape:label="color-sec-B"
+       style="display:none">
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_150"
+         y2="224.06985"
+         x2="82.570213"
+         y1="219.65492"
+         x1="64.13784"
+         stroke-width="4"
+         stroke="#666666"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_151"
+         y2="212.57167"
+         x2="82.236931"
+         y1="207.59795"
+         x1="61.471588"
+         stroke-width="4"
+         stroke="#666666"
+         fill="none" />
+      <rect
+         id="svg_152"
+         height="7.9987402"
+         width="18.163811"
+         y="212.07019"
+         x="62.71489"
+         stroke-width="4"
+         stroke="#666666"
+         fill="#666666" />
+      <rect
+         id="svg_153"
+         height="7.1655502"
+         width="0.49991"
+         y="207.40427"
+         x="61.715061"
+         stroke-width="2"
+         stroke="#666666"
+         fill="#666666" />
+    </g>
+    <g
+       id="g14"
+       inkscape:label="color-sec-A"
+       style="display:none">
+      <rect
+         id="svg_180"
+         height="7.9987402"
+         width="18.163811"
+         y="207.25533"
+         x="40.574131"
+         stroke-width="4"
+         stroke="#ffaa56"
+         fill="#ffaa56" />
+      <rect
+         id="svg_181"
+         height="7.1655502"
+         width="0.49991"
+         y="202.58939"
+         x="39.574299"
+         stroke-width="2"
+         stroke="#ffaa56"
+         fill="#ffaa56" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_179"
+         y2="207.75681"
+         x2="60.096169"
+         y1="202.78307"
+         x1="39.330841"
+         stroke-width="4"
+         stroke="#ffaa56"
+         fill="none"
+         style="display:inline" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_178"
+         y2="219.25499"
+         x2="60.429451"
+         y1="214.84006"
+         x1="41.997082"
+         stroke-width="4"
+         stroke="#ffaa56"
+         fill="none" />
+    </g>
+    <g
+       id="g15"
+       inkscape:label="color-prim-F"
+       style="display:none">
+      <line
+         id="svg_130"
+         y2="148.99777"
+         x2="149.88232"
+         y1="160.65668"
+         x1="149.54922"
+         stroke-width="4"
+         stroke="#ff5656"
+         fill="none" />
+      <rect
+         id="svg_129"
+         height="67.62159"
+         width="17.5714"
+         y="157.32556"
+         x="149.88239"
+         stroke-width="4"
+         stroke="#ff5656"
+         fill="#ff5656"
+         style="display:inline" />
+      <path
+         d="m 159.20945,160.65667 c 0,0 0,-0.33311 0,-0.99933 0,-0.66623 -0.15283,-1.56345 -0.3331,-1.99867 -0.12747,-0.30775 0,-0.66621 0,-0.99933 0,-0.33311 0.25494,-0.71695 0,-1.33244 -0.1803,-0.43524 -0.33313,-0.33311 -0.33313,-0.33311 0,-0.33311 0,-0.33311 0,-0.33311 -0.3331,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.66623,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 -0.3331,0 -0.69156,-0.20563 -0.99933,-0.33311 -0.43521,-0.18028 -0.66623,-0.33311 -0.66623,-0.33311 -0.3331,-0.3331 -0.6662,-0.3331 -0.6662,-0.3331 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.3331,-0.33311 -0.66623,-0.33311 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 0,0 0,0 0,0 0,0 -0.3331,0 v 0 h 0.3331 v 0"
+         id="svg_132"
+         stroke-width="4"
+         stroke="#ff5656"
+         fill="#ff5656" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_133"
+         y2="229.75568"
+         x2="167.12152"
+         y1="225.34073"
+         x1="148.68915"
+         stroke-width="4"
+         stroke="#ff5656"
+         fill="none" />
+      <line
+         transform="rotate(-11.5544,159.543,153.328)"
+         id="svg_131"
+         y2="157.25256"
+         x2="168.44283"
+         y1="149.40385"
+         x1="150.64227"
+         stroke-width="4"
+         stroke="#ff5656"
+         fill="none" />
+      <line
+         id="svg_134"
+         y2="232.26884"
+         x2="167.20412"
+         y1="207.62537"
+         x1="167.20412"
+         stroke-width="4"
+         stroke="#ff5656"
+         fill="none" />
+    </g>
+    <g
+       id="g4"
+       inkscape:label="color-prim-E"
+       style="display:none">
+      <rect
+         id="svg_123"
+         height="67.62159"
+         width="17.5714"
+         y="151.96472"
+         x="128.45392"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="#ff56ff"
+         style="display:inline" />
+      <line
+         transform="rotate(-11.5544,138.114,147.967)"
+         id="svg_125"
+         y2="151.89172"
+         x2="147.01437"
+         y1="144.04301"
+         x1="129.21382"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="none"
+         style="display:inline" />
+      <path
+         d="m 137.78099,155.29583 c 0,0 0,-0.33311 0,-0.99933 0,-0.66623 -0.15283,-1.56345 -0.3331,-1.99867 -0.12747,-0.30775 0,-0.66621 0,-0.99933 0,-0.33311 0.25494,-0.71695 0,-1.33244 -0.1803,-0.43524 -0.33313,-0.33311 -0.33313,-0.33311 0,-0.33311 0,-0.33311 0,-0.33311 -0.3331,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.66623,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 -0.3331,0 -0.69156,-0.20563 -0.99933,-0.33311 -0.43521,-0.18028 -0.66623,-0.33311 -0.66623,-0.33311 -0.3331,-0.3331 -0.6662,-0.3331 -0.6662,-0.3331 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.3331,-0.33311 -0.66623,-0.33311 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 0,0 0,0 0,0 0,0 -0.3331,0 v 0 h 0.3331 v 0"
+         id="svg_126"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="#ff56ff" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_127"
+         y2="224.39484"
+         x2="145.69305"
+         y1="219.97989"
+         x1="127.2607"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="none" />
+      <line
+         id="svg_128"
+         y2="226.908"
+         x2="145.77567"
+         y1="202.26453"
+         x1="145.77567"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="none"
+         style="display:inline" />
+      <line
+         id="svg_124"
+         y2="143.63693"
+         x2="128.45387"
+         y1="155.29584"
+         x1="128.12076"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="none" />
+    </g>
+    <g
+       id="g13"
+       style="display:none"
+       inkscape:label="color-prim-D">
+      <rect
+         id="svg_117"
+         height="67.62159"
+         width="17.5714"
+         y="146.63493"
+         x="106.80217"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="#56ff56" />
+      <line
+         id="svg_118"
+         y2="138.30716"
+         x2="106.80212"
+         y1="149.96605"
+         x1="106.46901"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="none" />
+      <line
+         transform="rotate(-11.5544,116.462,142.638)"
+         id="svg_119"
+         y2="146.56195"
+         x2="125.36262"
+         y1="138.71323"
+         x1="107.56206"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="none" />
+      <path
+         d="m 116.12924,149.96605 c 0,0 0,-0.33311 0,-0.99933 0,-0.66623 -0.15283,-1.56345 -0.3331,-1.99867 -0.12747,-0.30775 0,-0.66621 0,-0.99933 0,-0.33311 0.25494,-0.71695 0,-1.33244 -0.1803,-0.43524 -0.33313,-0.33311 -0.33313,-0.33311 0,-0.33311 0,-0.33311 0,-0.33311 -0.3331,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.66623,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 -0.3331,0 -0.69156,-0.20563 -0.99933,-0.33311 -0.43521,-0.18028 -0.66623,-0.33311 -0.66623,-0.33311 -0.3331,-0.3331 -0.6662,-0.3331 -0.6662,-0.3331 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.3331,-0.33311 -0.66623,-0.33311 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 0,0 0,0 0,0 0,0 -0.3331,0 v 0 h 0.3331 v 0"
+         id="svg_120"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="#56ff56" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_121"
+         y2="219.06505"
+         x2="124.0413"
+         y1="214.65012"
+         x1="105.60894"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="none" />
+      <line
+         id="svg_122"
+         y2="221.57823"
+         x2="124.12391"
+         y1="196.93474"
+         x1="124.12391"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="none" />
+    </g>
+    <g
+       id="g17"
+       inkscape:label="color-prim-C"
+       style="display:none">
+      <rect
+         id="svg_111"
+         height="67.62159"
+         width="17.5714"
+         y="141.30516"
+         x="85.149918"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="#56ffff" />
+      <line
+         id="svg_112"
+         y2="132.97739"
+         x2="85.149872"
+         y1="144.63628"
+         x1="84.816757"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="none" />
+      <line
+         transform="rotate(-11.5544,94.807,137.308)"
+         id="svg_113"
+         y2="141.23216"
+         x2="103.71037"
+         y1="133.38345"
+         x1="85.909813"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="none" />
+      <path
+         d="m 94.47699,144.63627 c 0,0 0,-0.33311 0,-0.99933 0,-0.66623 -0.15283,-1.56345 -0.3331,-1.99867 -0.12747,-0.30775 0,-0.66621 0,-0.99933 0,-0.33311 0.25494,-0.71695 0,-1.33244 -0.1803,-0.43524 -0.33313,-0.33311 -0.33313,-0.33311 0,-0.33311 0,-0.33311 0,-0.33311 -0.3331,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.66623,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 -0.3331,0 -0.69156,-0.20563 -0.99933,-0.33311 -0.43521,-0.18028 -0.66623,-0.33311 -0.66623,-0.33311 -0.3331,-0.3331 -0.6662,-0.3331 -0.6662,-0.3331 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.3331,-0.33311 -0.66623,-0.33311 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 0,0 0,0 0,0 0,0 -0.3331,0 v 0 h 0.3331 v 0"
+         id="svg_114"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="#56ffff" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_115"
+         y2="213.73528"
+         x2="102.38906"
+         y1="209.32033"
+         x1="83.956688"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="none" />
+      <line
+         id="svg_116"
+         y2="216.24844"
+         x2="102.47166"
+         y1="191.60497"
+         x1="102.47166"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="none" />
+    </g>
+    <g
+       id="g12"
+       style="display:none"
+       inkscape:label="color-prim-B">
+      <path
+         d="m 72.15853,138.97338 c 0,0 0,-0.33311 0,-0.99933 0,-0.66623 -0.15283,-1.56345 -0.3331,-1.99867 -0.12747,-0.30775 0,-0.66621 0,-0.99933 0,-0.33311 0.25494,-0.71695 0,-1.33244 -0.1803,-0.43524 -0.33313,-0.33311 -0.33313,-0.33311 0,-0.33311 0,-0.33311 0,-0.33311 -0.3331,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.66623,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 -0.3331,0 -0.69156,-0.20563 -0.99933,-0.33311 -0.43521,-0.18028 -0.66623,-0.33311 -0.66623,-0.33311 -0.3331,-0.3331 -0.6662,-0.3331 -0.6662,-0.3331 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.3331,-0.33311 -0.66623,-0.33311 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 0,0 0,0 0,0 0,0 -0.3331,0 v 0 h 0.3331 v 0"
+         id="svg_108"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="none" />
+      <rect
+         id="svg_104"
+         height="67.62159"
+         width="17.5714"
+         y="135.64227"
+         x="62.831459"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="#ffff56"
+         style="display:inline" />
+      <line
+         id="svg_105"
+         y2="127.31448"
+         x2="62.831421"
+         y1="138.97337"
+         x1="62.498299"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="none" />
+      <line
+         transform="rotate(-11.5544,72.492,131.645)"
+         id="svg_106"
+         y2="135.56927"
+         x2="81.391922"
+         y1="127.72056"
+         x1="63.591358"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_109"
+         y2="208.07237"
+         x2="80.070602"
+         y1="203.65744"
+         x1="61.638241"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="none" />
+      <line
+         id="svg_110"
+         y2="210.58556"
+         x2="80.153198"
+         y1="185.94206"
+         x1="80.153198"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="none" />
+    </g>
+    <g
+       id="g11"
+       inkscape:label="color-prim-A"
+       style="display:none">
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_139"
+         y2="203.06854"
+         x2="57.76881"
+         y1="198.65359"
+         x1="39.336441"
+         stroke-width="4"
+         stroke="#5656ff"
+         fill="none" />
+      <line
+         id="svg_140"
+         y2="205.58173"
+         x2="57.85141"
+         y1="180.93823"
+         x1="57.85141"
+         stroke-width="4"
+         stroke="#5656ff"
+         fill="none" />
+      <rect
+         id="svg_135"
+         height="67.62159"
+         width="17.5714"
+         y="130.63843"
+         x="40.529671"
+         stroke-width="4"
+         stroke="#5656ff"
+         fill="#5656ff"
+         style="display:inline" />
+      <line
+         id="svg_136"
+         y2="122.31065"
+         x2="40.529621"
+         y1="133.96954"
+         x1="40.19651"
+         stroke-width="4"
+         stroke="#5656ff"
+         fill="none" />
+      <line
+         transform="rotate(-11.5544,50.19,126.641)"
+         id="svg_137"
+         y2="130.56544"
+         x2="59.09013"
+         y1="122.71672"
+         x1="41.289558"
+         stroke-width="4"
+         stroke="#5656ff"
+         fill="none" />
+      <path
+         d="m 49.85674,133.96954 c 0,0 0,-0.33311 0,-0.99933 0,-0.66623 -0.15283,-1.56345 -0.3331,-1.99867 -0.12747,-0.30775 0,-0.66621 0,-0.99933 0,-0.33311 0.25494,-0.71695 0,-1.33244 -0.1803,-0.43524 -0.33313,-0.33311 -0.33313,-0.33311 0,-0.33311 0,-0.33311 0,-0.33311 -0.3331,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.66623,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 -0.3331,0 -0.69156,-0.20563 -0.99933,-0.33311 -0.43521,-0.18028 -0.66623,-0.33311 -0.66623,-0.33311 -0.3331,-0.3331 -0.6662,-0.3331 -0.6662,-0.3331 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.3331,-0.33311 -0.66623,-0.33311 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 0,0 0,0 0,0 0,0 -0.3331,0 v 0 h 0.3331 v 0"
+         id="svg_138"
+         stroke-width="4"
+         stroke="#5656ff"
+         fill="#5656ff" />
+    </g>
+    <g
+       id="g5"
+       inkscape:label="screen-border"
+       style="display:none">
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_76"
+         y2="134.32593"
+         x2="35.988682"
+         y1="206.34776"
+         x1="35.988682"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_79"
+         y2="243.2625"
+         x2="151.02332"
+         y1="218.98056"
+         x1="49.64624"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_78"
+         y2="148.13828"
+         x2="153.35509"
+         y1="123.28388"
+         x1="49.58794"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_77"
+         y2="164.63905"
+         x2="167.90076"
+         y1="231.66422"
+         x1="167.90076"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+    </g>
+    <g
+       id="g18"
+       style="display:none"
+       inkscape:label="ext-border">
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_1"
+         y2="112"
+         x2="272"
+         y1="72"
+         x1="105"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none"
+         style="display:inline" />
+      <line
+         fill="none"
+         stroke="#000000"
+         stroke-width="4"
+         x1="19"
+         y1="95.574997"
+         x2="105"
+         y2="72"
+         id="svg_4"
+         stroke-linejoin="undefined"
+         stroke-linecap="undefined"
+         style="display:inline" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_3"
+         y2="113.0188"
+         x2="270"
+         y1="246"
+         x1="270"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none"
+         style="display:inline" />
+      <line
+         fill="none"
+         stroke="#000000"
+         stroke-width="4"
+         x1="186"
+         y1="136.575"
+         x2="272"
+         y2="113"
+         id="svg_5"
+         stroke-linejoin="undefined"
+         stroke-linecap="undefined" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_6"
+         y2="267"
+         x2="185"
+         y1="227"
+         x1="18"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none"
+         style="display:inline" />
+      <line
+         fill="none"
+         stroke="#000000"
+         stroke-width="4"
+         x1="186"
+         y1="267.57501"
+         x2="272"
+         y2="244"
+         id="svg_34"
+         stroke-linejoin="undefined"
+         stroke-linecap="undefined" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_7"
+         y2="95.018799"
+         x2="19"
+         y1="228"
+         x1="19"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_8"
+         y2="137"
+         x2="186"
+         y1="97"
+         x1="19"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_10"
+         y2="138.0188"
+         x2="184"
+         y1="269"
+         x1="184"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="if-light-theme-show-me"
+     style="display:none">
+    <path
+       style="fill:#4c4c4c;fill-opacity:1"
+       d="m 22.540404,94.91278 -3.425257,5.41412 -0.110493,121.98336 3.204274,5.96658 158.445782,38.00931 6.85051,0.88393 79.55437,-21.43548 2.98329,-4.64067 -0.11049,-125.40862 -2.8728,-5.19313 -159.10873,-37.677836 -5.85609,-0.220984 z"
+       id="tv-box-background" />
+    <g
+       id="g2"
+       style="display:inline"
+       inkscape:label="antenae-right">
+      <line
+         fill="none"
+         stroke="#000000"
+         stroke-width="4"
+         x1="159"
+         y1="107"
+         x2="236"
+         y2="53"
+         id="wire-2"
+         stroke-linejoin="undefined"
+         stroke-linecap="undefined" />
+      <ellipse
+         style="display:inline;fill:#000000;fill-opacity:1"
+         id="base-2"
+         cx="159.15788"
+         cy="106.85718"
+         rx="1.9123522"
+         ry="2.0862024" />
+      <ellipse
+         fill="none"
+         stroke="#000000"
+         stroke-width="2"
+         cx="239"
+         cy="48.5"
+         id="foam-ball-2"
+         rx="6"
+         ry="5.5" />
+      <ellipse
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         cx="238.96629"
+         cy="48.432583"
+         id="foam-ball-3"
+         ry="3.7883894"
+         rx="4.3220973"
+         style="display:inline" />
+    </g>
+    <g
+       id="g3"
+       inkscape:label="antenae-left"
+       style="display:inline">
+      <line
+         fill="none"
+         stroke="#000000"
+         stroke-width="4"
+         x1="118"
+         y1="99"
+         x2="74"
+         y2="25"
+         id="wire"
+         stroke-linejoin="undefined"
+         stroke-linecap="undefined" />
+      <ellipse
+         style="display:inline;fill:#000000;fill-opacity:1;stroke-width:1.01844"
+         id="base"
+         cx="118.1377"
+         cy="99.240196"
+         rx="1.9607856"
+         ry="2.110419" />
+      <ellipse
+         fill="none"
+         stroke="#000000"
+         stroke-width="2"
+         cx="72"
+         cy="21.5"
+         id="foam-ball-border"
+         rx="6"
+         ry="5.5" />
+      <ellipse
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         cx="72.066086"
+         cy="21.566084"
+         id="foam-ball"
+         rx="4.1226115"
+         ry="3.745223"
+         style="display:inline" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="g22"
+     inkscape:label="if-dark-theme-show-me"
+     style="display:inline">
+    <path
+       style="fill:#b3b3b3;fill-opacity:1"
+       d="m 22.540404,94.91278 -3.425257,5.41412 -0.110493,121.98336 3.204274,5.96658 158.445782,38.00931 6.85051,0.88393 79.55437,-21.43548 2.98329,-4.64067 -0.11049,-125.40862 -2.8728,-5.19313 -159.10873,-37.677836 -5.85609,-0.220984 z"
+       id="path1" />
+    <g
+       id="g8"
+       style="display:inline"
+       inkscape:label="antenae-right">
+      <line
+         fill="none"
+         stroke="#000000"
+         stroke-width="4"
+         x1="159"
+         y1="107"
+         x2="236"
+         y2="53"
+         id="line1"
+         stroke-linejoin="undefined"
+         stroke-linecap="undefined" />
+      <ellipse
+         style="display:inline;fill:#000000;fill-opacity:1"
+         id="ellipse1"
+         cx="159.15788"
+         cy="106.85718"
+         rx="1.9123522"
+         ry="2.0862024" />
+      <ellipse
+         fill="none"
+         stroke="#000000"
+         stroke-width="2"
+         cx="239"
+         cy="48.5"
+         id="ellipse2"
+         rx="6"
+         ry="5.5"
+         style="fill:#b3b3b3" />
+      <ellipse
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         cx="238.96629"
+         cy="48.432583"
+         id="ellipse3"
+         ry="3.7883894"
+         rx="4.3220973"
+         style="display:inline;fill:#b3b3b3;stroke:#b3b3b3;stroke-opacity:1" />
+    </g>
+    <g
+       id="g21"
+       inkscape:label="antenae-left"
+       style="display:inline">
+      <line
+         fill="none"
+         stroke="#000000"
+         stroke-width="4"
+         x1="118"
+         y1="99"
+         x2="74"
+         y2="25"
+         id="line8"
+         stroke-linejoin="undefined"
+         stroke-linecap="undefined" />
+      <ellipse
+         style="display:inline;fill:#000000;fill-opacity:1;stroke-width:1.01844"
+         id="ellipse8"
+         cx="118.1377"
+         cy="99.240196"
+         rx="1.9607856"
+         ry="2.110419" />
+      <ellipse
+         fill="none"
+         stroke="#000000"
+         stroke-width="2"
+         cx="72"
+         cy="21.5"
+         id="ellipse9"
+         rx="6"
+         ry="5.5" />
+      <ellipse
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         cx="72.066086"
+         cy="21.566084"
+         id="ellipse10"
+         rx="4.1226115"
+         ry="3.745223"
+         style="display:inline;fill:#b3b3b3;stroke:#b3b3b3;stroke-opacity:1" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="iteration2-show-me"
+     style="display:inline">
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 18.857678,100.33708 0.09435,121.85866 3.188097,6.02992 159.006335,38.21059 6.4156,0.75477 79.50317,-21.51114 3.0191,-4.65446 -0.25159,-125.67035 -2.76751,-4.78025 -159.50952,-37.864645 -5.40924,-0.125796 -79.880548,22.014326 z"
+       id="tv-box-border"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <path
+       style="display:inline;fill:#ff5656;fill-opacity:1"
+       d="m 167.48106,229.34651 -21.76115,-5.01304 v -77.81603 l 7.17776,1.48112 5.12697,1.59506 3.30405,1.59506 2.16472,1.70899 1.70899,2.16472 1.25326,2.39259 1.13933,3.75978 0.22786,3.53191 0.11394,63.91624 z"
+       id="color-tall-F" />
+    <path
+       style="fill:#5656ff;fill-opacity:1;stroke-width:1.01066"
+       d="m 38.314468,126.39491 v 73.20515 l 21.65449,4.91939 v -78.3588 l -6.221179,-1.63979 -5.0248,-1.17128 -4.426608,0.46851 -3.469504,1.40554 z"
+       id="color-tall-A" />
+    <path
+       style="fill:#56ff56;fill-opacity:1"
+       d="m 145.82068,224.35904 v 17.51879 l 4.82402,1.26948 4.57012,0.0846 5.07791,-0.93095 3.7238,-1.8619 2.45432,-3.4699 0.67706,-3.89307 -0.0846,-3.80843 z"
+       id="color-short-F" />
+    <path
+       style="display:none;fill:#5656ff;fill-opacity:1"
+       d="m 38.500905,120.54773 v 78.98729 l 21.511433,5.04174 v -78.81923 z"
+       id="color-tall-A-old" />
+    <path
+       style="display:inline;fill:#ffff56;fill-opacity:1"
+       d="m 60.044858,125.58198 v 78.98729 l 21.511433,5.04174 v -78.81923 z"
+       id="color-tall-B" />
+    <path
+       style="display:inline;fill:#56ffff;fill-opacity:1"
+       d="m 81.537336,130.58847 v 78.98729 l 21.511434,5.04174 v -78.81923 z"
+       id="color-tall-C" />
+    <path
+       style="display:inline;fill:#56ff56;fill-opacity:1"
+       d="m 103.05703,135.63108 v 78.98729 l 21.51143,5.04174 v -78.81923 z"
+       id="color-tall-D" />
+    <path
+       style="display:inline;fill:#ff56ff;fill-opacity:1"
+       d="m 124.57317,140.61108 v 78.98729 l 21.51143,5.04174 v -78.81923 z"
+       id="color-tall-E" />
+    <path
+       style="display:inline;fill:#ffaa56;fill-opacity:1;stroke-width:0.991301"
+       d="m 38.468507,199.51739 v 16.14244 l 21.539423,4.8659 V 204.3833 Z"
+       id="color-short-A" />
+    <path
+       style="fill:#666666;fill-opacity:1;stroke-width:1.00559"
+       d="m 60.006114,204.54637 v 16.61117 l 21.539423,5.00719 v -16.61116 z"
+       id="color-short-B" />
+    <path
+       style="fill:#ff56ff;fill-opacity:1;stroke-width:1.00559"
+       d="m 81.536466,209.5606 v 16.61117 l 21.539424,5.00719 V 214.5678 Z"
+       id="color-short-C" />
+    <path
+       style="fill:#ffff56;fill-opacity:1;stroke-width:1.00559"
+       d="m 103.04156,214.58516 v 16.61117 l 21.53942,5.00719 v -16.61116 z"
+       id="color-short-D" />
+    <path
+       style="fill:#56ffff;fill-opacity:1;stroke-width:1.00559"
+       d="m 124.58815,219.61634 v 16.61117 l 21.53942,5.00719 v -16.61116 z"
+       id="color-short-E" />
+    <path
+       style="fill:#ffaa56;fill-opacity:1"
+       d="m 38.529641,199.52036 v 14.38854 l -1.616246,-2.87771 -0.788413,-2.60176 -0.157682,-9.5398 z"
+       id="color-short-G" />
+    <path
+       style="fill:#5656ff;fill-opacity:1;stroke-width:1.21145"
+       d="m 38.518046,199.52992 v -72.55495 l -2.680152,3.47937 -0.595589,4.29803 v 63.95888 z"
+       id="color-tall-G"
+       inkscape:label="color-tall-G" />
+    <path
+       style="display:none;fill:#ff5656;fill-opacity:1"
+       d="m 146.10332,145.63865 v 78.98729 l 21.51143,5.04174 v -78.81923 z"
+       id="color-tall-F-old" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:2.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 167.9976,165.99118 -0.15628,64.78763 c 0,0 0.0801,8.73988 -5.80952,11.3343 -5.88961,2.59443 -13.08912,0.92505 -13.08912,0.92505 l -101.045756,-24.373 c 0,0 -6.322219,-1.58475 -8.550977,-3.66243 -3.740947,-3.48737 -3.336759,-9.23168 -3.336759,-9.23168 l -0.0629,-72.23844 c 0,0 -0.186545,-6.516 5.000397,-8.83717 6.714326,-3.00469 10.849917,-0.72334 10.849917,-0.72334 L 152.216,147.83337 c 0,0 9.44867,1.88525 12.56043,6.46902 3.96331,5.83816 3.22121,11.68879 3.22121,11.68879 z"
+       id="path5"
+       sodipodi:nodetypes="cczccsccsccscc"
+       inkscape:label="screen-border-new" />
+  </g>
+</svg>

--- a/assets/404_tv_box_light_theme.svg
+++ b/assets/404_tv_box_light_theme.svg
@@ -1,0 +1,1261 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="293"
+   height="285"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="404_tv_box_light_theme.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#cccccc"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="1"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5481496"
+     inkscape:cx="88.169773"
+     inkscape:cy="114.97597"
+     inkscape:window-width="1680"
+     inkscape:window-height="997"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g22" />
+  <g
+     id="iteration1-hide-me"
+     style="display:inline">
+    <title
+       id="title1">Layer 1</title>
+    <g
+       id="g20"
+       inkscape:label="background"
+       style="display:none">
+      <rect
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         x="26.40877"
+         y="85.812943"
+         width="83.182457"
+         height="29.374121"
+         id="svg_41"
+         transform="rotate(-15.5424,68,100.5)" />
+      <rect
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         x="177.76955"
+         y="205.15295"
+         width="84.960922"
+         height="48.69408"
+         id="svg_38"
+         transform="rotate(-15.8743,220.25,229.5)" />
+      <rect
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         x="100"
+         y="93.5"
+         width="160.5"
+         height="29"
+         id="svg_39"
+         transform="rotate(13.2636,180.25,108)"
+         style="display:inline" />
+      <rect
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         x="27.81702"
+         y="177.55167"
+         width="167.84125"
+         height="68"
+         id="svg_37"
+         transform="rotate(13.4509,111.738,211.552)"
+         style="display:inline" />
+      <rect
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         x="104.5"
+         y="113.5"
+         width="164.5"
+         height="131"
+         id="svg_36"
+         style="display:inline" />
+      <rect
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         x="19"
+         y="100.5"
+         width="194.5"
+         height="126"
+         id="svg_35"
+         style="display:inline" />
+    </g>
+    <g
+       id="g19"
+       inkscape:label="misc-hidden"
+       style="display:none">
+      <path
+         id="svg_45"
+         d="m -221.41847,-369.62391 -15.05659,4.86339 c 0.0666,0.13328 30.0466,-9.86006 15.05659,-4.86339 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_47"
+         d="m -168.40183,-372.2921 -27.71482,9.52694 c 0.0666,0.13328 55.36305,-19.18717 27.71482,-9.52694 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_48"
+         d="m -178.39315,-372.6232 -28.38104,9.19383 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_49"
+         d="m -171.40115,-370.95834 -27.38171,9.52694 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_50"
+         d="m -183.05871,-375.95499 -28.71415,9.19383 c 0.0666,0.13328 57.36172,-18.52095 28.71415,-9.19383 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_52"
+         d="m -188.72294,-375.95568 -27.04859,9.52694 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_53"
+         d="m -193.05806,-379.95236 -24.71682,9.52694 32.31179,8.994 -7.59498,-18.52095 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_55"
+         d="m -205.72561,-370.29142 c -16.98868,6.32911 -35.97602,-0.99933 -16.98868,6.32911 18.98734,7.32845 33.97735,-12.65823 16.98868,-6.32911 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_56"
+         d="m -141.72493,-295.82575 -41.03927,22.18518 40.30646,31.64557 0.7328,-53.83075 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_62"
+         d="m -169.71226,-278.47334 -36.0426,22.51829 z"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_80"
+         d="m 36.18251,206.31413 c 0.34038,10.55191 15.65768,13.27499 15.58963,13.1388"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_81"
+         d="m 35.8494,134.43226 c 0,-13.89386 16.32529,-10.76774 16.25585,-10.90671"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_83"
+         d="m 167.76147,231.57832 c 0,15.32312 -17.98801,11.6589 -18.05461,11.52561"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <path
+         id="svg_84"
+         d="m 168.09458,165.28917 c 0,-13.32445 -16.65556,-17.6549 -16.72216,-17.78817"
+         opacity="0"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+    </g>
+    <g
+       id="g16"
+       inkscape:label="color-sec-F"
+       style="display:none">
+      <rect
+         id="svg_173"
+         height="7.1655502"
+         width="0.49991"
+         y="228.08191"
+         x="149.57083"
+         stroke-width="2"
+         stroke="#56ff56"
+         fill="#56ff56" />
+      <rect
+         id="svg_172"
+         height="7.9987402"
+         width="15.66568"
+         y="232.74783"
+         x="150.57066"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="#56ff56"
+         style="display:inline" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_171"
+         y2="233.24931"
+         x2="170.0927"
+         y1="228.27557"
+         x1="149.32738"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="none" />
+    </g>
+    <g
+       id="g6"
+       inkscape:label="color-sec-E"
+       style="display:none">
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_174"
+         y2="239.18797"
+         x2="148.36562"
+         y1="234.77303"
+         x1="129.93324"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_175"
+         y2="227.68977"
+         x2="148.03233"
+         y1="222.71603"
+         x1="127.267"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="none" />
+      <rect
+         id="svg_176"
+         height="7.9987402"
+         width="18.163811"
+         y="227.18829"
+         x="128.5103"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="#56ffff"
+         style="display:inline" />
+      <rect
+         id="svg_177"
+         height="7.1655502"
+         width="0.49991"
+         y="222.52237"
+         x="127.51046"
+         stroke-width="2"
+         stroke="#56ffff"
+         fill="#56ffff" />
+    </g>
+    <g
+       id="g7"
+       inkscape:label="color-sec-D"
+       style="display:none">
+      <rect
+         id="svg_161"
+         height="7.1655502"
+         width="0.49991"
+         y="217.06941"
+         x="105.70813"
+         stroke-width="2"
+         stroke="#ffff56"
+         fill="#ffff56" />
+      <rect
+         id="svg_160"
+         height="7.9987402"
+         width="18.163811"
+         y="221.73534"
+         x="106.70796"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="#ffff56"
+         style="display:inline" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_158"
+         y2="233.735"
+         x2="126.56328"
+         y1="229.32007"
+         x1="108.13091"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_159"
+         y2="222.23682"
+         x2="126.23"
+         y1="217.26308"
+         x1="105.46467"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="none" />
+    </g>
+    <g
+       id="g9"
+       inkscape:label="color-sec-C"
+       style="display:none">
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_154"
+         y2="229.90228"
+         x2="104.90002"
+         y1="225.48734"
+         x1="86.467659"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_155"
+         y2="218.40408"
+         x2="104.56675"
+         y1="213.43034"
+         x1="83.801407"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="none" />
+      <rect
+         id="svg_157"
+         height="7.1655502"
+         width="0.49991"
+         y="213.23668"
+         x="84.044868"
+         stroke-width="2"
+         stroke="#ff56ff"
+         fill="#ff56ff" />
+      <rect
+         id="svg_156"
+         height="7.9987402"
+         width="18.163811"
+         y="217.9026"
+         x="85.044708"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="#ff56ff"
+         style="display:inline" />
+    </g>
+    <g
+       id="g10"
+       inkscape:label="color-sec-B"
+       style="display:none">
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_150"
+         y2="224.06985"
+         x2="82.570213"
+         y1="219.65492"
+         x1="64.13784"
+         stroke-width="4"
+         stroke="#666666"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_151"
+         y2="212.57167"
+         x2="82.236931"
+         y1="207.59795"
+         x1="61.471588"
+         stroke-width="4"
+         stroke="#666666"
+         fill="none" />
+      <rect
+         id="svg_152"
+         height="7.9987402"
+         width="18.163811"
+         y="212.07019"
+         x="62.71489"
+         stroke-width="4"
+         stroke="#666666"
+         fill="#666666" />
+      <rect
+         id="svg_153"
+         height="7.1655502"
+         width="0.49991"
+         y="207.40427"
+         x="61.715061"
+         stroke-width="2"
+         stroke="#666666"
+         fill="#666666" />
+    </g>
+    <g
+       id="g14"
+       inkscape:label="color-sec-A"
+       style="display:none">
+      <rect
+         id="svg_180"
+         height="7.9987402"
+         width="18.163811"
+         y="207.25533"
+         x="40.574131"
+         stroke-width="4"
+         stroke="#ffaa56"
+         fill="#ffaa56" />
+      <rect
+         id="svg_181"
+         height="7.1655502"
+         width="0.49991"
+         y="202.58939"
+         x="39.574299"
+         stroke-width="2"
+         stroke="#ffaa56"
+         fill="#ffaa56" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_179"
+         y2="207.75681"
+         x2="60.096169"
+         y1="202.78307"
+         x1="39.330841"
+         stroke-width="4"
+         stroke="#ffaa56"
+         fill="none"
+         style="display:inline" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_178"
+         y2="219.25499"
+         x2="60.429451"
+         y1="214.84006"
+         x1="41.997082"
+         stroke-width="4"
+         stroke="#ffaa56"
+         fill="none" />
+    </g>
+    <g
+       id="g15"
+       inkscape:label="color-prim-F"
+       style="display:none">
+      <line
+         id="svg_130"
+         y2="148.99777"
+         x2="149.88232"
+         y1="160.65668"
+         x1="149.54922"
+         stroke-width="4"
+         stroke="#ff5656"
+         fill="none" />
+      <rect
+         id="svg_129"
+         height="67.62159"
+         width="17.5714"
+         y="157.32556"
+         x="149.88239"
+         stroke-width="4"
+         stroke="#ff5656"
+         fill="#ff5656"
+         style="display:inline" />
+      <path
+         d="m 159.20945,160.65667 c 0,0 0,-0.33311 0,-0.99933 0,-0.66623 -0.15283,-1.56345 -0.3331,-1.99867 -0.12747,-0.30775 0,-0.66621 0,-0.99933 0,-0.33311 0.25494,-0.71695 0,-1.33244 -0.1803,-0.43524 -0.33313,-0.33311 -0.33313,-0.33311 0,-0.33311 0,-0.33311 0,-0.33311 -0.3331,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.66623,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 -0.3331,0 -0.69156,-0.20563 -0.99933,-0.33311 -0.43521,-0.18028 -0.66623,-0.33311 -0.66623,-0.33311 -0.3331,-0.3331 -0.6662,-0.3331 -0.6662,-0.3331 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.3331,-0.33311 -0.66623,-0.33311 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 0,0 0,0 0,0 0,0 -0.3331,0 v 0 h 0.3331 v 0"
+         id="svg_132"
+         stroke-width="4"
+         stroke="#ff5656"
+         fill="#ff5656" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_133"
+         y2="229.75568"
+         x2="167.12152"
+         y1="225.34073"
+         x1="148.68915"
+         stroke-width="4"
+         stroke="#ff5656"
+         fill="none" />
+      <line
+         transform="rotate(-11.5544,159.543,153.328)"
+         id="svg_131"
+         y2="157.25256"
+         x2="168.44283"
+         y1="149.40385"
+         x1="150.64227"
+         stroke-width="4"
+         stroke="#ff5656"
+         fill="none" />
+      <line
+         id="svg_134"
+         y2="232.26884"
+         x2="167.20412"
+         y1="207.62537"
+         x1="167.20412"
+         stroke-width="4"
+         stroke="#ff5656"
+         fill="none" />
+    </g>
+    <g
+       id="g4"
+       inkscape:label="color-prim-E"
+       style="display:none">
+      <rect
+         id="svg_123"
+         height="67.62159"
+         width="17.5714"
+         y="151.96472"
+         x="128.45392"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="#ff56ff"
+         style="display:inline" />
+      <line
+         transform="rotate(-11.5544,138.114,147.967)"
+         id="svg_125"
+         y2="151.89172"
+         x2="147.01437"
+         y1="144.04301"
+         x1="129.21382"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="none"
+         style="display:inline" />
+      <path
+         d="m 137.78099,155.29583 c 0,0 0,-0.33311 0,-0.99933 0,-0.66623 -0.15283,-1.56345 -0.3331,-1.99867 -0.12747,-0.30775 0,-0.66621 0,-0.99933 0,-0.33311 0.25494,-0.71695 0,-1.33244 -0.1803,-0.43524 -0.33313,-0.33311 -0.33313,-0.33311 0,-0.33311 0,-0.33311 0,-0.33311 -0.3331,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.66623,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 -0.3331,0 -0.69156,-0.20563 -0.99933,-0.33311 -0.43521,-0.18028 -0.66623,-0.33311 -0.66623,-0.33311 -0.3331,-0.3331 -0.6662,-0.3331 -0.6662,-0.3331 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.3331,-0.33311 -0.66623,-0.33311 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 0,0 0,0 0,0 0,0 -0.3331,0 v 0 h 0.3331 v 0"
+         id="svg_126"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="#ff56ff" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_127"
+         y2="224.39484"
+         x2="145.69305"
+         y1="219.97989"
+         x1="127.2607"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="none" />
+      <line
+         id="svg_128"
+         y2="226.908"
+         x2="145.77567"
+         y1="202.26453"
+         x1="145.77567"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="none"
+         style="display:inline" />
+      <line
+         id="svg_124"
+         y2="143.63693"
+         x2="128.45387"
+         y1="155.29584"
+         x1="128.12076"
+         stroke-width="4"
+         stroke="#ff56ff"
+         fill="none" />
+    </g>
+    <g
+       id="g13"
+       style="display:none"
+       inkscape:label="color-prim-D">
+      <rect
+         id="svg_117"
+         height="67.62159"
+         width="17.5714"
+         y="146.63493"
+         x="106.80217"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="#56ff56" />
+      <line
+         id="svg_118"
+         y2="138.30716"
+         x2="106.80212"
+         y1="149.96605"
+         x1="106.46901"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="none" />
+      <line
+         transform="rotate(-11.5544,116.462,142.638)"
+         id="svg_119"
+         y2="146.56195"
+         x2="125.36262"
+         y1="138.71323"
+         x1="107.56206"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="none" />
+      <path
+         d="m 116.12924,149.96605 c 0,0 0,-0.33311 0,-0.99933 0,-0.66623 -0.15283,-1.56345 -0.3331,-1.99867 -0.12747,-0.30775 0,-0.66621 0,-0.99933 0,-0.33311 0.25494,-0.71695 0,-1.33244 -0.1803,-0.43524 -0.33313,-0.33311 -0.33313,-0.33311 0,-0.33311 0,-0.33311 0,-0.33311 -0.3331,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.66623,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 -0.3331,0 -0.69156,-0.20563 -0.99933,-0.33311 -0.43521,-0.18028 -0.66623,-0.33311 -0.66623,-0.33311 -0.3331,-0.3331 -0.6662,-0.3331 -0.6662,-0.3331 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.3331,-0.33311 -0.66623,-0.33311 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 0,0 0,0 0,0 0,0 -0.3331,0 v 0 h 0.3331 v 0"
+         id="svg_120"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="#56ff56" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_121"
+         y2="219.06505"
+         x2="124.0413"
+         y1="214.65012"
+         x1="105.60894"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="none" />
+      <line
+         id="svg_122"
+         y2="221.57823"
+         x2="124.12391"
+         y1="196.93474"
+         x1="124.12391"
+         stroke-width="4"
+         stroke="#56ff56"
+         fill="none" />
+    </g>
+    <g
+       id="g17"
+       inkscape:label="color-prim-C"
+       style="display:none">
+      <rect
+         id="svg_111"
+         height="67.62159"
+         width="17.5714"
+         y="141.30516"
+         x="85.149918"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="#56ffff" />
+      <line
+         id="svg_112"
+         y2="132.97739"
+         x2="85.149872"
+         y1="144.63628"
+         x1="84.816757"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="none" />
+      <line
+         transform="rotate(-11.5544,94.807,137.308)"
+         id="svg_113"
+         y2="141.23216"
+         x2="103.71037"
+         y1="133.38345"
+         x1="85.909813"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="none" />
+      <path
+         d="m 94.47699,144.63627 c 0,0 0,-0.33311 0,-0.99933 0,-0.66623 -0.15283,-1.56345 -0.3331,-1.99867 -0.12747,-0.30775 0,-0.66621 0,-0.99933 0,-0.33311 0.25494,-0.71695 0,-1.33244 -0.1803,-0.43524 -0.33313,-0.33311 -0.33313,-0.33311 0,-0.33311 0,-0.33311 0,-0.33311 -0.3331,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.66623,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 -0.3331,0 -0.69156,-0.20563 -0.99933,-0.33311 -0.43521,-0.18028 -0.66623,-0.33311 -0.66623,-0.33311 -0.3331,-0.3331 -0.6662,-0.3331 -0.6662,-0.3331 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.3331,-0.33311 -0.66623,-0.33311 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 0,0 0,0 0,0 0,0 -0.3331,0 v 0 h 0.3331 v 0"
+         id="svg_114"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="#56ffff" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_115"
+         y2="213.73528"
+         x2="102.38906"
+         y1="209.32033"
+         x1="83.956688"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="none" />
+      <line
+         id="svg_116"
+         y2="216.24844"
+         x2="102.47166"
+         y1="191.60497"
+         x1="102.47166"
+         stroke-width="4"
+         stroke="#56ffff"
+         fill="none" />
+    </g>
+    <g
+       id="g12"
+       style="display:none"
+       inkscape:label="color-prim-B">
+      <path
+         d="m 72.15853,138.97338 c 0,0 0,-0.33311 0,-0.99933 0,-0.66623 -0.15283,-1.56345 -0.3331,-1.99867 -0.12747,-0.30775 0,-0.66621 0,-0.99933 0,-0.33311 0.25494,-0.71695 0,-1.33244 -0.1803,-0.43524 -0.33313,-0.33311 -0.33313,-0.33311 0,-0.33311 0,-0.33311 0,-0.33311 -0.3331,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.66623,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 -0.3331,0 -0.69156,-0.20563 -0.99933,-0.33311 -0.43521,-0.18028 -0.66623,-0.33311 -0.66623,-0.33311 -0.3331,-0.3331 -0.6662,-0.3331 -0.6662,-0.3331 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.3331,-0.33311 -0.66623,-0.33311 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 0,0 0,0 0,0 0,0 -0.3331,0 v 0 h 0.3331 v 0"
+         id="svg_108"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="none" />
+      <rect
+         id="svg_104"
+         height="67.62159"
+         width="17.5714"
+         y="135.64227"
+         x="62.831459"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="#ffff56"
+         style="display:inline" />
+      <line
+         id="svg_105"
+         y2="127.31448"
+         x2="62.831421"
+         y1="138.97337"
+         x1="62.498299"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="none" />
+      <line
+         transform="rotate(-11.5544,72.492,131.645)"
+         id="svg_106"
+         y2="135.56927"
+         x2="81.391922"
+         y1="127.72056"
+         x1="63.591358"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_109"
+         y2="208.07237"
+         x2="80.070602"
+         y1="203.65744"
+         x1="61.638241"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="none" />
+      <line
+         id="svg_110"
+         y2="210.58556"
+         x2="80.153198"
+         y1="185.94206"
+         x1="80.153198"
+         stroke-width="4"
+         stroke="#ffff56"
+         fill="none" />
+    </g>
+    <g
+       id="g11"
+       inkscape:label="color-prim-A"
+       style="display:none">
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_139"
+         y2="203.06854"
+         x2="57.76881"
+         y1="198.65359"
+         x1="39.336441"
+         stroke-width="4"
+         stroke="#5656ff"
+         fill="none" />
+      <line
+         id="svg_140"
+         y2="205.58173"
+         x2="57.85141"
+         y1="180.93823"
+         x1="57.85141"
+         stroke-width="4"
+         stroke="#5656ff"
+         fill="none" />
+      <rect
+         id="svg_135"
+         height="67.62159"
+         width="17.5714"
+         y="130.63843"
+         x="40.529671"
+         stroke-width="4"
+         stroke="#5656ff"
+         fill="#5656ff"
+         style="display:inline" />
+      <line
+         id="svg_136"
+         y2="122.31065"
+         x2="40.529621"
+         y1="133.96954"
+         x1="40.19651"
+         stroke-width="4"
+         stroke="#5656ff"
+         fill="none" />
+      <line
+         transform="rotate(-11.5544,50.19,126.641)"
+         id="svg_137"
+         y2="130.56544"
+         x2="59.09013"
+         y1="122.71672"
+         x1="41.289558"
+         stroke-width="4"
+         stroke="#5656ff"
+         fill="none" />
+      <path
+         d="m 49.85674,133.96954 c 0,0 0,-0.33311 0,-0.99933 0,-0.66623 -0.15283,-1.56345 -0.3331,-1.99867 -0.12747,-0.30775 0,-0.66621 0,-0.99933 0,-0.33311 0.25494,-0.71695 0,-1.33244 -0.1803,-0.43524 -0.33313,-0.33311 -0.33313,-0.33311 0,-0.33311 0,-0.33311 0,-0.33311 -0.3331,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.3331,0 -0.66623,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 -0.3331,0 -0.69156,-0.20563 -0.99933,-0.33311 -0.43521,-0.18028 -0.66623,-0.33311 -0.66623,-0.33311 -0.3331,-0.3331 -0.6662,-0.3331 -0.6662,-0.3331 0,0 -0.33313,0 -0.33313,0 0,0 -0.3331,0 -0.3331,0 0,0 -0.3331,-0.33311 -0.66623,-0.33311 0,0 -0.3331,0 -0.3331,0 0,0 -0.33313,0 -0.33313,0 0,0 0,0 0,0 0,0 0,0 -0.3331,0 v 0 h 0.3331 v 0"
+         id="svg_138"
+         stroke-width="4"
+         stroke="#5656ff"
+         fill="#5656ff" />
+    </g>
+    <g
+       id="g5"
+       inkscape:label="screen-border"
+       style="display:none">
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_76"
+         y2="134.32593"
+         x2="35.988682"
+         y1="206.34776"
+         x1="35.988682"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_79"
+         y2="243.2625"
+         x2="151.02332"
+         y1="218.98056"
+         x1="49.64624"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_78"
+         y2="148.13828"
+         x2="153.35509"
+         y1="123.28388"
+         x1="49.58794"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_77"
+         y2="164.63905"
+         x2="167.90076"
+         y1="231.66422"
+         x1="167.90076"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+    </g>
+    <g
+       id="g18"
+       style="display:none"
+       inkscape:label="ext-border">
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_1"
+         y2="112"
+         x2="272"
+         y1="72"
+         x1="105"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none"
+         style="display:inline" />
+      <line
+         fill="none"
+         stroke="#000000"
+         stroke-width="4"
+         x1="19"
+         y1="95.574997"
+         x2="105"
+         y2="72"
+         id="svg_4"
+         stroke-linejoin="undefined"
+         stroke-linecap="undefined"
+         style="display:inline" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_3"
+         y2="113.0188"
+         x2="270"
+         y1="246"
+         x1="270"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none"
+         style="display:inline" />
+      <line
+         fill="none"
+         stroke="#000000"
+         stroke-width="4"
+         x1="186"
+         y1="136.575"
+         x2="272"
+         y2="113"
+         id="svg_5"
+         stroke-linejoin="undefined"
+         stroke-linecap="undefined" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_6"
+         y2="267"
+         x2="185"
+         y1="227"
+         x1="18"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none"
+         style="display:inline" />
+      <line
+         fill="none"
+         stroke="#000000"
+         stroke-width="4"
+         x1="186"
+         y1="267.57501"
+         x2="272"
+         y2="244"
+         id="svg_34"
+         stroke-linejoin="undefined"
+         stroke-linecap="undefined" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_7"
+         y2="95.018799"
+         x2="19"
+         y1="228"
+         x1="19"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_8"
+         y2="137"
+         x2="186"
+         y1="97"
+         x1="19"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+      <line
+         stroke-linecap="undefined"
+         stroke-linejoin="undefined"
+         id="svg_10"
+         y2="138.0188"
+         x2="184"
+         y1="269"
+         x1="184"
+         stroke-width="4"
+         stroke="#000000"
+         fill="none" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="if-light-theme-show-me"
+     style="display:inline">
+    <path
+       style="fill:#4c4c4c;fill-opacity:1"
+       d="m 22.540404,94.91278 -3.425257,5.41412 -0.110493,121.98336 3.204274,5.96658 158.445782,38.00931 6.85051,0.88393 79.55437,-21.43548 2.98329,-4.64067 -0.11049,-125.40862 -2.8728,-5.19313 -159.10873,-37.677836 -5.85609,-0.220984 z"
+       id="tv-box-background" />
+    <g
+       id="g2"
+       style="display:inline"
+       inkscape:label="antenae-right">
+      <line
+         fill="none"
+         stroke="#000000"
+         stroke-width="4"
+         x1="159"
+         y1="107"
+         x2="236"
+         y2="53"
+         id="wire-2"
+         stroke-linejoin="undefined"
+         stroke-linecap="undefined" />
+      <ellipse
+         style="display:inline;fill:#000000;fill-opacity:1"
+         id="base-2"
+         cx="159.15788"
+         cy="106.85718"
+         rx="1.9123522"
+         ry="2.0862024" />
+      <ellipse
+         fill="none"
+         stroke="#000000"
+         stroke-width="2"
+         cx="239"
+         cy="48.5"
+         id="foam-ball-2"
+         rx="6"
+         ry="5.5" />
+      <ellipse
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         cx="238.96629"
+         cy="48.432583"
+         id="foam-ball-3"
+         ry="3.7883894"
+         rx="4.3220973"
+         style="display:inline" />
+    </g>
+    <g
+       id="g3"
+       inkscape:label="antenae-left"
+       style="display:inline">
+      <line
+         fill="none"
+         stroke="#000000"
+         stroke-width="4"
+         x1="118"
+         y1="99"
+         x2="74"
+         y2="25"
+         id="wire"
+         stroke-linejoin="undefined"
+         stroke-linecap="undefined" />
+      <ellipse
+         style="display:inline;fill:#000000;fill-opacity:1;stroke-width:1.01844"
+         id="base"
+         cx="118.1377"
+         cy="99.240196"
+         rx="1.9607856"
+         ry="2.110419" />
+      <ellipse
+         fill="none"
+         stroke="#000000"
+         stroke-width="2"
+         cx="72"
+         cy="21.5"
+         id="foam-ball-border"
+         rx="6"
+         ry="5.5" />
+      <ellipse
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         cx="72.066086"
+         cy="21.566084"
+         id="foam-ball"
+         rx="4.1226115"
+         ry="3.745223"
+         style="display:inline" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="g22"
+     inkscape:label="if-dark-theme-show-me"
+     style="display:none">
+    <path
+       style="fill:#b3b3b3;fill-opacity:1"
+       d="m 22.540404,94.91278 -3.425257,5.41412 -0.110493,121.98336 3.204274,5.96658 158.445782,38.00931 6.85051,0.88393 79.55437,-21.43548 2.98329,-4.64067 -0.11049,-125.40862 -2.8728,-5.19313 -159.10873,-37.677836 -5.85609,-0.220984 z"
+       id="path1" />
+    <g
+       id="g8"
+       style="display:inline"
+       inkscape:label="antenae-right">
+      <line
+         fill="none"
+         stroke="#000000"
+         stroke-width="4"
+         x1="159"
+         y1="107"
+         x2="236"
+         y2="53"
+         id="line1"
+         stroke-linejoin="undefined"
+         stroke-linecap="undefined" />
+      <ellipse
+         style="display:inline;fill:#000000;fill-opacity:1"
+         id="ellipse1"
+         cx="159.15788"
+         cy="106.85718"
+         rx="1.9123522"
+         ry="2.0862024" />
+      <ellipse
+         fill="none"
+         stroke="#000000"
+         stroke-width="2"
+         cx="239"
+         cy="48.5"
+         id="ellipse2"
+         rx="6"
+         ry="5.5"
+         style="fill:#b3b3b3" />
+      <ellipse
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         cx="238.96629"
+         cy="48.432583"
+         id="ellipse3"
+         ry="3.7883894"
+         rx="4.3220973"
+         style="display:inline;fill:#b3b3b3;stroke:#b3b3b3;stroke-opacity:1" />
+    </g>
+    <g
+       id="g21"
+       inkscape:label="antenae-left"
+       style="display:inline">
+      <line
+         fill="none"
+         stroke="#000000"
+         stroke-width="4"
+         x1="118"
+         y1="99"
+         x2="74"
+         y2="25"
+         id="line8"
+         stroke-linejoin="undefined"
+         stroke-linecap="undefined" />
+      <ellipse
+         style="display:inline;fill:#000000;fill-opacity:1;stroke-width:1.01844"
+         id="ellipse8"
+         cx="118.1377"
+         cy="99.240196"
+         rx="1.9607856"
+         ry="2.110419" />
+      <ellipse
+         fill="none"
+         stroke="#000000"
+         stroke-width="2"
+         cx="72"
+         cy="21.5"
+         id="ellipse9"
+         rx="6"
+         ry="5.5" />
+      <ellipse
+         fill="#4c4c4c"
+         stroke="#4c4c4c"
+         stroke-width="4"
+         cx="72.066086"
+         cy="21.566084"
+         id="ellipse10"
+         rx="4.1226115"
+         ry="3.745223"
+         style="display:inline;fill:#b3b3b3;stroke:#b3b3b3;stroke-opacity:1" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="iteration2-show-me"
+     style="display:inline">
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 18.857678,100.33708 0.09435,121.85866 3.188097,6.02992 159.006335,38.21059 6.4156,0.75477 79.50317,-21.51114 3.0191,-4.65446 -0.25159,-125.67035 -2.76751,-4.78025 -159.50952,-37.864645 -5.40924,-0.125796 -79.880548,22.014326 z"
+       id="tv-box-border"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <path
+       style="display:inline;fill:#ff5656;fill-opacity:1"
+       d="m 167.48106,229.34651 -21.76115,-5.01304 v -77.81603 l 7.17776,1.48112 5.12697,1.59506 3.30405,1.59506 2.16472,1.70899 1.70899,2.16472 1.25326,2.39259 1.13933,3.75978 0.22786,3.53191 0.11394,63.91624 z"
+       id="color-tall-F" />
+    <path
+       style="fill:#5656ff;fill-opacity:1;stroke-width:1.01066"
+       d="m 38.314468,126.39491 v 73.20515 l 21.65449,4.91939 v -78.3588 l -6.221179,-1.63979 -5.0248,-1.17128 -4.426608,0.46851 -3.469504,1.40554 z"
+       id="color-tall-A" />
+    <path
+       style="fill:#56ff56;fill-opacity:1"
+       d="m 145.82068,224.35904 v 17.51879 l 4.82402,1.26948 4.57012,0.0846 5.07791,-0.93095 3.7238,-1.8619 2.45432,-3.4699 0.67706,-3.89307 -0.0846,-3.80843 z"
+       id="color-short-F" />
+    <path
+       style="display:none;fill:#5656ff;fill-opacity:1"
+       d="m 38.500905,120.54773 v 78.98729 l 21.511433,5.04174 v -78.81923 z"
+       id="color-tall-A-old" />
+    <path
+       style="display:inline;fill:#ffff56;fill-opacity:1"
+       d="m 60.044858,125.58198 v 78.98729 l 21.511433,5.04174 v -78.81923 z"
+       id="color-tall-B" />
+    <path
+       style="display:inline;fill:#56ffff;fill-opacity:1"
+       d="m 81.537336,130.58847 v 78.98729 l 21.511434,5.04174 v -78.81923 z"
+       id="color-tall-C" />
+    <path
+       style="display:inline;fill:#56ff56;fill-opacity:1"
+       d="m 103.05703,135.63108 v 78.98729 l 21.51143,5.04174 v -78.81923 z"
+       id="color-tall-D" />
+    <path
+       style="display:inline;fill:#ff56ff;fill-opacity:1"
+       d="m 124.57317,140.61108 v 78.98729 l 21.51143,5.04174 v -78.81923 z"
+       id="color-tall-E" />
+    <path
+       style="display:inline;fill:#ffaa56;fill-opacity:1;stroke-width:0.991301"
+       d="m 38.468507,199.51739 v 16.14244 l 21.539423,4.8659 V 204.3833 Z"
+       id="color-short-A" />
+    <path
+       style="fill:#666666;fill-opacity:1;stroke-width:1.00559"
+       d="m 60.006114,204.54637 v 16.61117 l 21.539423,5.00719 v -16.61116 z"
+       id="color-short-B" />
+    <path
+       style="fill:#ff56ff;fill-opacity:1;stroke-width:1.00559"
+       d="m 81.536466,209.5606 v 16.61117 l 21.539424,5.00719 V 214.5678 Z"
+       id="color-short-C" />
+    <path
+       style="fill:#ffff56;fill-opacity:1;stroke-width:1.00559"
+       d="m 103.04156,214.58516 v 16.61117 l 21.53942,5.00719 v -16.61116 z"
+       id="color-short-D" />
+    <path
+       style="fill:#56ffff;fill-opacity:1;stroke-width:1.00559"
+       d="m 124.58815,219.61634 v 16.61117 l 21.53942,5.00719 v -16.61116 z"
+       id="color-short-E" />
+    <path
+       style="fill:#ffaa56;fill-opacity:1"
+       d="m 38.529641,199.52036 v 14.38854 l -1.616246,-2.87771 -0.788413,-2.60176 -0.157682,-9.5398 z"
+       id="color-short-G" />
+    <path
+       style="fill:#5656ff;fill-opacity:1;stroke-width:1.21145"
+       d="m 38.518046,199.52992 v -72.55495 l -2.680152,3.47937 -0.595589,4.29803 v 63.95888 z"
+       id="color-tall-G"
+       inkscape:label="color-tall-G" />
+    <path
+       style="display:none;fill:#ff5656;fill-opacity:1"
+       d="m 146.10332,145.63865 v 78.98729 l 21.51143,5.04174 v -78.81923 z"
+       id="color-tall-F-old" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:2.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 167.9976,165.99118 -0.15628,64.78763 c 0,0 0.0801,8.73988 -5.80952,11.3343 -5.88961,2.59443 -13.08912,0.92505 -13.08912,0.92505 l -101.045756,-24.373 c 0,0 -6.322219,-1.58475 -8.550977,-3.66243 -3.740947,-3.48737 -3.336759,-9.23168 -3.336759,-9.23168 l -0.0629,-72.23844 c 0,0 -0.186545,-6.516 5.000397,-8.83717 6.714326,-3.00469 10.849917,-0.72334 10.849917,-0.72334 L 152.216,147.83337 c 0,0 9.44867,1.88525 12.56043,6.46902 3.96331,5.83816 3.22121,11.68879 3.22121,11.68879 z"
+       id="path5"
+       sodipodi:nodetypes="cczccsccsccscc"
+       inkscape:label="screen-border-new" />
+  </g>
+</svg>

--- a/src/invidious/helpers/errors.cr
+++ b/src/invidious/helpers/errors.cr
@@ -74,7 +74,8 @@ def error_template_helper(env : HTTP::Server::Context, status_code : Int32, exce
   # Don't show the usual "next steps" widget. The same options are
   # proposed above the error message, just worded differently.
   next_steps = ""
-
+  unfound_tv_box_dark_theme = File.read("assets/404_tv_box_dark_theme.svg")
+  
   return templated "error"
 end
 
@@ -84,7 +85,7 @@ def error_template_helper(env : HTTP::Server::Context, status_code : Int32, mess
 
   locale = env.get("preferences").as(Preferences).locale
 
-  error_message = translate(locale, message)
+  unfound_tv_box_dark_theme = File.read("assets/404_tv_box_dark_theme.svg")
   next_steps = error_redirect_helper(env)
 
   return templated "error"

--- a/src/invidious/helpers/errors.cr
+++ b/src/invidious/helpers/errors.cr
@@ -85,6 +85,7 @@ def error_template_helper(env : HTTP::Server::Context, status_code : Int32, mess
 
   locale = env.get("preferences").as(Preferences).locale
 
+  error_message = translate(locale, message)
   unfound_tv_box_dark_theme = File.read("assets/404_tv_box_dark_theme.svg")
   next_steps = error_redirect_helper(env)
 

--- a/src/invidious/helpers/errors.cr
+++ b/src/invidious/helpers/errors.cr
@@ -75,7 +75,8 @@ def error_template_helper(env : HTTP::Server::Context, status_code : Int32, exce
   # proposed above the error message, just worded differently.
   next_steps = ""
   unfound_tv_box_dark_theme = File.read("assets/404_tv_box_dark_theme.svg")
-  
+  unfound_tv_box_light_theme = File.read("assets/404_tv_box_light_theme.svg")
+
   return templated "error"
 end
 
@@ -87,6 +88,7 @@ def error_template_helper(env : HTTP::Server::Context, status_code : Int32, mess
 
   error_message = translate(locale, message)
   unfound_tv_box_dark_theme = File.read("assets/404_tv_box_dark_theme.svg")
+  unfound_tv_box_light_theme = File.read("assets/404_tv_box_light_theme.svg")
   next_steps = error_redirect_helper(env)
 
   return templated "error"

--- a/src/invidious/views/error.ecr
+++ b/src/invidious/views/error.ecr
@@ -3,6 +3,6 @@
 <% end %>
 
 <div class="h-box">
-    <%= error_message %>
+    <%= unfound_tv_box_dark_theme %>
     <%= next_steps %>
 </div>

--- a/src/invidious/views/error.ecr
+++ b/src/invidious/views/error.ecr
@@ -1,11 +1,19 @@
+<%
+  dark_mode = env.get("preferences").as(Preferences).dark_mode
+%>
+
 <% content_for "header" do %>
 <title><%= "Error" %> - Invidious</title>
 <% end %>
 
 <div class="h-box">
-    <a id="error-parent">
+    <div style="display: flex; flex-direction: column;">
         <%= error_message %>
-    </a>
-    <%= unfound_tv_box_dark_theme %>
+        <% if dark_mode == "dark" %>
+            <%= unfound_tv_box_dark_theme %>  
+        <% else %>
+            <%= unfound_tv_box_light_theme %> 
+        <% end %>
+    </div>
     <%= next_steps %>
 </div>

--- a/src/invidious/views/error.ecr
+++ b/src/invidious/views/error.ecr
@@ -3,6 +3,9 @@
 <% end %>
 
 <div class="h-box">
+    <a id="error-parent">
+        <%= error_message %>
+    </a>
     <%= unfound_tv_box_dark_theme %>
     <%= next_steps %>
 </div>


### PR DESCRIPTION
A classic sign of a hip website is their 404 page. Making them fun or clever has been trending upward since 2010.

This @SamantazFox-approved graphic resembles a Video Input error for Cable TVs to represent a `video_id` that is unfound