### PR TITLE
add more parameter to look a lot like official youtube client

### DIFF
--- a/src/invidious/yt_backend/connection_pool.cr
+++ b/src/invidious/yt_backend/connection_pool.cr
@@ -3,7 +3,7 @@ def add_yt_headers(request)
   request.headers["User-Agent"] ||= "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
 
   request.headers["Accept-Charset"] ||= "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
-  request.headers["Accept"] ||= "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+  request.headers["Accept"] ||= "*"
   request.headers["Accept-Language"] ||= "en-us,en;q=0.5"
 
   # Preserve original cookies and add new YT consent cookie for EU servers

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -665,8 +665,6 @@ module YoutubeAPI
       "x-goog-api-format-version" => "2",
       "x-youtube-client-name"     => client_config.name_proto,
       "x-youtube-client-version"  => client_config.version,
-      "accept"                    => "*",
-      "accept-language"           => "*",
     }
 
     if user_agent = client_config.user_agent


### PR DESCRIPTION
Taken from a request done by youtube.js: https://github.com/LuanRT/YouTube.js and I tried to add as much new parameters as possible.

[example_yt_request_youtubejs.txt](https://github.com/user-attachments/files/16627563/example_yt_request_youtubejs.txt)

We are missing:
```
       "mainAppWebInfo"     => {
          "graftUrl"                  => "https://www.youtube.com",
          "isWebNativeShareAvailable" => true,
          "pwaInstallabilityStatus"   => "PWA_INSTALLABILITY_STATUS_UNKNOWN",
          "webDisplayMode"            => "WEB_DISPLAY_MODE_BROWSER",
        },
```
inside `client_context = {` but I can't get my head around the compiler issue:
```
Done checking player dependencies, now compiling Invidious...
Showing last frame. Use --error-trace for full trace.

In src/invidious/yt_backend/youtube_api.cr:320:33

 320 | "mainAppWebInfo"     => {
                               ^----------
Error: expected argument #2 to 'Hash(String, Int64 | String)#[]=' to be (Int64 | String), not Hash(String, Bool | String)

Overloads are:
 - Hash(K, V)#[]=(key : K, value : V)
```

Other parameters we are missing:
- timeZone: in youtube.js this is dynamically generated from the actual timezone but I don't know if we should or just set a default one
- utcOffsetMinutes: same as above
- visitorData: this one is tricky because it requires to generate a visitordata from scratch
- remoteHost: we will have to fetch the public IP of the server at the start; not sure how
- "configInfo"."appInstallData": like visitordata, it's an ID

Remarks:
- Some parameters do not make sense in the context of the ANDROID client but I don't think this will do any harm like the size for screenHeightPoints or memoryTotalKbytes
- I required useragent to be passed because youtube is expecting it now on all the requests whatever the client name