### PR TITLE
API: Proxy formatStreams URLs too

### DIFF
--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -162,7 +162,13 @@ module Invidious::JSONify::APIv1
         json.array do
           video.fmt_stream.each do |fmt|
             json.object do
-              json.field "url", fmt["url"]
+              if proxy
+                json.field "url", Invidious::HttpServer::Utils.proxy_video_url(
+                  fmt["url"].to_s, absolute: true
+                )
+              else
+                json.field "url", fmt["url"]
+              end
               json.field "itag", fmt["itag"].as_i.to_s
               json.field "type", fmt["mimeType"]
               json.field "quality", fmt["quality"]


### PR DESCRIPTION
Hello,

I have noticed that the /api/v1/videos endpoint does not proxify the formatStreams URLs when passed ?local=true, whereas the adaptiveFormats URLs are correctly proxified. 

The Web UI does proxify when clicking Download with fmt=18 for example, so I suppose this is an oversight. This PR aims to fix that.

Hope this helps.