### PR TITLE
Parsers: Fix parsing live_now and premiere_timestamp

### DIFF
--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -224,8 +224,17 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
   premiere_timestamp = microformat.dig?("liveBroadcastDetails", "startTimestamp")
     .try { |t| Time.parse_rfc3339(t.as_s) }
 
+  premiere_timestamp ||= player_response.dig?(
+    "playabilityStatus", "liveStreamability",
+    "liveStreamabilityRenderer", "offlineSlate",
+    "liveStreamOfflineSlateRenderer", "scheduledStartTime"
+  )
+    .try &.as_s.to_i64
+      .try { |t| Time.unix(t) }
+
   live_now = microformat.dig?("liveBroadcastDetails", "isLiveNow")
-    .try &.as_bool || false
+    .try &.as_bool
+  live_now ||= video_details.dig?("isLive").try &.as_bool || false
 
   post_live_dvr = video_details.dig?("isPostLiveDvr")
     .try &.as_bool || false


### PR DESCRIPTION
Related to https://github.com/iv-org/invidious/issues/4929

This pull request fixes the parsing for the `live_now` and `premiere_timestamp` variables so that they work without the microformat data being present.

Testing `live_now`:
`/api/v1/videos/jfKfPfyJRdk` -> `type` should be `"livestream"` and `liveNow` should be `true`

Testing `premiere_timestamp`:
1. Go to https://www.youtube.com/live and pick a video from the `Upcoming Live Streams` section
2. `/api/v1/videos/{videoID}` => should return a HTTP 500 status code and the following json `{"error":"This live event will begin in 56 minutes."}`