### PR TITLE
fix: safely access "label" key

### DIFF
--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -115,7 +115,7 @@ private module Parsers
       badges = VideoBadges::None
       item_contents["badges"]?.try &.as_a.each do |badge|
         b = badge["metadataBadgeRenderer"]
-        case b["label"].as_s
+        case b["label"]?.try &.as_s
         when "LIVE"
           badges |= VideoBadges::LiveNow
         when "New"


### PR DESCRIPTION
Fixes https://github.com/iv-org/invidious/issues/5095

On some videos, `label` is missing from the video information. Invidious assumed that the `label` key existed.

Videos with label have this inside `metadataBadgeRenderer`:

```
{"style" => "BADGE_STYLE_TYPE_SIMPLE",
 "label" => "4K",
 "trackingParams" => "COMDENwwGAoiEwiCrebe6JWNAxWIxz8EHSQRFTU="}
```

but other videos, for some reason, look like this:

```
{"icon" => {"iconType" => "PERSON_RADAR"},
 "style" => "BADGE_STYLE_TYPE_SIMPLE",
 "trackingParams" => "CM4DENwwGAsiEwiCrebe6JWNAxWIxz8EHSQRFTU="}
```

~~As said in https://github.com/iv-org/invidious/issues/5095#issuecomment-2865418366, the labels seems to be stored somewhere else, so this fix is more like a lazy fix, but I'll leave it here just in case.~~ Read https://github.com/iv-org/invidious/pull/5282#issuecomment-2867722820