### PR TITLE
Logger: Add color support for different log levels

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -226,11 +226,13 @@ https_only: false
 ## Enables colors in logs. Useful for debugging purposes
 ## This is overridden if "-k" or "--colorize" 
 ## are passed on the command line.
+## Colors are also disabled if the environment variable
+## NO_COLOR is present and has any value
 ##
 ## Accepted values: true, false
-## Default: false
+## Default: true
 ##
-#colorize_logs: false
+#colorize_logs: true
 
 # -----------------------------
 #  Features

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -224,7 +224,7 @@ https_only: false
 
 ##
 ## Enables colors in logs. Useful for debugging purposes
-## This is overridden if "-k" or "--colorize" 
+## This is overridden if "-k" or "--colorize"
 ## are passed on the command line.
 ## Colors are also disabled if the environment variable
 ## NO_COLOR is present and has any value

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -232,7 +232,7 @@ https_only: false
 ## Accepted values: true, false
 ## Default: true
 ##
-#colorize_logs: true
+#colorize_logs: false
 
 # -----------------------------
 #  Features

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -222,6 +222,15 @@ https_only: false
 ##
 #log_level: Info
 
+##
+## Enables colors in logs. Useful for debugging purposes
+## This is overridden if "-k" or "--colorize" 
+## are passed on the command line.
+##
+## Accepted values: true, false
+## Default: false
+##
+#colorize_logs: false
 
 # -----------------------------
 #  Features

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -117,6 +117,9 @@ Kemal.config.extra_options do |parser|
   parser.on("-l LEVEL", "--log-level=LEVEL", "Log level, one of #{LogLevel.values} (default: #{CONFIG.log_level})") do |log_level|
     CONFIG.log_level = LogLevel.parse(log_level)
   end
+  parser.on("-k", "--colorize", "Colorize logs") do
+    CONFIG.colorize_logs = true
+  end
   parser.on("-v", "--version", "Print version") do
     puts SOFTWARE.to_pretty_json
     exit
@@ -133,7 +136,7 @@ if CONFIG.output.upcase != "STDOUT"
   FileUtils.mkdir_p(File.dirname(CONFIG.output))
 end
 OUTPUT = CONFIG.output.upcase == "STDOUT" ? STDOUT : File.open(CONFIG.output, mode: "a")
-LOGGER = Invidious::LogHandler.new(OUTPUT, CONFIG.log_level)
+LOGGER = Invidious::LogHandler.new(OUTPUT, CONFIG.log_level, CONFIG.colorize_logs)
 
 # Check table integrity
 Invidious::Database.check_integrity(CONFIG)

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -68,6 +68,8 @@ class Config
   property output : String = "STDOUT"
   # Default log level, valid YAML values are ints and strings, see src/invidious/helpers/logger.cr
   property log_level : LogLevel = LogLevel::Info
+  # Enables colors in logs. Useful for debugging purposes
+  property colorize_logs : Bool = false
   # Database configuration with separate parameters (username, hostname, etc)
   property db : DBConfig? = nil
 

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -69,7 +69,7 @@ class Config
   # Default log level, valid YAML values are ints and strings, see src/invidious/helpers/logger.cr
   property log_level : LogLevel = LogLevel::Info
   # Enables colors in logs. Useful for debugging purposes
-  property colorize_logs : Bool = false
+  property colorize_logs : Bool = true
   # Database configuration with separate parameters (username, hostname, etc)
   property db : DBConfig? = nil
 

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -69,7 +69,7 @@ class Config
   # Default log level, valid YAML values are ints and strings, see src/invidious/helpers/logger.cr
   property log_level : LogLevel = LogLevel::Info
   # Enables colors in logs. Useful for debugging purposes
-  property colorize_logs : Bool = true
+  property colorize_logs : Bool = false
   # Database configuration with separate parameters (username, hostname, etc)
   property db : DBConfig? = nil
 

--- a/src/invidious/helpers/logger.cr
+++ b/src/invidious/helpers/logger.cr
@@ -12,7 +12,7 @@ enum LogLevel
 end
 
 class Invidious::LogHandler < Kemal::BaseLogHandler
-  def initialize(@io : IO = STDOUT, @level = LogLevel::Debug, @color : Bool = true)
+  def initialize(@io : IO = STDOUT, @level = LogLevel::Debug, @use_color : Bool = true)
   end
 
   def call(context : HTTP::Server::Context)
@@ -56,8 +56,7 @@ class Invidious::LogHandler < Kemal::BaseLogHandler
   {% for level in %w(trace debug info warn error fatal) %}
     def {{level.id}}(message : String)
       if LogLevel::{{level.id.capitalize}} >= @level
-        puts("#{Time.utc} [{{level.id}}] #{message}".colorize(color(LogLevel::{{level.id.capitalize}})).toggle(@color))
-
+        puts("#{Time.utc} [{{level.id}}] #{message}".colorize(color(LogLevel::{{level.id.capitalize}})).toggle(@use_color))
       end
     end
   {% end %}

--- a/src/invidious/helpers/logger.cr
+++ b/src/invidious/helpers/logger.cr
@@ -12,7 +12,9 @@ enum LogLevel
 end
 
 class Invidious::LogHandler < Kemal::BaseLogHandler
-  def initialize(@io : IO = STDOUT, @level = LogLevel::Debug, @use_color : Bool = true)
+  def initialize(@io : IO = STDOUT, @level = LogLevel::Debug, use_color : Bool = true)
+    Colorize.enabled = use_color
+    Colorize.on_tty_only!
   end
 
   def call(context : HTTP::Server::Context)
@@ -56,7 +58,7 @@ class Invidious::LogHandler < Kemal::BaseLogHandler
   {% for level in %w(trace debug info warn error fatal) %}
     def {{level.id}}(message : String)
       if LogLevel::{{level.id.capitalize}} >= @level
-        puts("#{Time.utc} [{{level.id}}] #{message}".colorize(color(LogLevel::{{level.id.capitalize}})).toggle(@use_color))
+        puts("#{Time.utc} [{{level.id}}] #{message}".colorize(color(LogLevel::{{level.id.capitalize}})))
       end
     end
   {% end %}

--- a/src/invidious/helpers/logger.cr
+++ b/src/invidious/helpers/logger.cr
@@ -1,3 +1,5 @@
+require "colorize"
+
 enum LogLevel
   All   = 0
   Trace = 1
@@ -10,7 +12,7 @@ enum LogLevel
 end
 
 class Invidious::LogHandler < Kemal::BaseLogHandler
-  def initialize(@io : IO = STDOUT, @level = LogLevel::Debug)
+  def initialize(@io : IO = STDOUT, @level = LogLevel::Debug, @color : Bool = true)
   end
 
   def call(context : HTTP::Server::Context)
@@ -39,10 +41,23 @@ class Invidious::LogHandler < Kemal::BaseLogHandler
     @io.flush
   end
 
+  def color(level)
+    case level
+    when LogLevel::Trace then :cyan
+    when LogLevel::Debug then :green
+    when LogLevel::Info  then :white
+    when LogLevel::Warn  then :yellow
+    when LogLevel::Error then :red
+    when LogLevel::Fatal then :magenta
+    else                      :default
+    end
+  end
+
   {% for level in %w(trace debug info warn error fatal) %}
     def {{level.id}}(message : String)
       if LogLevel::{{level.id.capitalize}} >= @level
-        puts("#{Time.utc} [{{level.id}}] #{message}")
+        puts("#{Time.utc} [{{level.id}}] #{message}".colorize(color(LogLevel::{{level.id.capitalize}})).toggle(@color))
+
       end
     end
   {% end %}


### PR DESCRIPTION
Looks like this:

![image](https://github.com/user-attachments/assets/b2af3471-7dda-4ebc-825b-314455e48a3a)

As I said in the code, this is useful when debugging things in Invidious. Having to find the type of error just by the name of the log level is not comfortable in my opinion.

Feel free to edit anything.