### PR TITLE
initial base_url companion support + proxy companion

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -75,7 +75,7 @@ db:
 ## If you are using a reverse proxy then you will probably need to
 ## configure the public_url to be the same as the domain used for Invidious.
 ## Also apply when used from an external IP address (without a domain).
-## Examples: https://MYINVIDIOUSDOMAIN or http://192.168.1.100:8282
+## Examples: https://MYINVIDIOUSDOMAIN/companion or http://192.168.1.100:8282/companion
 ##
 ## Both parameter can have identical URL when Invidious is hosted in
 ## an internal network or at home or locally (localhost).
@@ -84,8 +84,8 @@ db:
 ## Default: <none>
 ##
 #invidious_companion:
-#  - private_url: "http://localhost:8282"
-#    public_url: "http://localhost:8282"
+#  - private_url: "http://localhost:8282/companion"
+#    public_url: "http://localhost:8282/companion"
 
 ##
 ## API key for Invidious companion, used for securing the communication

--- a/src/invidious/routes/companion.cr
+++ b/src/invidious/routes/companion.cr
@@ -1,0 +1,37 @@
+module Invidious::Routes::Companion
+  # /companion
+  def self.get_companion(env)
+    url = env.request.path.lchop("/companion")
+
+    begin
+      COMPANION_POOL.client &.get(url, env.request.header) do |resp|
+        return self.proxy_companion(env, resp)
+      end
+    rescue ex
+    end
+  end
+
+  def self.options_companion(env)
+    url = env.request.path.lchop("/companion")
+
+    begin
+      COMPANION_POOL.client &.options(url, env.request.header) do |resp|
+        return self.proxy_companion(env, resp)
+      end
+    rescue ex
+    end
+  end
+
+  private def self.proxy_companion(env, response)
+    env.response.status_code = response.status_code
+    response.headers.each do |key, value|
+      env.response.headers[key] = value
+    end
+
+    if response.status_code >= 300
+      return env.response.headers.delete("Transfer-Encoding")
+    end
+
+    return proxy_file(response, env)
+  end
+end

--- a/src/invidious/routes/embed.cr
+++ b/src/invidious/routes/embed.cr
@@ -205,10 +205,14 @@ module Invidious::Routes::Embed
 
     if CONFIG.invidious_companion.present?
       invidious_companion = CONFIG.invidious_companion.sample
+      invidious_companion_urls = CONFIG.invidious_companion.map do |companion|
+        uri =
+          "#{companion.public_url.scheme}://#{companion.public_url.host}#{companion.public_url.port ? ":#{companion.public_url.port}" : ""}"
+      end.join(" ")
       env.response.headers["Content-Security-Policy"] =
         env.response.headers["Content-Security-Policy"]
-          .gsub("media-src", "media-src #{invidious_companion.public_url}")
-          .gsub("connect-src", "connect-src #{invidious_companion.public_url}")
+          .gsub("media-src", "media-src #{invidious_companion_urls}")
+          .gsub("connect-src", "connect-src #{invidious_companion_urls}")
     end
 
     rendered "embed"

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -194,10 +194,14 @@ module Invidious::Routes::Watch
 
     if CONFIG.invidious_companion.present?
       invidious_companion = CONFIG.invidious_companion.sample
+      invidious_companion_urls = CONFIG.invidious_companion.map do |companion|
+        uri =
+          "#{companion.public_url.scheme}://#{companion.public_url.host}#{companion.public_url.port ? ":#{companion.public_url.port}" : ""}"
+      end.join(" ")
       env.response.headers["Content-Security-Policy"] =
         env.response.headers["Content-Security-Policy"]
-          .gsub("media-src", "media-src #{invidious_companion.public_url}")
-          .gsub("connect-src", "connect-src #{invidious_companion.public_url}")
+          .gsub("media-src", "media-src #{invidious_companion_urls}")
+          .gsub("connect-src", "connect-src #{invidious_companion_urls}")
     end
 
     templated "watch"

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -188,7 +188,7 @@ module Invidious::Routing
   end
 
   # -------------------
-  #  Media proxy routes
+  #  Proxy routes
   # -------------------
 
   def register_api_manifest_routes
@@ -221,6 +221,13 @@ module Invidious::Routing
     get "/s_p/:id/:name", Routes::Images, :s_p_image
     get "/yts/img/:name", Routes::Images, :yts_image
     get "/vi/:id/:name", Routes::Images, :thumbnails
+  end
+
+  def register_companion_routes
+    if CONFIG.invidious_companion.present?
+      get "/companion/*", Routes::Companion, :get_companion
+      options "/companion/*", Routes::Companion, :options_companion
+    end
   end
 
   # -------------------

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -695,22 +695,28 @@ module YoutubeAPI
     # Send the POST request
 
     begin
-      response = COMPANION_POOL.client &.post(endpoint, headers: headers, body: data.to_json)
-      body = response.body
-      if (response.status_code != 200)
-        raise Exception.new(
-          "Error while communicating with Invidious companion: \
-          status code: #{response.status_code} and body: #{body.dump}"
-        )
+      response_body = ""
+
+      COMPANION_POOL.client do |wrapper|
+        companion_base_url = wrapper.companion.private_url.path
+        puts "Using companion: #{wrapper.companion.private_url}"
+
+        response = wrapper.client.post(companion_base_url + endpoint, headers: headers, body: data.to_json)
+        response_body = response.body
+
+        if response.status_code != 200
+          raise Exception.new(
+            "Error while communicating with Invidious companion: " \
+            "status code: #{response.status_code} and body: #{response_body.dump}"
+          )
+        end
       end
+
+      # Convert result to Hash
+      return JSON.parse(response_body).as_h
     rescue ex
       raise InfoException.new("Error while communicating with Invidious companion: " + (ex.message || "no extra info found"))
     end
-
-    # Convert result to Hash
-    initial_data = JSON.parse(body).as_h
-
-    return initial_data
   end
 
   ####################################################################


### PR DESCRIPTION
Explained what I want to implement: https://github.com/iv-org/invidious-companion/issues/118#issuecomment-2840387298

And support proxying the requests to invidious companion from invidious: https://github.com/iv-org/invidious/issues/5215 in order to ease the deployment of invidious + companion.

## TODO
- [ ] Allow the ability to omit "public_url" in "invidious_companion" config for activating the built-in proxy in invidious.
- [ ] Fix the built-in proxy
- [ ] Re-review if the way of accessing the chosen invidious_companion created from the COMPANION_POOL is a correct way.