### PR TITLE
fix: pass user to `query.process` if present.

### DIFF
--- a/src/invidious/routes/search.cr
+++ b/src/invidious/routes/search.cr
@@ -58,7 +58,11 @@ module Invidious::Routes::Search
       end
 
       begin
-        items = query.process
+        if user
+          items = query.process(user.as(User))
+        else
+          items = query.process
+        end
       rescue ex : ChannelSearchException
         return error_template(404, "Unable to find channel with id of '#{HTML.escape(ex.channel)}'. Are you sure that's an actual channel id? It should look like 'UC4QobU6STFB0P71PMvOGN5A'.")
       rescue ex


### PR DESCRIPTION
Fixes https://github.com/iv-org/invidious/issues/5097

Using `subscriptions:true Touhou` pulls the videos that match "Touhou", "touhou" or "TouHou" in the title (case insensitive) from the subscriptions materialized view of the registered user.

![image](https://github.com/user-attachments/assets/f4b9f3e5-b9ad-4e93-845a-da4a75028be7)
