### PR TITLE
fix /api/v1/videos/:id returns 200 with no content

### DIFF
--- a/src/invidious/jsonify/api_v1/video_json.cr
+++ b/src/invidious/jsonify/api_v1/video_json.cr
@@ -268,7 +268,7 @@ module Invidious::JSONify::APIv1
                 json.field "viewCountText", rv["short_view_count"]?
                 json.field "viewCount", rv["view_count"]?.try &.empty? ? nil : rv["view_count"].to_i64
                 json.field "published", rv["published"]?
-                if !rv["published"]?.nil?
+                if rv["published"]?.try &.presence
                   json.field "publishedText", translate(locale, "`x` ago", recode_date(Time.parse_rfc3339(rv["published"].to_s), locale))
                 else
                   json.field "publishedText", ""


### PR DESCRIPTION
fixes #5161 by checking recommended videos published field for presence before attempting to parse it in api

Tested by checking random videos on `/api/v1/videos/`. Where a request would normally fail it now correctly returns an empty published field on an offending recommended video.

```
http get https://invidious.lab/api/v1/videos/Cxjn16rNd0k | jq .recommendedVideos[].published
"2024-02-29T02:43:22Z"
"2025-01-26T02:43:22Z"
"2025-01-28T02:43:22Z"
"2025-01-28T14:43:22Z"
"2025-01-28T21:43:22Z"
"2024-12-29T02:43:22Z"
"2024-02-29T02:43:22Z"
"2024-12-29T02:43:22Z"
""
"2024-01-29T02:43:22Z"
"2024-05-29T02:43:22Z"
"2025-01-28T22:43:22Z"
"2024-01-29T02:43:22Z"
"2025-01-28T22:43:22Z"
"2025-01-28T16:43:22Z"
"2025-01-28T20:43:22Z"
"2025-01-15T02:43:22Z"
"2025-01-15T02:43:22Z"
"2025-01-26T02:43:22Z"
"2021-01-29T02:43:22Z"
```