### PR TITLE
Add support for author thumbnails in search api for videos

### DIFF
--- a/src/invidious/helpers/serialized_yt_data.cr
+++ b/src/invidious/helpers/serialized_yt_data.cr
@@ -24,6 +24,7 @@ struct SearchVideo
   property length_seconds : Int32
   property premiere_timestamp : Time?
   property author_verified : Bool
+  property author_thumbnail : String?
   property badges : VideoBadges
 
   def to_xml(auto_generated, query_params, xml : XML::Builder)
@@ -87,6 +88,24 @@ struct SearchVideo
       json.field "authorId", self.ucid
       json.field "authorUrl", "/channel/#{self.ucid}"
       json.field "authorVerified", self.author_verified
+
+      author_thumbnail = self.author_thumbnail
+
+      if author_thumbnail
+        json.field "authorThumbnails" do
+          json.array do
+            qualities = {32, 48, 76, 100, 176, 512}
+
+            qualities.each do |quality|
+              json.object do
+                json.field "url", author_thumbnail.gsub(/=s\d+/, "=s#{quality}")
+                json.field "width", quality
+                json.field "height", quality
+              end
+            end
+          end
+        end
+      end
 
       json.field "videoThumbnails" do
         Invidious::JSONify::APIv1.thumbnails(json, self.id)
@@ -223,7 +242,7 @@ struct SearchChannel
 
           qualities.each do |quality|
             json.object do
-              json.field "url", self.author_thumbnail.gsub(/=\d+/, "=s#{quality}")
+              json.field "url", self.author_thumbnail.gsub(/=s\d+/, "=s#{quality}")
               json.field "width", quality
               json.field "height", quality
             end

--- a/src/invidious/routes/feeds.cr
+++ b/src/invidious/routes/feeds.cr
@@ -194,6 +194,7 @@ module Invidious::Routes::Feeds
         length_seconds:     0,
         premiere_timestamp: nil,
         author_verified:    false,
+        author_thumbnail:   nil,
         badges:             VideoBadges::None,
       })
     end

--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -67,6 +67,8 @@ private module Parsers
         author_id = author_fallback.id
       end
 
+      author_thumbnail = item_contents.dig?("channelThumbnailSupportedRenderers", "channelThumbnailWithLinkRenderer", "thumbnail", "thumbnails", 0, "url").try &.as_s
+
       author_verified = has_verified_badge?(item_contents["ownerBadges"]?)
 
       # For live videos (and possibly recently premiered videos) there is no published information.
@@ -148,6 +150,7 @@ private module Parsers
         length_seconds:     length_seconds,
         premiere_timestamp: premiere_timestamp,
         author_verified:    author_verified,
+        author_thumbnail:   author_thumbnail,
         badges:             badges,
       })
     end
@@ -579,6 +582,7 @@ private module Parsers
         length_seconds:     duration,
         premiere_timestamp: Time.unix(0),
         author_verified:    false,
+        author_thumbnail:   nil,
         badges:             VideoBadges::None,
       })
     end
@@ -708,6 +712,7 @@ private module Parsers
         length_seconds:     duration,
         premiere_timestamp: Time.unix(0),
         author_verified:    false,
+        author_thumbnail:   nil,
         badges:             VideoBadges::None,
       })
     end


### PR DESCRIPTION
This PR add support for parsing the author thumbnails for videos when using the search API.
It also fixes a bug with replacing thumbnails for channels in the search results.

closes https://github.com/iv-org/invidious/issues/4986
closes https://github.com/iv-org/invidious/issues/4896