### PR TITLE
Videos: use WEB client instead of WEB CREATOR

### DIFF
--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -53,10 +53,6 @@ end
 def extract_video_info(video_id : String)
   # Init client config for the API
   client_config = YoutubeAPI::ClientConfig.new
-  # Use the WEB when po_token is configured
-  if CONFIG.po_token
-    client_config.client_type = YoutubeAPI::ClientType::Web
-  end
 
   # Fetch data from the player endpoint
   player_response = YoutubeAPI.player(video_id: video_id, params: "2AMB", client_config: client_config)

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -53,9 +53,9 @@ end
 def extract_video_info(video_id : String)
   # Init client config for the API
   client_config = YoutubeAPI::ClientConfig.new
-  # Use the WEB_CREATOR when po_token is configured because it fully only works on this client
+  # Use the WEB when po_token is configured
   if CONFIG.po_token
-    client_config.client_type = YoutubeAPI::ClientType::WebCreator
+    client_config.client_type = YoutubeAPI::ClientType::Web
   end
 
   # Fetch data from the player endpoint
@@ -113,8 +113,8 @@ def extract_video_info(video_id : String)
     new_player_response = try_fetch_streaming_data(video_id, client_config)
   end
 
-  # Don't use Android client if po_token is passed because po_token doesn't
-  # work for Android client.
+  # Don't use Android test suite client if po_token is passed because po_token doesn't
+  # work for Android test suite client.
   if reason.nil? && CONFIG.po_token.nil?
     # Fetch the video streams using an Android client in order to get the
     # decrypted URLs and maybe fix throttling issues (#2194). See the

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -106,13 +106,6 @@ def extract_video_info(video_id : String)
 
   new_player_response = nil
 
-  # Second try in case WEB_CREATOR doesn't work with po_token.
-  # Only trigger if reason found and po_token configured.
-  if reason && CONFIG.po_token
-    client_config.client_type = YoutubeAPI::ClientType::WebEmbeddedPlayer
-    new_player_response = try_fetch_streaming_data(video_id, client_config)
-  end
-
   # Don't use Android test suite client if po_token is passed because po_token doesn't
   # work for Android test suite client.
   if reason.nil? && CONFIG.po_token.nil?

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -300,9 +300,8 @@ module YoutubeAPI
     end
 
     if client_config.screen == "EMBED"
-      # embedUrl https://www.google.com allow loading almost all video that are configured not embeddable
       client_context["thirdParty"] = {
-        "embedUrl" => "https://www.google.com/",
+        "embedUrl" => "https://www.youtube.com/embed/#{video_id}",
       } of String => String | Int64
     end
 


### PR DESCRIPTION
This switch to using WEB client when a potoken is configured. Otherwise try with Android test suite if there is no potoken configured.