### PR TITLE
require base_job before the other jobs

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -49,7 +49,8 @@ require "./invidious/channels/*"
 require "./invidious/user/*"
 require "./invidious/search/*"
 require "./invidious/routes/**"
-require "./invidious/jobs/**"
+require "./invidious/jobs/base_job"
+require "./invidious/jobs/*"
 
 # Declare the base namespace for invidious
 module Invidious


### PR DESCRIPTION
The crystal compiler seems to evaluate `require` in an alphabetical way, so if anyone in the future, wants to add another job and that job is above `base_job.cr` in alphabetical order, the compiler is going to fail with `Error: undefined constant: Invidious::Jobs::BaseJob`.

This doesn't fix anything, but it will prevent a future headache.

![image](https://github.com/user-attachments/assets/f392d0b8-5e7c-4807-9a8b-02b1077a3864)
