### PR TITLE
HTML: Fix XSS vulnerability in description/comments

### DIFF
--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -36,7 +36,13 @@ def parse_description(desc, video_id : String) : String?
   return "" if content.empty?
 
   commands = desc["commandRuns"]?.try &.as_a
-  return content if commands.nil?
+  if commands.nil?
+    # Slightly faster than HTML.escape, as we're only doing one pass on
+    # the string instead of five for the standard library
+    return String.build do |str|
+      copy_string(str, content.each_codepoint, content.size)
+    end
+  end
 
   # Not everything is stored in UTF-8 on youtube's side. The SMP codepoints
   # (0x10000 and above) are encoded as UTF-16 surrogate pairs, which are


### PR DESCRIPTION
Before that PR, the comment/description content was not HTML escaped when `parse_description` was called with a JSON object that was lacking the `"commandRuns"` entry.

Closes #4727