### PR TITLE
removed version line for docker-compose.yml, docker version is obsolete

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@
 # If you want to use Invidious in production, see the docker-compose.yml file provided
 # in the installation documentation: https://docs.invidious.io/installation/
 
-version: "3"
 services:
 
   invidious:


### PR DESCRIPTION
removed the line `version: "3"` in the docker-compose.yml file. Specifying version in a docker compose is now obsolete and will throw a warning message when launching a docker compose.