### PR TITLE
chore: set dash by default

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -858,9 +858,9 @@ default_user_preferences:
   ## Default video quality.
   ##
   ## Accepted values: dash, hd720, medium, small
-  ## Default: hd720
+  ## Default: dash
   ##
-  #quality: hd720
+  #quality: dash
 
   ##
   ## Default dash video quality.

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -35,7 +35,7 @@ struct ConfigPreferences
   property max_results : Int32 = 40
   property notifications_only : Bool = false
   property player_style : String = "invidious"
-  property quality : String = "hd720"
+  property quality : String = "dash"
   property quality_dash : String = "auto"
   property default_home : String? = "Popular"
   property feed_menu : Array(String) = ["Popular", "Trending", "Subscriptions", "Playlists"]


### PR DESCRIPTION
Related to https://github.com/iv-org/invidious/issues/4847

The last remaining non dash format is 360p which is horrible to watch. This PR switches to DASH.

This is important because a user by default needs to get a good user experience, and just having a very low video format is unacceptable. Also, having to dig into the docs in order to understand how to get a better video quality is unacceptable too.