### PR TITLE
Release container: add -arm64 to each tag for arm64

### DIFF
--- a/.github/workflows/build-stable-container.yml
+++ b/.github/workflows/build-stable-container.yml
@@ -70,11 +70,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: quay.io/invidious/invidious
-          flavor: |
-            suffix=-arm64
           tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+            type=semver,pattern={{version}},suffix=-arm64
+            type=raw,value=latest,suffix=-arm64,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
           labels: |
             quay.expires-after=12w
 


### PR DESCRIPTION
This PR explicitly adds the -arm64 suffix to tags created for the arm64 image instead of relying on the global default specified in flavors.

This should fix the latest tag for amd64 getting replaced by the arm64 version.

---

On a side note, this is a really weird bug.

The same `type=raw` tag over on the nightly build (just with the name changed to `master`) is able to have the flavor suffix appended but not on the stable builds for some reason...

And on the stable build itself the `type=semver` tag is able to add the suffix as well. 

So why was `type=raw` (`latest`) skipped over?

Also, the nightly container build wasn't triggered when the release commit for `3e17d04` was pushed meaning that the nightly build is stuck on `cec905e`

