### PR TITLE
feat: add option to change username

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -501,5 +501,11 @@
     "toggle_theme": "Toggle Theme",
     "carousel_slide": "Slide {{current}} of {{total}}",
     "carousel_skip": "Skip the Carousel",
-    "carousel_go_to": "Go to slide `x`"
+    "carousel_go_to": "Go to slide `x`",
+    "new_username": "New username",
+    "change_username": "Change username",
+    "username_required_field": "Username is a required field",
+    "username_empty": "Username cannot be empty",
+    "username_is_the_same": "This is your username, use another one",
+    "username_taken": "Username is already taken, use another one"
 }

--- a/src/invidious/database/users.cr
+++ b/src/invidious/database/users.cr
@@ -214,6 +214,13 @@ module Invidious::Database::Users
     PG_DB.exec(request, username, user.email)
   end
 
+  def update_user_materialized_view(user : User, username : String)
+    view_name = "public.subscriptions_#{sha256(user.email)}"
+    new_view_name = "subscriptions_#{sha256(username)}"
+
+    PG_DB.exec("ALTER MATERIALIZED VIEW #{view_name} RENAME TO #{new_view_name}")
+  end
+
   # -------------------
   #  Select
   # -------------------

--- a/src/invidious/database/users.cr
+++ b/src/invidious/database/users.cr
@@ -184,6 +184,36 @@ module Invidious::Database::Users
     PG_DB.exec(request, pass, user.email)
   end
 
+  def update_username(user : User, username : String)
+    request = <<-SQL
+      UPDATE users
+      SET email = $1
+      WHERE email = $2
+    SQL
+
+    PG_DB.exec(request, username, user.email)
+  end
+
+  def update_user_session_id(user : User, username : String)
+    request = <<-SQL
+      UPDATE session_ids
+      SET email = $1
+      WHERE email = $2
+    SQL
+
+    PG_DB.exec(request, username, user.email)
+  end
+
+  def update_user_playlists_author(user : User, username : String)
+    request = <<-SQL
+      UPDATE playlists
+      SET author = $1
+      WHERE author = $2
+    SQL
+
+    PG_DB.exec(request, username, user.email)
+  end
+
   # -------------------
   #  Select
   # -------------------

--- a/src/invidious/routes/account.cr
+++ b/src/invidious/routes/account.cr
@@ -143,6 +143,7 @@ module Invidious::Routes::Account
     Invidious::Database::Users.update_username(user, new_username.to_s)
     Invidious::Database::Users.update_user_session_id(user, new_username.to_s)
     Invidious::Database::Users.update_user_playlists_author(user, new_username.to_s)
+    Invidious::Database::Users.update_user_materialized_view(user, new_username.to_s)
 
     env.redirect referer
   end

--- a/src/invidious/routes/account.cr
+++ b/src/invidious/routes/account.cr
@@ -79,6 +79,75 @@ module Invidious::Routes::Account
   end
 
   # -------------------
+  #  Username update
+  # -------------------
+
+  # Show the username change interface (GET request)
+  def get_change_username(env)
+    locale = env.get("preferences").as(Preferences).locale
+
+    user = env.get? "user"
+    sid = env.get? "sid"
+    referer = get_referer(env)
+
+    if !user
+      return env.redirect referer
+    end
+
+    user = user.as(User)
+    sid = sid.as(String)
+    csrf_token = generate_response(sid, {":change_username"}, HMAC_KEY)
+
+    templated "user/change_username"
+  end
+
+  # Handle the username change (POST request)
+  def post_change_username(env)
+    locale = env.get("preferences").as(Preferences).locale
+
+    user = env.get? "user"
+    sid = env.get? "sid"
+    referer = get_referer(env)
+
+    if !user
+      return env.redirect referer
+    end
+
+    user = user.as(User)
+    sid = sid.as(String)
+    token = env.params.body["csrf_token"]?
+
+    begin
+      validate_request(token, sid, env.request, HMAC_KEY, locale)
+    rescue ex
+      return error_template(400, ex)
+    end
+
+    new_username = env.params.body["new_username"]?
+    if new_username.nil?
+      return error_template(401, "username_required_field")
+    end
+
+    if new_username.empty?
+      return error_template(401, "username_empty")
+    end
+
+    if new_username == user.email
+      return error_template(401, "username_is_the_same")
+    end
+
+    if Invidious::Database::Users.select(email: new_username)
+      return error_template(401, "username_taken")
+    end
+
+    Invidious::Database::Users.update_username(user, new_username.to_s)
+    Invidious::Database::Users.update_user_session_id(user, new_username.to_s)
+    Invidious::Database::Users.update_user_playlists_author(user, new_username.to_s)
+
+    env.redirect referer
+  end
+
+  # -------------------
   #  Account deletion
   # -------------------
 

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -68,6 +68,8 @@ module Invidious::Routing
     # User account management
     get "/change_password", Routes::Account, :get_change_password
     post "/change_password", Routes::Account, :post_change_password
+    get "/change_username", Routes::Account, :get_change_username
+    post "/change_username", Routes::Account, :post_change_username
     get "/delete_account", Routes::Account, :get_delete
     post "/delete_account", Routes::Account, :post_delete
     get "/clear_watch_history", Routes::Account, :get_clear_history

--- a/src/invidious/views/user/change_username.ecr
+++ b/src/invidious/views/user/change_username.ecr
@@ -1,0 +1,26 @@
+<% content_for "header" do %>
+<title><%= translate(locale, "change_username") %> - Invidious</title>
+<% end %>
+
+<div class="pure-g">
+    <div class="pure-u-1 pure-u-lg-1-5"></div>
+    <div class="pure-u-1 pure-u-lg-3-5">
+        <div class="h-box">
+            <form class="pure-form pure-form-aligned" action="/change_username?referer=<%= URI.encode_www_form(referer) %>" method="post">
+                <legend><%= translate(locale, "") %></legend>
+
+                <fieldset>
+                    <label for="new_username"><%= translate(locale, "new_username") %> :</label>
+                    <input required class="pure-input-1" name="new_username" type="text" placeholder="<%= translate(locale, "new_username") %>">
+
+                    <button type="submit" name="action" value="change_username" class="pure-button pure-button-primary">
+                        <%= translate(locale, "change_username") %>
+                    </button>
+
+                    <input type="hidden" name="csrf_token" value="<%= HTML.escape(csrf_token) %>">
+                </fieldset>
+            </form>
+        </div>
+    </div>
+    <div class="pure-u-1 pure-u-lg-1-5"></div>
+</div>

--- a/src/invidious/views/user/preferences.ecr
+++ b/src/invidious/views/user/preferences.ecr
@@ -331,6 +331,10 @@
                 </div>
 
                 <div class="pure-control-group">
+                    <a href="/change_username?referer=<%= URI.encode_www_form(referer) %>"><%= translate(locale, "change_username") %></a>
+                </div>
+
+                <div class="pure-control-group">
                     <a href="/data_control?referer=<%= URI.encode_www_form(referer) %>"><%= translate(locale, "Import/export data") %></a>
                 </div>
 


### PR DESCRIPTION
Tested and it works fine. I made this for people that want to change their username on public Invidious instance without having to create a new account or having to contact the instance maintainer to change their username. It also updates the materialized views sha256 ids, so if a user changed their account name from `user` to `user2` and a new user registers on the instance with the `username`, there shouldn't be a relation collision (when the collision happens, this is displayed: `relation "subscriptions_sha256" already exists`)

Tested:

- Changing username from `user1` to `user2`, subscriptions are maintained across username changes
- Playlist author (for Invidious playlists) updated on username change.
- Changing the username from `user2` to `user1` works well.
- If the user tries to change their username to one that already exists on the database, a "Username is already taken, use another one" will be returned. (Although someone can still register or change their username with an already taken username but with a slight unnoticeable SPACE character on it, it's possible to have a user called `user1` and `user1 `)

