### PR TITLE
Captions: Add "Filipino (auto-generated)" to the list of languages

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -286,6 +286,7 @@
     "Esperanto": "Esperanto",
     "Estonian": "Estonian",
     "Filipino": "Filipino",
+    "Filipino (auto-generated)": "Filipino (auto-generated)",
     "Finnish": "Finnish",
     "French": "French",
     "French (auto-generated)": "French (auto-generated)",

--- a/src/invidious/videos/caption.cr
+++ b/src/invidious/videos/caption.cr
@@ -123,6 +123,7 @@ module Invidious::Videos
       "Esperanto",
       "Estonian",
       "Filipino",
+      "Filipino (auto-generated)",
       "Finnish",
       "French",
       "French (auto-generated)",


### PR DESCRIPTION
I encountered a wild
```
[warn] i18n: Missing translation key "Filipino (auto-generated)"
```
while browsing videos on the test instance.