### PR TITLE
Update images in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,20 @@
 
 
 ## Screenshots
+| Player                              |
+|-------------------------------------|
+| ![](screenshots/01_player.png)      |
+| ![](screenshots/04_description.png) |
 
-| Player                              | Preferences                         | Subscriptions                         |
-|-------------------------------------|-------------------------------------|---------------------------------------|
-| ![](screenshots/01_player.png)      | ![](screenshots/02_preferences.png) | ![](screenshots/03_subscriptions.png) |
-| ![](screenshots/04_description.png) | ![](screenshots/05_preferences.png) | ![](screenshots/06_subscriptions.png) |
+| Preferences                         |
+|-------------------------------------|
+| ![](screenshots/02_preferences.png) |
+| ![](screenshots/05_preferences.png) |
 
+| Subscriptions                         |
+|---------------------------------------|
+| ![](screenshots/03_subscriptions.png) |
+| ![](screenshots/06_subscriptions.png) |
 
 ## Features
 


### PR DESCRIPTION
I noticed that the images are hard to look at on desktop because they are presented in multiple columns (on mobile its even worse). Someone that is skimming through the README probably doesnt want to open allot of tabs to look at the images in more detail. 

I split the big table up into three separate ones so that its easier to see the image contents on both desktop and mobile

See how it looks like here: https://github.com/efb4f5ff-1298-471a-8973-3d47447115dc/invidious/tree/patch-1?tab=readme-ov-file#screenshots