### PR TITLE
fix: restore dmca_content functionality

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -501,5 +501,6 @@
     "toggle_theme": "Toggle Theme",
     "carousel_slide": "Slide {{current}} of {{total}}",
     "carousel_skip": "Skip the Carousel",
-    "carousel_go_to": "Go to slide `x`"
+    "carousel_go_to": "Go to slide `x`",
+    "dmca_content": "Sorry, this video cannot be played on this instance due to a DMCA/copyright infringement letter sent to the instance administrator."
 }

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -30,6 +30,10 @@ module Invidious::Routes::Watch
       return env.redirect "/"
     end
 
+    if CONFIG.dmca_content.includes?(id)
+      return error_template(403, "dmca_content")
+    end
+
     plid = env.params.query["list"]?.try &.gsub(/[^a-zA-Z0-9_-]/, "")
     continuation = process_continuation(env.params.query, plid, id)
 


### PR DESCRIPTION
This restores (or adds) the functionality of the `dmca_content` config option that at this date, has been unused and makes no effect.

I prefer to leave it enabled only for the frontend, I'm not sure about the API, so tell me what do you guys (iv-org) prefer