### PR TITLE
Search: Fix 'youtu.be' URLs in sanitizer

### DIFF
--- a/src/invidious/yt_backend/url_sanitizer.cr
+++ b/src/invidious/yt_backend/url_sanitizer.cr
@@ -111,7 +111,7 @@ module UrlSanitizer
       new_uri.path = "/watch"
 
       new_params = copy_params(unsafe_uri.query_params, :watch)
-      new_params["id"] = breadcrumbs[0]
+      new_params["v"] = breadcrumbs[0]
 
       new_uri.query_params = new_params
     end


### PR DESCRIPTION
Use the proper URL argument when transforming `youtu.be` URLs to their `youtube.com` equivalents.


Thanks to [Tuhgy](https://social.tchncs.de/@tuhgy@sharkey.world) for reporting this!