### PR TITLE
send query string instead of range http header

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -42,6 +42,15 @@ embed_url = location.origin + '/embed/' + video_data.id + embed_url.search;
 var save_player_pos_key = 'save_player_pos';
 
 videojs.Vhs.xhr.beforeRequest = function(options) {
+    if (options.uri.includes("videoplayback")) {
+        if (options.headers) {
+            if (options.headers.Range) {
+                options.uri += `&range=${options.headers.Range.split('=')[1]}`
+                delete options.headers.range
+            }
+        }
+    }
+
     // set local if requested not videoplayback
     if (!options.uri.includes('videoplayback')) {
         if (!options.uri.includes('local=true'))


### PR DESCRIPTION
Send the range using query string like the YouTube player do.

This avoids having to do some processing inside Invidious and just straight send the correct query string to YouTube servers.

Makes it easier to be compatible with other videoplayback proxies like [http3-ytproxy](https://github.com/TeamPiped/http3-ytproxy) or [piped-proxy](https://github.com/TeamPiped/piped-proxy). Especially the last one because piped only use query string now for the range.