### PR TITLE
use web screen embed for fixing potoken functionality

### DIFF
--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -53,6 +53,8 @@ end
 def extract_video_info(video_id : String)
   # Init client config for the API
   client_config = YoutubeAPI::ClientConfig.new
+  # use WEB screen embed for potoken functionality
+  client_config.client_type = YoutubeAPI::ClientType::WebEmbeddedPlayer
 
   # Fetch data from the player endpoint
   player_response = YoutubeAPI.player(video_id: video_id, params: "2AMB", client_config: client_config)

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -291,8 +291,9 @@ module YoutubeAPI
     end
 
     if client_config.screen == "EMBED"
+      # embedUrl https://www.google.com allow loading video that are configured not embeddable
       client_context["thirdParty"] = {
-        "embedUrl" => "https://www.youtube.com/embed/#{video_id}",
+        "embedUrl" => "https://www.google.com/",
       } of String => String | Int64
     end
 


### PR DESCRIPTION
Helps for #4734

Since potoken is generated from a YouTube embed page, YouTube has started to enforce this token on exclusive usage of WEB_EMBEDDED_PLAYER client.

Thanks to `"embedUrl":"https://www.google.com/"`, this allows to have WEB_EMBEDDED_PLAYER working even on video that disallowed the embedding. As tested on https://www.youtube.com/watch?v=JfJYHfrOGgQ

I did found this parameter by entering the youtube video url on google.com and seeing that it worked there but not on the youtube embed page.

![image](https://github.com/user-attachments/assets/edb0e034-0ee9-4acc-9345-75d71972c500)

This also deactivates TVHTML5_SIMPLY_EMBEDDED_PLAYER when po_token is configured, since this doesn't work with that client.