### PR TITLE
Comment out http_proxy in example config

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -178,11 +178,11 @@ https_only: false
 ##
 ## If unset, then no HTTP proxy will be used.
 ## 
-http_proxy:
-  user:
-  password:
-  host:
-  port:
+#http_proxy:
+#  user:
+#  password:
+#  host:
+#  port:
 
 
 ##


### PR DESCRIPTION
The http proxy config section wasn't commented out in the example config causing Invidious to error unless filled or commented out when copying config.example.yml to config.yml during a manual install