### PR TITLE
CI: Check Crystal lint only on latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
             shards install
           fi
 
-      - name: Run Crystal linter
+      - name: Check Crystal formatter compliance
         run: |
           if ! crystal tool format --check; then
             crystal tool format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install required APT packages
         run: |
-          sudo apt install -y libsqlite3-dev 
+          sudo apt install -y libsqlite3-dev
         shell: bash
 
       - name: Install Crystal
@@ -65,7 +65,9 @@ jobs:
       - name: Cache Shards
         uses: actions/cache@v3
         with:
-          path: ./lib
+          path: |
+            ./lib
+            ./bin
           key: shards-${{ hashFiles('shard.lock') }}
 
       - name: Install Shards
@@ -76,14 +78,6 @@ jobs:
 
       - name: Run tests
         run: crystal spec
-
-      - name: Run lint
-        run: |
-          if ! crystal tool format --check; then
-            crystal tool format
-            git diff
-            exit 1
-          fi
 
       - name: Build
         run: crystal build --warnings all --error-on-warnings --error-trace src/invidious.cr
@@ -130,8 +124,12 @@ jobs:
       - name: Test Docker
         run: while curl -Isf http://localhost:3000; do sleep 1; done
 
-  ameba_lint:
+  lint:
+
     runs-on: ubuntu-latest
+
+    continue-on-error: true
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -151,7 +149,18 @@ jobs:
           key: shards-${{ hashFiles('shard.lock') }}
 
       - name: Install Shards
-        run: shards install
+        run: |
+          if ! shards check; then
+            shards install
+          fi
+
+      - name: Run Crystal linter
+        run: |
+          if ! crystal tool format --check; then
+            crystal tool format
+            git diff
+            exit 1
+          fi
 
       - name: Run Ameba linter
         run: bin/ameba


### PR DESCRIPTION
Required for #5014

Run the linter against a single version of Crystal, as recommended by @straight-shoota in the Crystal Matrix room:

> I'd also suggest to run the formatter only against one version of the compiler. Formatter behaviour should not be expected to be forward compatible (we try to have at least one version overlap, but not necessarily more). So there might be a patch release for 1.14 to make it accept the trailing comma. But that won't be ported back to earlier versions.
>
> https://matrix.to/#/%23crystal-lang_crystal%3Agitter.im/%24_UuRZsBnmr5Q0OTQRiUaYDq1duOjXHZVfmoV3g0QJck?via=gitter.im&via=matrix.org&via=kde.org


I have also unified the way shards are installed and cached between the `build` and `lint` jobs to better use the cache.

Closes #5017