### PR TITLE
Makefile: Add MT option to enable the 'preview_mt' flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ STATIC   := 0
 
 NO_DBG_SYMBOLS := 0
 
+# Enable multi-threading.
+# Warning: Experimental feature!!
+# invidious is not stable when MT is enabled.
+MT := 0
+
 
 FLAGS ?=
 
@@ -17,6 +22,10 @@ endif
 
 ifeq ($(STATIC), 1)
   FLAGS += --static
+endif
+
+ifeq ($(MT), 1)
+  FLAGS += -Dpreview_mt
 endif
 
 


### PR DESCRIPTION
This PR add an `MT` option to the Makefile. \
When `make` is invoked with `MT=1`, the `preview_mt` flag is passed to the Crystal compiler.

It doesn't mean that invidious fully supports multi-threading, but at least it provides an easy way for trying that out.