### PR TITLE
Add invidious companion support

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -54,6 +54,22 @@ db:
 ##
 #signature_server:
 
+##
+## Path to the Invidious companion.
+## An external program for loading the video streams from YouTube servers.
+##
+## When this setting is commented out, Invidious companion is not used.
+##
+## When this setting is configured and "external_port" is used then
+## you need to configure Invidious companion routes into your reverse proxy.
+## If "external_port" is not configured then Invidious will proxy the requests
+## to Invidious companion.
+##
+## Accepted values: "http(s)://<IP-HOSTNAME>:<Port>"
+## Default: <none>
+##
+#invidious_companion:
+
 
 #########################################
 #

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -55,15 +55,14 @@ db:
 #signature_server:
 
 ##
-## Path to the Invidious companion.
-## An external program for loading the video streams from YouTube servers.
+## Invidious companion is an external program
+## for loading the video streams from YouTube servers.
 ##
 ## When this setting is commented out, Invidious companion is not used.
 ##
-## When this setting is configured and "external_port" is used then
-## you need to configure Invidious companion routes into your reverse proxy.
-## If "external_port" is not configured then Invidious will proxy the requests
+## When this setting is configured, then Invidious will proxy the requests
 ## to Invidious companion.
+## Or randomly choose one if multiple Invidious companion are configured.
 ##
 ## Accepted values: "http(s)://<IP-HOSTNAME>:<Port>"
 ## Default: <none>

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -67,9 +67,19 @@ db:
 ## Accepted values: "http(s)://<IP-HOSTNAME>:<Port>"
 ## Default: <none>
 ##
-# invidious_companion:
+#invidious_companion:
 # - http://127.0.0.1:8282
 
+##
+## API key for Invidious companion
+##
+## Needed when invidious_companion is configured
+##
+## Accepted values: "http(s)://<IP-HOSTNAME>:<Port>"
+## Default: <none>
+##
+
+#invidious_companion_key: "CHANGE_ME!!"
 
 #########################################
 #

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -71,8 +71,14 @@ db:
 ## communication between the companion and Invidious.
 ## And public_url is the public URL from which companion is listening
 ## to the requests from the user(s).
+##
+## If you are using a reverse proxy then you will probably need to
+## configure the public_url to be the same as the domain used for Invidious.
+## Also apply when used from an external IP address (without a domain).
+## Examples: https://MYINVIDIOUSDOMAIN or http://192.168.1.100:8282
+##
 ## Both parameter can have identical URL when Invidious is hosted in
-## an internal network or at home.
+## an internal network or at home or locally (localhost).
 ##
 ## Accepted values: "http(s)://<IP-HOSTNAME>:<Port>"
 ## Default: <none>

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -88,15 +88,18 @@ db:
 #    public_url: "http://localhost:8282"
 
 ##
-## API key for Invidious companion
+## API key for Invidious companion, used for securing the communication
+## between Invidious and Invidious companion.
 ## The size of the key needs to be more or equal to 16.
 ##
-## Needed when invidious_companion is configured
+## Note: This parameter is mandatory when Invidious companion is enabled
+## and should be a random string.
+## Such random string can be generated on linux with the following
+## command: `pwgen 16 1`
 ##
-## Accepted values: "http(s)://<IP-HOSTNAME>:<Port>"
+## Accepted values: a string
 ## Default: <none>
 ##
-
 #invidious_companion_key: "CHANGE_ME!!"
 
 #########################################

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -83,6 +83,7 @@ db:
 
 ##
 ## API key for Invidious companion
+## The size of the key needs to be more or equal to 16.
 ##
 ## Needed when invidious_companion is configured
 ##

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -68,7 +68,8 @@ db:
 ## Accepted values: "http(s)://<IP-HOSTNAME>:<Port>"
 ## Default: <none>
 ##
-#invidious_companion:
+# invidious_companion:
+# - http://127.0.0.1:8282
 
 
 #########################################

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -59,16 +59,27 @@ db:
 ## for loading the video streams from YouTube servers.
 ##
 ## When this setting is commented out, Invidious companion is not used.
+## Otherwise, Invidious will proxy the requests to Invidious companion.
+## 
+## Note: multiple URL can be configured. In this case, invidious will
+## randomly pick one every time video data needs to be retrieved. This
+## URL is then kept in the video metadata cache to allow video playback
+## to work. Once said cache has expired, requesting that video's data
+## again will cause a new companion URL to be picked.
 ##
-## When this setting is configured, then Invidious will proxy the requests
-## to Invidious companion.
-## Or randomly choose one if multiple Invidious companion are configured.
+## The parameter private_url needs to be configured for the internal
+## communication between the companion and Invidious.
+## And public_url is the public URL from which companion is listening
+## to the requests from the user(s).
+## Both parameter can have identical URL when Invidious is hosted in
+## an internal network or at home.
 ##
 ## Accepted values: "http(s)://<IP-HOSTNAME>:<Port>"
 ## Default: <none>
 ##
 #invidious_companion:
-# - http://127.0.0.1:8282
+#  - private_url: "http://localhost:8282"
+#    public_url: "http://localhost:8282"
 
 ##
 ## API key for Invidious companion

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -161,6 +161,12 @@ Invidious::Database.check_integrity(CONFIG)
   {% puts "\nDone checking player dependencies, now compiling Invidious...\n" %}
 {% end %}
 
+# invidious_companion and signature_server can't work together
+if CONFIG.signature_server && CONFIG.invidious_companion
+  puts "You can not run inv_sig_helper and invidious_companion at the same time."
+  exit(1)
+end
+
 # Misc
 
 DECRYPT_FUNCTION =

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -161,12 +161,6 @@ Invidious::Database.check_integrity(CONFIG)
   {% puts "\nDone checking player dependencies, now compiling Invidious...\n" %}
 {% end %}
 
-# invidious_companion and signature_server can't work together
-if CONFIG.signature_server && CONFIG.invidious_companion
-  puts "You can not run inv_sig_helper and invidious_companion at the same time."
-  exit(1)
-end
-
 # Misc
 
 DECRYPT_FUNCTION =

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -97,6 +97,10 @@ YT_POOL = YoutubeConnectionPool.new(YT_URL, capacity: CONFIG.pool_size)
 
 GGPHT_POOL = YoutubeConnectionPool.new(URI.parse("https://yt3.ggpht.com"), capacity: CONFIG.pool_size)
 
+COMPANION_POOL = CompanionConnectionPool.new(
+  capacity: CONFIG.pool_size
+)
+
 # CLI
 Kemal.config.extra_options do |parser|
   parser.banner = "Usage: invidious [arguments]"

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -171,15 +171,8 @@ DECRYPT_FUNCTION =
   if sig_helper_address = CONFIG.signature_server.presence
     IV::DecryptFunction.new(sig_helper_address)
   else
-    LOGGER.warn("WARNING: inv-sig-helper is required for video playback. For more information see https://docs.invidious.io/installation")
     nil
   end
-
-{% for field in %w(po_token visitor_data) %}
-  if !CONFIG.{{field.id}}
-    LOGGER.warn("WARNING: {{field.id}} is required to view and playback videos. For more information see https://docs.invidious.io/installation")
-  end
-{% end %}
 
 # Start jobs
 

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -163,6 +163,9 @@ class Config
   # Invidious companion
   property invidious_companion : Array(String)? = nil
 
+  # Invidious companion API key
+  property invidious_companion_key : String? = nil
+
   # Saved cookies in "name1=value1; name2=value2..." format
   @[YAML::Field(converter: Preferences::StringToCookies)]
   property cookies : HTTP::Cookies = HTTP::Cookies.new
@@ -242,6 +245,21 @@ class Config
           exit(1)
         end
     {% end %}
+
+    if CONFIG.invidious_companion
+      # invidious_companion and signature_server can't work together
+      if CONFIG.signature_server
+        puts "Config: You can not run inv_sig_helper and invidious_companion at the same time."
+        exit(1)
+      end
+      if !CONFIG.invidious_companion_key
+        puts "Config: Please configure a key if you are using invidious companion."
+        exit(1)
+      elsif CONFIG.invidious_companion_key == "CHANGE_ME!!"
+        puts "Config: The value of 'invidious_companion_key' needs to be changed!!"
+        exit(1)
+      end
+    end
 
     # HMAC_key is mandatory
     # See: https://github.com/iv-org/invidious/issues/3854

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -74,26 +74,14 @@ end
 class Config
   include YAML::Serializable
 
-  module URIArrayConverter
-    def self.to_yaml(values : Array(URI), yaml : YAML::Nodes::Builder)
-      yaml.sequence do
-        values.each { |v| yaml.scalar v.to_s }
-      end
-    end
+  class CompanionConfig
+    include YAML::Serializable
 
-    def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Array(URI)
-      if node.is_a?(YAML::Nodes::Sequence)
-        node.map do |child|
-          unless child.is_a?(YAML::Nodes::Scalar)
-            node.raise "Expected scalar, not #{child.class}"
-          end
+    @[YAML::Field(converter: Preferences::URIConverter)]
+    property private_url : URI = URI.parse("")
 
-          URI.parse(child.value)
-        end
-      else
-        node.raise "Expected sequence, not #{node.class}"
-      end
-    end
+    @[YAML::Field(converter: Preferences::URIConverter)]
+    property public_url : URI = URI.parse("")
   end
 
   # Number of threads to use for crawling videos from channels (for updating subscriptions)
@@ -183,8 +171,7 @@ class Config
   property po_token : String? = nil
 
   # Invidious companion
-  @[YAML::Field(converter: Config::URIArrayConverter)]
-  property invidious_companion : Array(URI) = [] of URI
+  property invidious_companion : Array(CompanionConfig) = [] of CompanionConfig
 
   # Invidious companion API key
   property invidious_companion_key : String = ""

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -256,13 +256,12 @@ class Config
         end
     {% end %}
 
-    if !config.invidious_companion.empty?
+    if config.invidious_companion.present?
       # invidious_companion and signature_server can't work together
       if config.signature_server
         puts "Config: You can not run inv_sig_helper and invidious_companion at the same time."
         exit(1)
-      end
-      if config.invidious_companion_key.empty?
+      elsif config.invidious_companion_key.empty?
         puts "Config: Please configure a key if you are using invidious companion."
         exit(1)
       elsif config.invidious_companion_key == "CHANGE_ME!!"

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -275,7 +275,7 @@ class Config
         puts "Config: You can not run inv_sig_helper and invidious_companion at the same time."
         exit(1)
       end
-      if !CONFIG.invidious_companion_key
+      if CONFIG.invidious_companion_key.empty?
         puts "Config: Please configure a key if you are using invidious companion."
         exit(1)
       elsif CONFIG.invidious_companion_key == "CHANGE_ME!!"

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -269,16 +269,16 @@ class Config
         end
     {% end %}
 
-    if !CONFIG.invidious_companion.empty?
+    if !config.invidious_companion.empty?
       # invidious_companion and signature_server can't work together
-      if CONFIG.signature_server
+      if config.signature_server
         puts "Config: You can not run inv_sig_helper and invidious_companion at the same time."
         exit(1)
       end
-      if CONFIG.invidious_companion_key.empty?
+      if config.invidious_companion_key.empty?
         puts "Config: Please configure a key if you are using invidious companion."
         exit(1)
-      elsif CONFIG.invidious_companion_key == "CHANGE_ME!!"
+      elsif config.invidious_companion_key == "CHANGE_ME!!"
         puts "Config: The value of 'invidious_companion_key' needs to be changed!!"
         exit(1)
       end

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -160,6 +160,9 @@ class Config
   # poToken for passing bot attestation
   property po_token : String? = nil
 
+  # Invidious companion
+  property invidious_companion : String? = nil
+
   # Saved cookies in "name1=value1; name2=value2..." format
   @[YAML::Field(converter: Preferences::StringToCookies)]
   property cookies : HTTP::Cookies = HTTP::Cookies.new

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -161,7 +161,7 @@ class Config
   property po_token : String? = nil
 
   # Invidious companion
-  property invidious_companion : String? = nil
+  property invidious_companion : Array(String)? = nil
 
   # Saved cookies in "name1=value1; name2=value2..." format
   @[YAML::Field(converter: Preferences::StringToCookies)]

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -268,6 +268,9 @@ class Config
       elsif config.invidious_companion_key == "CHANGE_ME!!"
         puts "Config: The value of 'invidious_companion_key' needs to be changed!!"
         exit(1)
+      elsif config.invidious_companion_key.size < 16
+        puts "Config: The value of 'invidious_companion_key' needs to be a size of 16 or more."
+        exit(1)
       end
     end
 

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -271,6 +271,8 @@ class Config
         puts "Config: The value of 'invidious_companion_key' needs to be a size of 16 or more."
         exit(1)
       end
+    else
+      LOGGER.warn("WARNING: Invidious companion is required to view and playback videos. For more information see https://docs.invidious.io/companion-installation/")
     end
 
     # HMAC_key is mandatory

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -271,8 +271,10 @@ class Config
         puts "Config: The value of 'invidious_companion_key' needs to be a size of 16 or more."
         exit(1)
       end
+    elsif config.signature_server
+      puts("WARNING: inv-sig-helper is deprecated. Please switch to Invidious companion: https://docs.invidious.io/companion-installation/")
     else
-      LOGGER.warn("WARNING: Invidious companion is required to view and playback videos. For more information see https://docs.invidious.io/companion-installation/")
+      puts("WARNING: Invidious companion is required to view and playback videos. For more information see https://docs.invidious.io/companion-installation/")
     end
 
     # HMAC_key is mandatory

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -383,3 +383,22 @@ def parse_link_endpoint(endpoint : JSON::Any, text : String, video_id : String)
   end
   return text
 end
+
+def encrypt_ecb_without_salt(data, key)
+  cipher = OpenSSL::Cipher.new("aes-128-ecb")
+  cipher.encrypt
+  cipher.key = key
+
+  io = IO::Memory.new
+  io.write(cipher.update(data))
+  io.write(cipher.final)
+  io.rewind
+
+  return io
+end
+
+def invidious_companion_encrypt(data)
+  timestamp = Time.utc.to_unix
+  encrypted_data = encrypt_ecb_without_salt("#{timestamp}|#{data}", CONFIG.invidious_companion_key)
+  return Base64.urlsafe_encode(encrypted_data)
+end

--- a/src/invidious/routes/api/manifest.cr
+++ b/src/invidious/routes/api/manifest.cr
@@ -1,16 +1,17 @@
 module Invidious::Routes::API::Manifest
   # /api/manifest/dash/id/:id
   def self.get_dash_video_id(env)
-    if !CONFIG.invidious_companion.empty?
-      return error_template(403, "This endpoint is not permitted because it is handled by Invidious companion.")
-    end
-
     env.response.headers.add("Access-Control-Allow-Origin", "*")
     env.response.content_type = "application/dash+xml"
 
     local = env.params.query["local"]?.try &.== "true"
     id = env.params.url["id"]
     region = env.params.query["region"]?
+
+    if !CONFIG.invidious_companion.empty?
+      invidious_companion = CONFIG.invidious_companion.sample
+      return env.redirect "#{invidious_companion.public_url.to_s}/api/manifest/dash/id/#{id}?#{env.params.query}"
+    end
 
     # Since some implementations create playlists based on resolution regardless of different codecs,
     # we can opt to only add a source to a representation if it has a unique height within that representation

--- a/src/invidious/routes/api/manifest.cr
+++ b/src/invidious/routes/api/manifest.cr
@@ -1,6 +1,10 @@
 module Invidious::Routes::API::Manifest
   # /api/manifest/dash/id/:id
   def self.get_dash_video_id(env)
+    if !CONFIG.invidious_companion.empty?
+      return error_template(403, "This endpoint is not permitted because it is handled by Invidious companion.")
+    end
+
     env.response.headers.add("Access-Control-Allow-Origin", "*")
     env.response.content_type = "application/dash+xml"
 
@@ -18,10 +22,6 @@ module Invidious::Routes::API::Manifest
       haltf env, status_code: 404
     rescue ex
       haltf env, status_code: 403
-    end
-
-    if local && CONFIG.invidious_companion
-      return env.redirect "#{video.invidious_companion["baseUrl"].as_s}#{env.request.path}?#{env.request.query}"
     end
 
     if dashmpd = video.dash_manifest_url

--- a/src/invidious/routes/api/manifest.cr
+++ b/src/invidious/routes/api/manifest.cr
@@ -8,7 +8,7 @@ module Invidious::Routes::API::Manifest
     id = env.params.url["id"]
     region = env.params.query["region"]?
 
-    if !CONFIG.invidious_companion.empty?
+    if CONFIG.invidious_companion.present?
       invidious_companion = CONFIG.invidious_companion.sample
       return env.redirect "#{invidious_companion.public_url}/api/manifest/dash/id/#{id}?#{env.params.query}"
     end

--- a/src/invidious/routes/api/manifest.cr
+++ b/src/invidious/routes/api/manifest.cr
@@ -20,6 +20,10 @@ module Invidious::Routes::API::Manifest
       haltf env, status_code: 403
     end
 
+    if local && CONFIG.invidious_companion
+      return env.redirect "#{video.invidious_companion["baseUrl"].as_s}#{env.request.path}?#{env.request.query}"
+    end
+
     if dashmpd = video.dash_manifest_url
       response = YT_POOL.client &.get(URI.parse(dashmpd).request_target)
 

--- a/src/invidious/routes/api/manifest.cr
+++ b/src/invidious/routes/api/manifest.cr
@@ -10,7 +10,7 @@ module Invidious::Routes::API::Manifest
 
     if !CONFIG.invidious_companion.empty?
       invidious_companion = CONFIG.invidious_companion.sample
-      return env.redirect "#{invidious_companion.public_url.to_s}/api/manifest/dash/id/#{id}?#{env.params.query}"
+      return env.redirect "#{invidious_companion.public_url}/api/manifest/dash/id/#{id}?#{env.params.query}"
     end
 
     # Since some implementations create playlists based on resolution regardless of different codecs,

--- a/src/invidious/routes/embed.cr
+++ b/src/invidious/routes/embed.cr
@@ -203,6 +203,13 @@ module Invidious::Routes::Embed
       return env.redirect url
     end
 
+    if (!CONFIG.invidious_companion.empty? && (preferences.local || preferences.quality == "dash"))
+      env.response.headers["Content-Security-Policy"] =
+        env.response.headers["Content-Security-Policy"]
+          .gsub("media-src", "media-src " + video.invidious_companion.not_nil!["baseUrl"].as_s)
+          .gsub("connect-src", "connect-src " + video.invidious_companion.not_nil!["baseUrl"].as_s)
+    end
+
     rendered "embed"
   end
 end

--- a/src/invidious/routes/embed.cr
+++ b/src/invidious/routes/embed.cr
@@ -203,7 +203,7 @@ module Invidious::Routes::Embed
       return env.redirect url
     end
 
-    if (!CONFIG.invidious_companion.empty? && (preferences.local || preferences.quality == "dash"))
+    if (!CONFIG.invidious_companion.empty?)
       env.response.headers["Content-Security-Policy"] =
         env.response.headers["Content-Security-Policy"]
           .gsub("media-src", "media-src " + video.invidious_companion.not_nil!["baseUrl"].as_s)

--- a/src/invidious/routes/embed.cr
+++ b/src/invidious/routes/embed.cr
@@ -203,11 +203,11 @@ module Invidious::Routes::Embed
       return env.redirect url
     end
 
-    if (!CONFIG.invidious_companion.empty?)
+    if companion_base_url = video.invidious_companion.try &.["baseUrl"].as_s
       env.response.headers["Content-Security-Policy"] =
         env.response.headers["Content-Security-Policy"]
-          .gsub("media-src", "media-src " + video.invidious_companion.not_nil!["baseUrl"].as_s)
-          .gsub("connect-src", "connect-src " + video.invidious_companion.not_nil!["baseUrl"].as_s)
+          .gsub("media-src", "media-src #{companion_base_url}")
+          .gsub("connect-src", "connect-src #{companion_base_url}")
     end
 
     rendered "embed"

--- a/src/invidious/routes/embed.cr
+++ b/src/invidious/routes/embed.cr
@@ -203,11 +203,12 @@ module Invidious::Routes::Embed
       return env.redirect url
     end
 
-    if companion_base_url = video.invidious_companion.try &.["baseUrl"].as_s
+    if CONFIG.invidious_companion.present?
+      invidious_companion = CONFIG.invidious_companion.sample
       env.response.headers["Content-Security-Policy"] =
         env.response.headers["Content-Security-Policy"]
-          .gsub("media-src", "media-src #{companion_base_url}")
-          .gsub("connect-src", "connect-src #{companion_base_url}")
+          .gsub("media-src", "media-src #{invidious_companion.public_url}")
+          .gsub("connect-src", "connect-src #{invidious_companion.public_url}")
     end
 
     rendered "embed"

--- a/src/invidious/routes/video_playback.cr
+++ b/src/invidious/routes/video_playback.cr
@@ -258,7 +258,7 @@ module Invidious::Routes::VideoPlayback
   def self.latest_version(env)
     if !CONFIG.invidious_companion.empty?
       invidious_companion = CONFIG.invidious_companion.sample
-      return env.redirect "#{invidious_companion.public_url.to_s}/latest_version?#{env.params.query}"
+      return env.redirect "#{invidious_companion.public_url}/latest_version?#{env.params.query}"
     end
 
     id = env.params.query["id"]?

--- a/src/invidious/routes/video_playback.cr
+++ b/src/invidious/routes/video_playback.cr
@@ -297,6 +297,9 @@ module Invidious::Routes::VideoPlayback
     end
 
     if local
+      if (CONFIG.invidious_companion)
+        return env.redirect "#{video.invidious_companion["baseUrl"].as_s}#{env.request.path}?#{env.request.query}"
+      end
       url = URI.parse(url).request_target.not_nil!
       url += "&title=#{URI.encode_www_form(title, space_to_plus: false)}" if title
     end

--- a/src/invidious/routes/video_playback.cr
+++ b/src/invidious/routes/video_playback.cr
@@ -257,7 +257,8 @@ module Invidious::Routes::VideoPlayback
   # so we have a mechanism here to redirect to the latest version
   def self.latest_version(env)
     if !CONFIG.invidious_companion.empty?
-      return error_template(403, "This endpoint is not permitted because it is handled by Invidious companion.")
+      invidious_companion = CONFIG.invidious_companion.sample
+      return env.redirect "#{invidious_companion.public_url.to_s}/latest_version?#{env.params.query}"
     end
 
     id = env.params.query["id"]?

--- a/src/invidious/routes/video_playback.cr
+++ b/src/invidious/routes/video_playback.cr
@@ -256,7 +256,7 @@ module Invidious::Routes::VideoPlayback
   # YouTube /videoplayback links expire after 6 hours,
   # so we have a mechanism here to redirect to the latest version
   def self.latest_version(env)
-    if !CONFIG.invidious_companion.empty?
+    if CONFIG.invidious_companion.present?
       invidious_companion = CONFIG.invidious_companion.sample
       return env.redirect "#{invidious_companion.public_url}/latest_version?#{env.params.query}"
     end

--- a/src/invidious/routes/video_playback.cr
+++ b/src/invidious/routes/video_playback.cr
@@ -256,7 +256,7 @@ module Invidious::Routes::VideoPlayback
   # YouTube /videoplayback links expire after 6 hours,
   # so we have a mechanism here to redirect to the latest version
   def self.latest_version(env)
-    if !CONFIG.invidious_companion.empty? && CONFIG.disabled?("downloads")
+    if !CONFIG.invidious_companion.empty?
       return error_template(403, "This endpoint is not permitted because it is handled by Invidious companion.")
     end
 
@@ -301,9 +301,6 @@ module Invidious::Routes::VideoPlayback
     end
 
     if local
-      if (!CONFIG.invidious_companion.empty?)
-        return env.redirect "#{video.invidious_companion.not_nil!["baseUrl"].as_s}#{env.request.path}?#{env.request.query}"
-      end
       url = URI.parse(url).request_target.not_nil!
       url += "&title=#{URI.encode_www_form(title, space_to_plus: false)}" if title
     end

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -192,7 +192,7 @@ module Invidious::Routes::Watch
       captions: video.captions
     )
 
-    if (!CONFIG.invidious_companion.empty? && (preferences.local || preferences.quality == "dash"))
+    if (!CONFIG.invidious_companion.empty?)
       env.response.headers["Content-Security-Policy"] =
         env.response.headers["Content-Security-Policy"]
           .gsub("media-src", "media-src " + video.invidious_companion.not_nil!["baseUrl"].as_s)

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -327,7 +327,7 @@ module Invidious::Routes::Watch
       env.params.query["title"] = filename
       env.params.query["local"] = "true"
 
-      if (!CONFIG.invidious_companion.empty?)
+      if (CONFIG.invidious_companion.present?)
         video = get_video(video_id)
         return env.redirect "#{video.invidious_companion["baseUrl"].as_s}/latest_version?#{env.params.query}"
       else

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -192,7 +192,7 @@ module Invidious::Routes::Watch
       captions: video.captions
     )
 
-    if (CONFIG.invidious_companion && env.params.query["local"] == true)
+    if (CONFIG.invidious_companion && (preferences.local || preferences.quality == "dash"))
       env.response.headers["Content-Security-Policy"] =
         env.response.headers["Content-Security-Policy"]
           .gsub("media-src", "media-src " + video.invidious_companion["baseUrl"].as_s)

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -192,6 +192,13 @@ module Invidious::Routes::Watch
       captions: video.captions
     )
 
+    if (CONFIG.invidious_companion && env.params.query["local"] == true)
+      env.response.headers["Content-Security-Policy"] =
+        env.response.headers["Content-Security-Policy"]
+          .gsub("media-src", "media-src " + video.invidious_companion["baseUrl"].as_s)
+          .gsub("connect-src", "connect-src " + video.invidious_companion["baseUrl"].as_s)
+    end
+
     templated "watch"
   end
 

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -322,7 +322,6 @@ module Invidious::Routes::Watch
 
       return Invidious::Routes::API::V1::Videos.captions(env)
     elsif itag = download_widget["itag"]?.try &.as_i.to_s
-
       # URL params specific to /latest_version
       env.params.query["id"] = video_id
       env.params.query["title"] = filename

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -192,11 +192,11 @@ module Invidious::Routes::Watch
       captions: video.captions
     )
 
-    if (CONFIG.invidious_companion && (preferences.local || preferences.quality == "dash"))
+    if (!CONFIG.invidious_companion.empty? && (preferences.local || preferences.quality == "dash"))
       env.response.headers["Content-Security-Policy"] =
         env.response.headers["Content-Security-Policy"]
-          .gsub("media-src", "media-src " + video.invidious_companion["baseUrl"].as_s)
-          .gsub("connect-src", "connect-src " + video.invidious_companion["baseUrl"].as_s)
+          .gsub("media-src", "media-src " + video.invidious_companion.not_nil!["baseUrl"].as_s)
+          .gsub("connect-src", "connect-src " + video.invidious_companion.not_nil!["baseUrl"].as_s)
     end
 
     templated "watch"

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -322,13 +322,20 @@ module Invidious::Routes::Watch
 
       return Invidious::Routes::API::V1::Videos.captions(env)
     elsif itag = download_widget["itag"]?.try &.as_i
+      itag = itag.to_s
+
       # URL params specific to /latest_version
       env.params.query["id"] = video_id
-      env.params.query["itag"] = itag.to_s
+      env.params.query["itag"] = itag
       env.params.query["title"] = filename
       env.params.query["local"] = "true"
 
-      return Invidious::Routes::VideoPlayback.latest_version(env)
+      if (!CONFIG.invidious_companion.empty?)
+        video = get_video(video_id)
+        return env.redirect "#{video.invidious_companion.not_nil!["baseUrl"].as_s}/latest_version?id=#{video_id}&itag=#{itag}&local=true"
+      else
+        return Invidious::Routes::VideoPlayback.latest_version(env)
+      end
     else
       return error_template(400, "Invalid label or itag")
     end

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -192,11 +192,12 @@ module Invidious::Routes::Watch
       captions: video.captions
     )
 
-    if companion_base_url = video.invidious_companion.try &.["baseUrl"].as_s
+    if CONFIG.invidious_companion.present?
+      invidious_companion = CONFIG.invidious_companion.sample
       env.response.headers["Content-Security-Policy"] =
         env.response.headers["Content-Security-Policy"]
-          .gsub("media-src", "media-src #{companion_base_url}")
-          .gsub("connect-src", "connect-src #{companion_base_url}")
+          .gsub("media-src", "media-src #{invidious_companion.public_url}")
+          .gsub("connect-src", "connect-src #{invidious_companion.public_url}")
     end
 
     templated "watch"
@@ -329,7 +330,8 @@ module Invidious::Routes::Watch
 
       if (CONFIG.invidious_companion.present?)
         video = get_video(video_id)
-        return env.redirect "#{video.invidious_companion["baseUrl"].as_s}/latest_version?#{env.params.query}"
+        invidious_companion = CONFIG.invidious_companion.sample
+        return env.redirect "#{invidious_companion.public_url}/latest_version?#{env.params.query}"
       else
         return Invidious::Routes::VideoPlayback.latest_version(env)
       end

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -193,7 +193,7 @@ struct Video
   end
 
   def invidious_companion : Hash(String, JSON::Any)?
-    info["invidiousCompanion"]?.try &.as_h
+    info["invidiousCompanion"]?.try &.as_h || {} of String => JSON::Any
   end
 
   # Macros defining getters/setters for various types of data

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -192,6 +192,10 @@ struct Video
     }
   end
 
+  def invidious_companion : Hash(String, JSON::Any)
+    info["invidiousCompanion"].try &.as_h
+  end
+
   # Macros defining getters/setters for various types of data
 
   private macro getset_string(name)

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -15,7 +15,7 @@ struct Video
   # NOTE: don't forget to bump this number if any change is made to
   # the `params` structure in videos/parser.cr!!!
   #
-  SCHEMA_VERSION = 2
+  SCHEMA_VERSION = 3
 
   property id : String
 
@@ -192,8 +192,8 @@ struct Video
     }
   end
 
-  def invidious_companion : Hash(String, JSON::Any)
-    info["invidiousCompanion"].try &.as_h
+  def invidious_companion : Hash(String, JSON::Any)?
+    info["invidiousCompanion"]?.try &.as_h
   end
 
   # Macros defining getters/setters for various types of data

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -192,10 +192,6 @@ struct Video
     }
   end
 
-  def invidious_companion : Hash(String, JSON::Any)?
-    info["invidiousCompanion"]?.try &.as_h || {} of String => JSON::Any
-  end
-
   # Macros defining getters/setters for various types of data
 
   private macro getset_string(name)

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -108,7 +108,7 @@ def extract_video_info(video_id : String)
   params = parse_video_info(video_id, player_response)
   params["reason"] = JSON::Any.new(reason) if reason
 
-  if !CONFIG.invidious_companion.empty?
+  if CONFIG.invidious_companion.present?
     new_player_response = nil
 
     # Don't use Android test suite client if po_token is passed because po_token doesn't

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -108,7 +108,7 @@ def extract_video_info(video_id : String)
   params = parse_video_info(video_id, player_response)
   params["reason"] = JSON::Any.new(reason) if reason
 
-  if CONFIG.invidious_companion.nil?
+  if !CONFIG.invidious_companion.empty?
     new_player_response = nil
 
     # Don't use Android test suite client if po_token is passed because po_token doesn't
@@ -134,7 +134,7 @@ def extract_video_info(video_id : String)
     end
   end
 
-  {"captions", "playabilityStatus", "playerConfig", "storyboards"}.each do |f|
+  {"captions", "playabilityStatus", "playerConfig", "storyboards", "invidiousCompanion"}.each do |f|
     params[f] = player_response[f] if player_response[f]?
   end
 
@@ -147,10 +147,6 @@ def extract_video_info(video_id : String)
     end
 
     params["streamingData"] = streaming_data
-  end
-
-  if CONFIG.invidious_companion
-    params["invidiousCompanion"] = player_response["invidiousCompanion"]
   end
 
   # Data structure version, for cache control
@@ -461,12 +457,11 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
     # Music section
     "music" => JSON.parse(music_list.to_json),
     # Author infos
-    "author"             => JSON::Any.new(author || ""),
-    "ucid"               => JSON::Any.new(ucid || ""),
-    "authorThumbnail"    => JSON::Any.new(author_thumbnail.try &.as_s || ""),
-    "authorVerified"     => JSON::Any.new(author_verified || false),
-    "subCountText"       => JSON::Any.new(subs_text || "-"),
-    "invidiousCompanion" => JSON::Any.new(subs_text),
+    "author"          => JSON::Any.new(author || ""),
+    "ucid"            => JSON::Any.new(ucid || ""),
+    "authorThumbnail" => JSON::Any.new(author_thumbnail.try &.as_s || ""),
+    "authorVerified"  => JSON::Any.new(author_verified || false),
+    "subCountText"    => JSON::Any.new(subs_text || "-"),
   }
 
   return params

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -149,6 +149,10 @@ def extract_video_info(video_id : String)
     params["streamingData"] = streaming_data
   end
 
+  if CONFIG.invidious_companion
+    params["invidiousCompanion"] = player_response["invidiousCompanion"]
+  end
+
   # Data structure version, for cache control
   params["version"] = JSON::Any.new(Video::SCHEMA_VERSION.to_i64)
 
@@ -457,11 +461,12 @@ def parse_video_info(video_id : String, player_response : Hash(String, JSON::Any
     # Music section
     "music" => JSON.parse(music_list.to_json),
     # Author infos
-    "author"          => JSON::Any.new(author || ""),
-    "ucid"            => JSON::Any.new(ucid || ""),
-    "authorThumbnail" => JSON::Any.new(author_thumbnail.try &.as_s || ""),
-    "authorVerified"  => JSON::Any.new(author_verified || false),
-    "subCountText"    => JSON::Any.new(subs_text || "-"),
+    "author"             => JSON::Any.new(author || ""),
+    "ucid"               => JSON::Any.new(ucid || ""),
+    "authorThumbnail"    => JSON::Any.new(author_thumbnail.try &.as_s || ""),
+    "authorVerified"     => JSON::Any.new(author_verified || false),
+    "subCountText"       => JSON::Any.new(subs_text || "-"),
+    "invidiousCompanion" => JSON::Any.new(subs_text),
   }
 
   return params

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -108,27 +108,30 @@ def extract_video_info(video_id : String)
   params = parse_video_info(video_id, player_response)
   params["reason"] = JSON::Any.new(reason) if reason
 
-  new_player_response = nil
+  if CONFIG.invidious_companion.nil?
+    new_player_response = nil
 
-  # Don't use Android test suite client if po_token is passed because po_token doesn't
-  # work for Android test suite client.
-  if reason.nil? && CONFIG.po_token.nil?
-    # Fetch the video streams using an Android client in order to get the
-    # decrypted URLs and maybe fix throttling issues (#2194). See the
-    # following issue for an explanation about decrypted URLs:
-    # https://github.com/TeamNewPipe/NewPipeExtractor/issues/562
-    client_config.client_type = YoutubeAPI::ClientType::AndroidTestSuite
-    new_player_response = try_fetch_streaming_data(video_id, client_config)
-  end
+    # Don't use Android test suite client if po_token is passed because po_token doesn't
+    # work for Android test suite client.
+    if reason.nil? && CONFIG.po_token.nil?
+      # Fetch the video streams using an Android client in order to get the
+      # decrypted URLs and maybe fix throttling issues (#2194). See the
+      # following issue for an explanation about decrypted URLs:
+      # https://github.com/TeamNewPipe/NewPipeExtractor/issues/562
+      client_config.client_type = YoutubeAPI::ClientType::AndroidTestSuite
+      new_player_response = try_fetch_streaming_data(video_id, client_config)
+    end
 
-  # Replace player response and reset reason
-  if !new_player_response.nil?
-    # Preserve captions & storyboard data before replacement
-    new_player_response["storyboards"] = player_response["storyboards"] if player_response["storyboards"]?
-    new_player_response["captions"] = player_response["captions"] if player_response["captions"]?
+    # Replace player response and reset reason
+    if !new_player_response.nil?
+      # Preserve captions & storyboard data before replacement
+      new_player_response["storyboards"] = player_response["storyboards"] if player_response["storyboards"]?
+      new_player_response["captions"] = player_response["captions"] if player_response["captions"]?
 
-    player_response = new_player_response
-    params.delete("reason")
+        player_response = new_player_response
+        params.delete("reason")
+      end
+    end
   end
 
   {"captions", "playabilityStatus", "playerConfig", "storyboards"}.each do |f|

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -131,7 +131,6 @@ def extract_video_info(video_id : String)
         player_response = new_player_response
         params.delete("reason")
       end
-    end
   end
 
   {"captions", "playabilityStatus", "playerConfig", "storyboards", "invidiousCompanion"}.each do |f|

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -128,9 +128,9 @@ def extract_video_info(video_id : String)
       new_player_response["storyboards"] = player_response["storyboards"] if player_response["storyboards"]?
       new_player_response["captions"] = player_response["captions"] if player_response["captions"]?
 
-        player_response = new_player_response
-        params.delete("reason")
-      end
+      player_response = new_player_response
+      params.delete("reason")
+    end
   end
 
   {"captions", "playabilityStatus", "playerConfig", "storyboards", "invidiousCompanion"}.each do |f|

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -133,7 +133,7 @@ def extract_video_info(video_id : String)
     end
   end
 
-  {"captions", "playabilityStatus", "playerConfig", "storyboards", "invidiousCompanion"}.each do |f|
+  {"captions", "playabilityStatus", "playerConfig", "storyboards"}.each do |f|
     params[f] = player_response[f] if player_response[f]?
   end
 

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -108,7 +108,7 @@ def extract_video_info(video_id : String)
   params = parse_video_info(video_id, player_response)
   params["reason"] = JSON::Any.new(reason) if reason
 
-  if CONFIG.invidious_companion.present?
+  if !CONFIG.invidious_companion.present?
     new_player_response = nil
 
     # Don't use Android test suite client if po_token is passed because po_token doesn't

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -22,7 +22,7 @@
                audio_streams.each_with_index do |fmt, i|
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
-                src_url = video.invidious_companion.not_nil!["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty?)
+                src_url = video.invidious_companion["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty?)
 
                 bitrate = fmt["bitrate"]
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
@@ -37,7 +37,7 @@
         <% else %>
             <% if params.quality == "dash"
                src_url = "/api/manifest/dash/id/" + video.id + "?local=true&unique_res=1"
-               src_url = video.invidious_companion.not_nil!["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty?)
+               src_url = video.invidious_companion["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty?)
             %>
                 <source src="<%= src_url %>" type='application/dash+xml' label="dash">
             <% end %>
@@ -48,7 +48,7 @@
             fmt_stream.each_with_index do |fmt, i|
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
-                src_url = video.invidious_companion.not_nil!["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty?)
+                src_url = video.invidious_companion["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty?)
 
                 quality = fmt["quality"]
                 mimetype = HTML.escape(fmt["mimeType"].as_s)

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -22,7 +22,7 @@
                audio_streams.each_with_index do |fmt, i|
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
-                src_url = video.invidious_companion["baseUrl"].as_s + src_url if (CONFIG.invidious_companion && params.local)
+                src_url = video.invidious_companion.not_nil!["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty? && params.local)
 
                 bitrate = fmt["bitrate"]
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
@@ -37,7 +37,7 @@
         <% else %>
             <% if params.quality == "dash"
                src_url = "/api/manifest/dash/id/" + video.id + "?local=true&unique_res=1"
-               src_url = video.invidious_companion["baseUrl"].as_s + src_url if (CONFIG.invidious_companion)
+               src_url = video.invidious_companion.not_nil!["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty?)
             %>
                 <source src="<%= src_url %>" type='application/dash+xml' label="dash">
             <% end %>
@@ -48,7 +48,7 @@
             fmt_stream.each_with_index do |fmt, i|
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
-                src_url = video.invidious_companion["baseUrl"].as_s + src_url if (CONFIG.invidious_companion && params.local)
+                src_url = video.invidious_companion.not_nil!["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty? && params.local)
 
                 quality = fmt["quality"]
                 mimetype = HTML.escape(fmt["mimeType"].as_s)

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -23,7 +23,7 @@
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
                 src_url = video.invidious_companion["baseUrl"].as_s + src_url + 
-                            "&check=#{invidious_companion_encrypt(video.id)}" if (!CONFIG.invidious_companion.empty?)
+                            "&check=#{invidious_companion_encrypt(video.id)}" if (CONFIG.invidious_companion.present?)
 
                 bitrate = fmt["bitrate"]
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
@@ -39,7 +39,7 @@
             <% if params.quality == "dash"
                src_url = "/api/manifest/dash/id/" + video.id + "?local=true&unique_res=1"
                src_url = video.invidious_companion["baseUrl"].as_s + src_url +
-                            "&check=#{invidious_companion_encrypt(video.id)}" if (!CONFIG.invidious_companion.empty?)
+                            "&check=#{invidious_companion_encrypt(video.id)}" if (CONFIG.invidious_companion.present?)
             %>
                 <source src="<%= src_url %>" type='application/dash+xml' label="dash">
             <% end %>
@@ -51,7 +51,7 @@
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
                 src_url = video.invidious_companion["baseUrl"].as_s + src_url +
-                            "&check=#{invidious_companion_encrypt(video.id)}" if (!CONFIG.invidious_companion.empty?)
+                            "&check=#{invidious_companion_encrypt(video.id)}" if (CONFIG.invidious_companion.present?)
 
                 quality = fmt["quality"]
                 mimetype = HTML.escape(fmt["mimeType"].as_s)

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -22,7 +22,7 @@
                audio_streams.each_with_index do |fmt, i|
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
-                src_url = video.invidious_companion.not_nil!["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty? && params.local)
+                src_url = video.invidious_companion.not_nil!["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty?)
 
                 bitrate = fmt["bitrate"]
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
@@ -48,7 +48,7 @@
             fmt_stream.each_with_index do |fmt, i|
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
-                src_url = video.invidious_companion.not_nil!["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty? && params.local)
+                src_url = video.invidious_companion.not_nil!["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty?)
 
                 quality = fmt["quality"]
                 mimetype = HTML.escape(fmt["mimeType"].as_s)

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -22,6 +22,7 @@
                audio_streams.each_with_index do |fmt, i|
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
+                src_url = video.invidious_companion["baseUrl"].as_s + src_url if (CONFIG.invidious_companion && params.local)
 
                 bitrate = fmt["bitrate"]
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
@@ -34,8 +35,11 @@
                 <% end %>
             <% end %>
         <% else %>
-            <% if params.quality == "dash" %>
-                <source src="/api/manifest/dash/id/<%= video.id %>?local=true&unique_res=1" type='application/dash+xml' label="dash">
+            <% if params.quality == "dash"
+               src_url = "/api/manifest/dash/id/" + video.id + "?local=true&unique_res=1"
+               src_url = video.invidious_companion["baseUrl"].as_s + src_url if (CONFIG.invidious_companion)
+            %>
+                <source src="<%= src_url %>" type='application/dash+xml' label="dash">
             <% end %>
 
             <%
@@ -44,6 +48,7 @@
             fmt_stream.each_with_index do |fmt, i|
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
+                src_url = video.invidious_companion["baseUrl"].as_s + src_url if (CONFIG.invidious_companion && params.local)
 
                 quality = fmt["quality"]
                 mimetype = HTML.escape(fmt["mimeType"].as_s)

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -22,7 +22,8 @@
                audio_streams.each_with_index do |fmt, i|
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
-                src_url = video.invidious_companion["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty?)
+                src_url = video.invidious_companion["baseUrl"].as_s + src_url + 
+                            "&check=#{invidious_companion_encrypt(video.id)}" if (!CONFIG.invidious_companion.empty?)
 
                 bitrate = fmt["bitrate"]
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
@@ -37,7 +38,8 @@
         <% else %>
             <% if params.quality == "dash"
                src_url = "/api/manifest/dash/id/" + video.id + "?local=true&unique_res=1"
-               src_url = video.invidious_companion["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty?)
+               src_url = video.invidious_companion["baseUrl"].as_s + src_url +
+                            "&check=#{invidious_companion_encrypt(video.id)}" if (!CONFIG.invidious_companion.empty?)
             %>
                 <source src="<%= src_url %>" type='application/dash+xml' label="dash">
             <% end %>
@@ -48,7 +50,8 @@
             fmt_stream.each_with_index do |fmt, i|
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
-                src_url = video.invidious_companion["baseUrl"].as_s + src_url if (!CONFIG.invidious_companion.empty?)
+                src_url = video.invidious_companion["baseUrl"].as_s + src_url +
+                            "&check=#{invidious_companion_encrypt(video.id)}" if (!CONFIG.invidious_companion.empty?)
 
                 quality = fmt["quality"]
                 mimetype = HTML.escape(fmt["mimeType"].as_s)

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -22,8 +22,8 @@
                audio_streams.each_with_index do |fmt, i|
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
-                src_url = video.invidious_companion["baseUrl"].as_s + src_url + 
-                            "&check=#{invidious_companion_encrypt(video.id)}" if (CONFIG.invidious_companion.present?)
+                src_url = invidious_companion.public_url.to_s + src_url + 
+                            "&check=#{invidious_companion_encrypt(video.id)}" if (invidious_companion)
 
                 bitrate = fmt["bitrate"]
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
@@ -38,8 +38,8 @@
         <% else %>
             <% if params.quality == "dash"
                src_url = "/api/manifest/dash/id/" + video.id + "?local=true&unique_res=1"
-               src_url = video.invidious_companion["baseUrl"].as_s + src_url +
-                            "&check=#{invidious_companion_encrypt(video.id)}" if (CONFIG.invidious_companion.present?)
+               src_url = invidious_companion.public_url.to_s + src_url +
+                            "&check=#{invidious_companion_encrypt(video.id)}" if (invidious_companion)
             %>
                 <source src="<%= src_url %>" type='application/dash+xml' label="dash">
             <% end %>
@@ -50,8 +50,8 @@
             fmt_stream.each_with_index do |fmt, i|
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
-                src_url = video.invidious_companion["baseUrl"].as_s + src_url +
-                            "&check=#{invidious_companion_encrypt(video.id)}" if (CONFIG.invidious_companion.present?)
+                src_url = invidious_companion.public_url.to_s + src_url +
+                            "&check=#{invidious_companion_encrypt(video.id)}" if (invidious_companion)
 
                 quality = fmt["quality"]
                 mimetype = HTML.escape(fmt["mimeType"].as_s)

--- a/src/invidious/yt_backend/connection_pool.cr
+++ b/src/invidious/yt_backend/connection_pool.cr
@@ -61,9 +61,9 @@ def add_yt_headers(request)
   end
 end
 
-def make_client(url : URI, region = nil, force_resolve : Bool = false, force_youtube_headers : Bool = false)
+def make_client(url : URI, region = nil, force_resolve : Bool = false, force_youtube_headers : Bool = false, use_http_proxy : Bool = true)
   client = HTTP::Client.new(url)
-  client.proxy = make_configured_http_proxy_client() if CONFIG.http_proxy
+  client.proxy = make_configured_http_proxy_client() if CONFIG.http_proxy && use_http_proxy
 
   # Force the usage of a specific configured IP Family
   if force_resolve
@@ -78,8 +78,8 @@ def make_client(url : URI, region = nil, force_resolve : Bool = false, force_you
   return client
 end
 
-def make_client(url : URI, region = nil, force_resolve : Bool = false, &)
-  client = make_client(url, region, force_resolve: force_resolve)
+def make_client(url : URI, region = nil, force_resolve : Bool = false, use_http_proxy : Bool = true, &)
+  client = make_client(url, region, force_resolve: force_resolve, use_http_proxy: use_http_proxy)
   begin
     yield client
   ensure

--- a/src/invidious/yt_backend/connection_pool.cr
+++ b/src/invidious/yt_backend/connection_pool.cr
@@ -59,14 +59,12 @@ struct CompanionConnectionPool
 
     @pool = DB::Pool(HTTP::Client).new(options) do
       companion = CONFIG.invidious_companion.sample
-      next make_client(companion.private_url, force_resolve: true)
+      next make_client(companion.private_url, use_http_proxy: false)
     end
   end
 
   def client(&)
     conn = pool.checkout
-    # Proxy needs to be reinstated every time we get a client from the pool
-    conn.proxy = make_configured_http_proxy_client() if CONFIG.http_proxy
 
     begin
       response = yield conn
@@ -74,7 +72,7 @@ struct CompanionConnectionPool
       conn.close
 
       companion = CONFIG.invidious_companion.sample
-      conn = make_client(companion.private_url, force_resolve: true)
+      conn = make_client(companion.private_url, use_http_proxy: false)
 
       response = yield conn
     ensure

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -681,7 +681,7 @@ module YoutubeAPI
   #
   def _post_invidious_companion(
     endpoint : String,
-    data : Hash
+    data : Hash,
   ) : Hash(String, JSON::Any)
     headers = HTTP::Headers{
       "Content-Type"  => "application/json; charset=UTF-8",
@@ -695,9 +695,7 @@ module YoutubeAPI
     # Send the POST request
 
     begin
-      invidious_companion = CONFIG.invidious_companion.sample
-      response = make_client(invidious_companion.private_url, use_http_proxy: false,
-        &.post(endpoint, headers: headers, body: data.to_json))
+      response = COMPANION_POOL.client &.post(endpoint, headers: headers, body: data.to_json)
       body = response.body
       if (response.status_code != 200)
         raise Exception.new(

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -685,7 +685,7 @@ module YoutubeAPI
   ) : Hash(String, JSON::Any)
     headers = HTTP::Headers{
       "Content-Type"  => "application/json; charset=UTF-8",
-      "Authorization" => "Bearer " + CONFIG.invidious_companion_key,
+      "Authorization" => "Bearer #{CONFIG.invidious_companion_key}",
     }
 
     # Logging
@@ -695,19 +695,18 @@ module YoutubeAPI
     # Send the POST request
 
     begin
-      response = make_client(CONFIG.invidious_companion.sample,
+      invidious_companion = CONFIG.invidious_companion.sample
+      response = make_client(invidious_companion.private_url,
         &.post(endpoint, headers: headers, body: data.to_json))
       body = response.body
       if (response.status_code != 200)
-        raise Exception.new("Error while communicating with Invidious companion: \
-                              status code: " + response.status_code.to_s + " and body: " + body)
+        raise Exception.new(
+          "Error while communicating with Invidious companion: \
+          status code: #{response.status_code} and body: #{body.dump}"
+        )
       end
     rescue ex
       raise InfoException.new("Error while communicating with Invidious companion: " + (ex.message || "no extra info found"))
-    end
-
-    if body.nil?
-      raise InfoException.new("Error while communicating with Invidious companion: no response data.")
     end
 
     # Convert result to Hash

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -685,7 +685,6 @@ module YoutubeAPI
   ) : Hash(String, JSON::Any)
     headers = HTTP::Headers{
       "Content-Type"    => "application/json; charset=UTF-8",
-      "Accept-Encoding" => "gzip",
       "Authorization"   => "Bearer " + CONFIG.invidious_companion_key,
     }
 
@@ -698,7 +697,7 @@ module YoutubeAPI
     begin
       response = make_client(CONFIG.invidious_companion.sample,
         &.post(endpoint, headers: headers, body: data.to_json))
-      body = self._decompress(response.body_io, response.headers["Content-Encoding"]?)
+      body = response.body
       if (response.status_code != 200)
         raise Exception.new("Error while communicating with Invidious companion: \
                               status code: " + response.status_code.to_s + " and body: " + body)

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -684,8 +684,8 @@ module YoutubeAPI
     data : Hash
   ) : Hash(String, JSON::Any)
     headers = HTTP::Headers{
-      "Content-Type"    => "application/json; charset=UTF-8",
-      "Authorization"   => "Bearer " + CONFIG.invidious_companion_key,
+      "Content-Type"  => "application/json; charset=UTF-8",
+      "Authorization" => "Bearer " + CONFIG.invidious_companion_key,
     }
 
     # Logging

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -648,11 +648,11 @@ module YoutubeAPI
       puts "invidious companion section"
       puts invidious_companion_urls[Random.rand(invidious_companion_urls.size)]
       begin
-        response = make_client(URI.parse(invidious_companion_urls[Random.rand(invidious_companion_urls.size)]),
+        invidious_companion_response = make_client(URI.parse(invidious_companion_urls[Random.rand(invidious_companion_urls.size)]),
           &.post(endpoint, headers: headers, body: data.to_json))
-        body = response.body
-        if (response.status_code != 200)
-          raise Exception.new("status code: " + response.status_code.to_s + " and body: " + body)
+        body = invidious_companion_response.body
+        if (invidious_companion_response.status_code != 200)
+          raise Exception.new("status code: " + invidious_companion_response.status_code.to_s + " and body: " + body)
         end
       rescue ex
         raise InfoException.new("Error while communicating with Invidious companion: " + (ex.message || "no extra info found"))

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -696,8 +696,8 @@ module YoutubeAPI
 
     begin
       invidious_companion = CONFIG.invidious_companion.sample
-      response = make_client(invidious_companion.private_url, use_http_proxy: false
-        &.post(endpoint, headers: headers, body: data.to_json))
+      response = make_client(invidious_companion.private_url, use_http_proxy: false &.post(endpoint, headers: headers, body: data.to_json)
+      )
       body = response.body
       if (response.status_code != 200)
         raise Exception.new(

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -696,8 +696,8 @@ module YoutubeAPI
 
     begin
       invidious_companion = CONFIG.invidious_companion.sample
-      response = make_client(invidious_companion.private_url, use_http_proxy: false &.post(endpoint, headers: headers, body: data.to_json)
-      )
+      response = make_client(invidious_companion.private_url, use_http_proxy: false,
+        &.post(endpoint, headers: headers, body: data.to_json))
       body = response.body
       if (response.status_code != 200)
         raise Exception.new(

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -645,8 +645,6 @@ module YoutubeAPI
 
     # Send the POST request
     if invidious_companion_urls && endpoint == "/youtubei/v1/player"
-      puts "invidious companion section"
-      puts invidious_companion_urls[Random.rand(invidious_companion_urls.size)]
       begin
         invidious_companion_response = make_client(URI.parse(invidious_companion_urls.sample),
           &.post(endpoint, headers: headers, body: data.to_json))

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -500,7 +500,7 @@ module YoutubeAPI
       data["params"] = params
     end
 
-    if !CONFIG.invidious_companion.empty?
+    if CONFIG.invidious_companion.present?
       return self._post_invidious_companion("/youtubei/v1/player", data)
     else
       return self._post_json("/youtubei/v1/player", data, client_config)
@@ -696,7 +696,7 @@ module YoutubeAPI
 
     begin
       invidious_companion = CONFIG.invidious_companion.sample
-      response = make_client(invidious_companion.private_url,
+      response = make_client(invidious_companion.private_url, use_http_proxy: false
         &.post(endpoint, headers: headers, body: data.to_json))
       body = response.body
       if (response.status_code != 200)

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -648,7 +648,7 @@ module YoutubeAPI
       puts "invidious companion section"
       puts invidious_companion_urls[Random.rand(invidious_companion_urls.size)]
       begin
-        invidious_companion_response = make_client(URI.parse(invidious_companion_urls[Random.rand(invidious_companion_urls.size)]),
+        invidious_companion_response = make_client(URI.parse(invidious_companion_urls.sample),
           &.post(endpoint, headers: headers, body: data.to_json))
         body = invidious_companion_response.body
         if (invidious_companion_response.status_code != 200)


### PR DESCRIPTION
# Description
Invidious companion is the new tool created for the retrieval of the YouTube streams: https://github.com/iv-org/invidious-companion

Invidious will not handle the videos streams retrieval anymore, as it has become a burner for the Invidious team to adapt. Instead, invidious companion will be based on https://github.com/LuanRT/YouTube.js which is the most up to date when it comes to video streams retrieval.

This allows us to spend more time on actually improving the Invidious frontend.

# What does this PR do?

Invidious send the /player request to Invidious companion in HTTP(S). Invidious companion [does all of its magic](https://github.com/iv-org/invidious-companion) then Invidious does the usual parsing of the player endpoint.

Invidious also delegate the work of `latest_version`, `/api/manifest/dash/id` and `/videoplayback` to Invidious companion.

# What does invidious companion do

- You can set multiple invidious_companion. Allowing you to utilize multiple external servers
- It supports SOCKS proxy - related to #301 
- There is a plan to support multiple proxies: https://github.com/iv-org/invidious-companion/issues/5
- There is no need to use inv_sig_helper as the program automatically handle the deciphering.
- There is no need for youtube-trusted-session-generator as the program automatically generate a po_token at a configurable frequency.
- You can logging with a yt account

# Incompatibilities

- You can't use inv_sig_helper with invidious companion

# Not supported yet - will be work in progress after this PR is merged

- The Invidious API is not fully supported. At least, if companion and invidious are not using the same "public" IP address, this won't work. Issue https://github.com/iv-org/invidious-companion/issues/22
- Download feature is not supported. Issue https://github.com/iv-org/invidious-companion/issues/13

# Future potential work

- Have Invidious proxying the requests to Invidious companion in order to make it easier for beginners.

# How to try?

Official test docker image **for Invidious** with this branch "invidious-companion" is available at `quay.io/invidious/invidious:companion` and `quay.io/invidious/invidious:companion-arm64`

1. Run Invidious companion with a secret key: https://github.com/iv-org/invidious-companion?tab=readme-ov-file#run-locally
3. Configure Invidious companion in the config.yaml and with the same secret key:
````yaml
invidious_companion:
  - private_url: "http://localhost:8282"
    public_url: "http://localhost:8282"
invidious_companion_key: hoMyBeautifulKey
````
3. Run Invidious

# Fixes
- Fixes #2007 - youtube.js provide DASH files with multi audio support
- Fixes #4660 - youtube.js provide the captions
- Fixes #4977 - youtube oauth is available thanks to youtube.js
- Fixes #2720 - dash manifest generated works with ipadOS
- Will help and maybe may close #4734 - Any new issue around YouTube breaking the /player will know have to happen on https://github.com/iv-org/invidious-companion/issues
- To investigate: #2236 
- To investigate: #2564
- To investigate: #3021

# Related to
- #4838

# Notes

- docker build for arm64: `docker buildx build -f docker/Dockerfile.arm64 --platform=linux/arm64/v8 -t quay.io/invidious/invidious:companion-arm64 --push .`
- docker build for x86: `docker buildx build -f docker/Dockerfile --platform=linux/amd64 -t quay.io/invidious/invidious:companion --push .`