### PR TITLE
Add missing javascript licenses

### DIFF
--- a/src/invidious/views/licenses.ecr
+++ b/src/invidious/views/licenses.ecr
@@ -302,6 +302,90 @@
                 <a href="/js/watch.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
             </td>
         </tr>
+
+        <tr>
+            <td>
+                <a href="/js/comments.js?v=<%= ASSET_COMMIT %>">comments.js</a>
+            </td>
+
+            <td>
+                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
+            </td>
+
+            <td>
+                <a href="/js/comments.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
+            </td>
+        </tr>
+
+        <tr>
+            <td>
+                <a href="/js/pagination.js?v=<%= ASSET_COMMIT %>">pagination.js</a>
+            </td>
+
+            <td>
+                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
+            </td>
+
+            <td>
+                <a href="/js/pagination.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
+            </td>
+        </tr>
+
+        <tr>
+            <td>
+                <a href="/js/playlist_widget.js?v=<%= ASSET_COMMIT %>">playlist_widget.js</a>
+            </td>
+
+            <td>
+                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
+            </td>
+
+            <td>
+                <a href="/js/playlist_widget.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
+            </td>
+        </tr>
+
+        <tr>
+            <td>
+                <a href="/js/post.js?v=<%= ASSET_COMMIT %>">post.js</a>
+            </td>
+
+            <td>
+                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
+            </td>
+
+            <td>
+                <a href="/js/post.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
+            </td>
+        </tr>
+
+        <tr>
+            <td>
+                <a href="/js/watched_indicator.js?v=<%= ASSET_COMMIT %>">watched_indicator.js</a>
+            </td>
+
+            <td>
+                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
+            </td>
+
+            <td>
+                <a href="/js/watched_indicator.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
+            </td>
+        </tr>
+
+        <tr>
+            <td>
+                <a href="/js/watched_widget.js?v=<%= ASSET_COMMIT %>">watched_widget.js</a>
+            </td>
+
+            <td>
+                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
+            </td>
+
+            <td>
+                <a href="/js/watched_widget.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
+            </td>
+        </tr>
     </table>
 </body>
 </html>


### PR DESCRIPTION
LibreJS is not able to load those JS files since they are missing in the licenses page. I will assume those JavaScript files were submitted under AGPL-3.0 at the time of being committed by the author, just like most of the JavaScript that was created/modified by Invidious contributors.