### PR TITLE
Fix an issue with the HLS manifest check for livestream videos

### DIFF
--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -4,7 +4,7 @@
     <% if params.autoplay %>autoplay<% end %>
     <% if params.video_loop %>loop<% end %>
     <% if params.controls %>controls<% end %>>
-    <% if (hlsvp = video.hls_manifest_url) && !CONFIG.disabled?("livestreams") %>
+    <% if (hlsvp = video.hls_manifest_url) && video.live_now && !CONFIG.disabled?("livestreams") %>
         <source src="<%= URI.parse(hlsvp).request_target %><% if params.local %>?local=true<% end %>" type="application/x-mpegURL" label="livestream">
     <% else %>
         <% if params.listen %>


### PR DESCRIPTION
Originally, the HLS manifest check was essentially a boolean: if the HLS manifest field was present, it was assumed to be a livestream. Some videos include the HLS Manifest but aren't livestreams.
    
In the case where they are livestreams, the video contains a videoType field with the value "Livestream". In the case that they're normal videos, the videoType is "Video". This is exposed via the video.live_now method.
    
This commit just checks that video.live_now is true before treating it as a livestream