### PR TITLE
feat: route to invidious companion on downloads

### DIFF
--- a/src/invidious/frontend/watch_page.cr
+++ b/src/invidious/frontend/watch_page.cr
@@ -23,10 +23,16 @@ module Invidious::Frontend::WatchPage
       return "<p id=\"download\">#{translate(locale, "Download is disabled")}</p>"
     end
 
+    url = "/download"
+    if (CONFIG.invidious_companion.present?)
+      invidious_companion = CONFIG.invidious_companion.sample
+      url = "#{invidious_companion.public_url}/download?check=#{invidious_companion_encrypt(video.id)}"
+    end
+
     return String.build(4000) do |str|
       str << "<form"
       str << " class=\"pure-form pure-form-stacked\""
-      str << " action='/download'"
+      str << " action='#{url}'"
       str << " method='post'"
       str << " rel='noopener'"
       str << " target='_blank'>"

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -293,6 +293,9 @@ module Invidious::Routes::Watch
     if CONFIG.disabled?("downloads")
       return error_template(403, "Administrator has disabled this endpoint.")
     end
+    if CONFIG.invidious_companion.present?
+      return error_template(403, "Downloads should be routed through Companion when present")
+    end
 
     title = env.params.body["title"]? || ""
     video_id = env.params.body["id"]? || ""
@@ -328,13 +331,7 @@ module Invidious::Routes::Watch
       env.params.query["title"] = filename
       env.params.query["local"] = "true"
 
-      if (CONFIG.invidious_companion.present?)
-        video = get_video(video_id)
-        invidious_companion = CONFIG.invidious_companion.sample
-        return env.redirect "#{invidious_companion.public_url}/latest_version?#{env.params.query}"
-      else
-        return Invidious::Routes::VideoPlayback.latest_version(env)
-      end
+      return Invidious::Routes::VideoPlayback.latest_version(env)
     else
       return error_template(400, "Invalid label or itag")
     end


### PR DESCRIPTION
This sets the download URL to invidious companion (as enabled in https://github.com/iv-org/invidious-companion/pull/41) when companion is used.

There is a secondary way of approaching this - proxying the download through invidious. However, it looks like the `CompanionConnectionPool` is set up to only have a short timeout, and a download endpoint will need to allow for long requests.

Note that this approach embeds the companion URL in the page, which means the `check` param would eventually expire. It looks like that's 6 hours though, so I'm not sure that's too much of a concern.


There's also a couple of extra bits needed in companion to make this work well, all in https://github.com/iv-org/invidious-companion/pull/95  
That PR does 2 things:
1. chunks up downloads so that companion isn't throttled by youtube servers
2. ensures the `check` query param is passed on to the `latestVersion` call that's made so that it doesn't error out.

Without that PR merged, this still works, but only if `verify_request` is `false` in invidious-companion. 

Addresses https://github.com/iv-org/invidious/issues/5218