### PR TITLE
Skip route if resp got closed by before handlers

### DIFF
--- a/src/invidious/helpers/handlers.cr
+++ b/src/invidious/helpers/handlers.cr
@@ -27,6 +27,7 @@ class Kemal::RouteHandler
   # Processes the route if it's a match. Otherwise renders 404.
   private def process_request(context)
     raise Kemal::Exceptions::RouteNotFound.new(context) unless context.route_found?
+    return if context.response.closed?
     content = context.route.handler.call(context)
 
     if !Kemal.config.error_handlers.empty? && Kemal.config.error_handlers.has_key?(context.response.status_code) && exclude_match?(context)


### PR DESCRIPTION
This is the culprit behind https://github.com/iv-org/invidious/pull/4259#issuecomment-1828573067

This is why we should avoid overrides... [the problem was fixed upstream in Kemal 5 years ago in 2019!](https://github.com/kemalcr/kemal/pull/550)