### PR TITLE
CI: Drop support for versions prior to 1.12 and add 1.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,6 @@ jobs:
       matrix:
         stable: [true]
         crystal:
-          - 1.10.1
-          - 1.11.2
           - 1.12.1
           - 1.13.2
           - 1.14.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           - 1.12.1
           - 1.13.2
           - 1.14.0
+          - 1.15.0
         include:
           - crystal: nightly
             stable: false


### PR DESCRIPTION
The oldest version supported must now be 1.12 due to Kemal (#4575) and the usage of the `Enumerable#present?` property (#4985)