### PR TITLE
Pick a different instance upon redirect

### DIFF
--- a/src/invidious/routes/misc.cr
+++ b/src/invidious/routes/misc.cr
@@ -46,13 +46,13 @@ module Invidious::Routes::Misc
     if instance_list.empty?
       instance_url = redirect_url
     else
-      # Sample returns an array
-      # Instances are packaged as {region, domain} in the instance list
       # Filter out the current instance
       other_available_instances = instance_list.reject! { |region, domain| domain == CONFIG.domain }
 
       # If there are any other instances, select a random one
       if other_available_instances.any?
+        # Sample returns an array
+        # Instances are packaged as {region, domain} in the instance list
         instance_url = other_available_instances.sample(1)[0][1]
       else
         # If the current instance is the only one, use the redirect URL as fallback

--- a/src/invidious/routes/misc.cr
+++ b/src/invidious/routes/misc.cr
@@ -43,7 +43,7 @@ module Invidious::Routes::Misc
 
     instance_list = Invidious::Jobs::InstanceListRefreshJob::INSTANCES["INSTANCES"]
     # Filter out the current instance
-    other_available_instances = instance_list.reject! { |_, domain| domain == CONFIG.domain }
+    other_available_instances = instance_list.reject { |_, domain| domain == CONFIG.domain }
 
     if other_available_instances.empty?
       # If the current instance is the only one, use the redirect URL as fallback

--- a/src/invidious/routes/misc.cr
+++ b/src/invidious/routes/misc.cr
@@ -57,6 +57,7 @@ module Invidious::Routes::Misc
       else
         # If the current instance is the only one, use the redirect URL as fallback
         instance_url = redirect_url
+      end
     end
 
     env.redirect "https://#{instance_url}#{referer}"

--- a/src/invidious/routes/misc.cr
+++ b/src/invidious/routes/misc.cr
@@ -40,24 +40,19 @@ module Invidious::Routes::Misc
 
   def self.cross_instance_redirect(env)
     referer = get_referer(env)
-    redirect_url = "redirect.invidious.io"
 
     instance_list = Invidious::Jobs::InstanceListRefreshJob::INSTANCES["INSTANCES"]
-    if instance_list.empty?
-      instance_url = redirect_url
-    else
-      # Filter out the current instance
-      other_available_instances = instance_list.reject! { |region, domain| domain == CONFIG.domain }
+    # Filter out the current instance
+    other_available_instances = instance_list.reject! { |_, domain| domain == CONFIG.domain }
 
-      # If there are any other instances, select a random one
-      if other_available_instances.any?
-        # Sample returns an array
-        # Instances are packaged as {region, domain} in the instance list
-        instance_url = other_available_instances.sample(1)[0][1]
-      else
-        # If the current instance is the only one, use the redirect URL as fallback
-        instance_url = redirect_url
-      end
+    if other_available_instances.empty?
+      # If the current instance is the only one, use the redirect URL as fallback
+      instance_url = "redirect.invidious.io"
+    else
+      # Select other random instance
+      # Sample returns an array
+      # Instances are packaged as {region, domain} in the instance list
+      instance_url = other_available_instances.sample(1)[0][1]
     end
 
     env.redirect "https://#{instance_url}#{referer}"

--- a/src/invidious/routes/misc.cr
+++ b/src/invidious/routes/misc.cr
@@ -40,14 +40,23 @@ module Invidious::Routes::Misc
 
   def self.cross_instance_redirect(env)
     referer = get_referer(env)
+    redirect_url = "redirect.invidious.io"
 
     instance_list = Invidious::Jobs::InstanceListRefreshJob::INSTANCES["INSTANCES"]
     if instance_list.empty?
-      instance_url = "redirect.invidious.io"
+      instance_url = redirect_url
     else
       # Sample returns an array
       # Instances are packaged as {region, domain} in the instance list
-      instance_url = instance_list.sample(1)[0][1]
+      # Filter out the current instance
+      other_available_instances = instance_list.reject! { |region, domain| domain == CONFIG.domain }
+
+      # If there are any other instances, select a random one
+      if other_available_instances.any?
+        instance_url = other_available_instances.sample(1)[0][1]
+      else
+        # If the current instance is the only one, use the redirect URL as fallback
+        instance_url = redirect_url
     end
 
     env.redirect "https://#{instance_url}#{referer}"


### PR DESCRIPTION
Currently, the redirect url may redirect the user back to the same instance they are currently on.