### PR TITLE
Bump CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,11 @@ jobs:
       matrix:
         stable: [true]
         crystal:
-          - 1.9.2
           - 1.10.1
           - 1.11.2
           - 1.12.1
+          - 1.13.2
+          - 1.14.0
         include:
           - crystal: nightly
             stable: false


### PR DESCRIPTION
Removes `1.9.2` due to incompatibility

Adds versions `1.13.2` and `1.14.0`