### PR TITLE
Add Javascript licence information automatically

### DIFF
--- a/scripts/generate_js_licenses.cr
+++ b/scripts/generate_js_licenses.cr
@@ -1,0 +1,56 @@
+# This file automatically generates Crystal strings of rows within an HTML Javascript licenses table
+#
+# These strings will then be placed within a `<%= %>` statement in licenses.ecr at compile time which
+# will be interpolated at run-time. This interpolation is only for the translation of the "source" string
+# so maybe we can just switch to a non-translated string to simplify the logic here.
+#
+# The Javascript Web Labels table defined at https://www.gnu.org/software/librejs/free-your-javascript.html#step3
+# for example just reiterates the name of the source file rather than use a "source" string.
+all_javascript_files = Dir.glob("assets/**/*.js")
+
+videojs_js = [] of String
+invidious_js = [] of String
+
+all_javascript_files.each do |js_path|
+  if js_path.starts_with?("assets/videojs/")
+    videojs_js << js_path[7..]
+  else
+    invidious_js << js_path[7..]
+  end
+end
+
+def create_licence_tr(path, file_name, licence_name, licence_link, source_location)
+  tr = <<-HTML
+    "<tr>
+    <td><a href=\\"/#{path}\\">#{file_name}</a></td>
+    <td><a href=\\"#{licence_link}\\">#{licence_name}</a></td>
+    <td><a href=\\"#{source_location}\\">\#{translate(locale, "source")}</a></td>
+    </tr>"
+    HTML
+
+  # New lines are removed as to allow for using String.join and StringLiteral.split
+  # to get a clean list of each table row.
+  tr.gsub('\n', "")
+end
+
+# TODO Use videojs-dependencies.yml to generate license info for videojs javascript
+jslicence_table_rows = [] of String
+
+invidious_js.each do |path|
+  file_name = path.split('/')[-1]
+
+  # A couple non Invidious JS files are also shipped alongside Invidious due to various reasons
+  next if {
+            "sse.js", "silvermine-videojs-quality-selector.min.js", "videojs-youtube-annotations.min.js",
+          }.includes?(file_name)
+
+  jslicence_table_rows << create_licence_tr(
+    path: path,
+    file_name: file_name,
+    licence_name: "AGPL-3.0",
+    licence_link: "https://www.gnu.org/licenses/agpl-3.0.html",
+    source_location: path
+  )
+end
+
+puts jslicence_table_rows.join("\n")

--- a/src/invidious/views/licenses.ecr
+++ b/src/invidious/views/licenses.ecr
@@ -11,90 +11,6 @@
     <table id="jslicense-labels1">
         <tr>
             <td>
-                <a href="/js/_helpers.js?v=<%= ASSET_COMMIT %>">_helpers.js</a>
-            </td>
-
-            <td>
-                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
-            </td>
-
-            <td>
-                <a href="/js/_helpers.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
-            </td>
-        </tr>
-
-        <tr>
-            <td>
-                <a href="/js/handlers.js?v=<%= ASSET_COMMIT %>">handlers.js</a>
-            </td>
-
-            <td>
-                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
-            </td>
-
-            <td>
-                <a href="/js/handlers.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
-            </td>
-        </tr>
-
-        <tr>
-            <td>
-                <a href="/js/community.js?v=<%= ASSET_COMMIT %>">community.js</a>
-            </td>
-
-            <td>
-                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
-            </td>
-
-            <td>
-                <a href="/js/community.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
-            </td>
-        </tr>
-
-        <tr>
-            <td>
-                <a href="/js/embed.js?v=<%= ASSET_COMMIT %>">embed.js</a>
-            </td>
-
-            <td>
-                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
-            </td>
-
-            <td>
-                <a href="/js/embed.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
-            </td>
-        </tr>
-
-        <tr>
-            <td>
-                <a href="/js/notifications.js?v=<%= ASSET_COMMIT %>">notifications.js</a>
-            </td>
-
-            <td>
-                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
-            </td>
-
-            <td>
-                <a href="/js/notifications.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
-            </td>
-        </tr>
-
-        <tr>
-            <td>
-                <a href="/js/player.js?v=<%= ASSET_COMMIT %>">player.js</a>
-            </td>
-
-            <td>
-                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
-            </td>
-
-            <td>
-                <a href="/js/player.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
-            </td>
-        </tr>
-
-        <tr>
-            <td>
                 <a href="/js/silvermine-videojs-quality-selector.min.js?v=<%= ASSET_COMMIT %>">silvermine-videojs-quality-selector.min.js</a>
             </td>
 
@@ -118,34 +34,6 @@
 
             <td>
                 <a href="https://github.com/mpetazzoni/sse.js"><%= translate(locale, "source") %></a>
-            </td>
-        </tr>
-
-        <tr>
-            <td>
-                <a href="/js/subscribe_widget.js?v=<%= ASSET_COMMIT %>">subscribe_widget.js</a>
-            </td>
-
-            <td>
-                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
-            </td>
-
-            <td>
-                <a href="/js/subscribe_widget.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
-            </td>
-        </tr>
-
-        <tr>
-            <td>
-                <a href="/js/themes.js?v=<%= ASSET_COMMIT %>">themes.js</a>
-            </td>
-
-            <td>
-                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
-            </td>
-
-            <td>
-                <a href="/js/themes.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
             </td>
         </tr>
 
@@ -289,19 +177,9 @@
             </td>
         </tr>
 
-        <tr>
-            <td>
-                <a href="/js/watch.js?v=<%= ASSET_COMMIT %>">watch.js</a>
-            </td>
-
-            <td>
-                <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>
-            </td>
-
-            <td>
-                <a href="/js/watch.js?v=<%= ASSET_COMMIT %>"><%= translate(locale, "source") %></a>
-            </td>
-        </tr>
+        <%- {% for row in run("../../../scripts/generate_js_licenses.cr").stringify.split('\n') %} %>
+            <%-= {{row.id}} -%>
+        <% {% end %} -%>
     </table>
 </body>
 </html>


### PR DESCRIPTION
This commit automates the process of documenting the licenses of Invidious Javascript files through a compile time macro in the licenses.ecr template file.

The script it calls is much smaller and does not depend on external IO so Invidious' compile-time is not impacted significantly. 

This should hopefully help keep the licence documentation up-to-date and allow extensions like LibreJS to always be able to load the latest Javascript files of Invidious.

Currently only Invidious's first-party Javascript files are supported. In the future it should be possible to leverage videojs-dependencies.yml to automatically document the Javascript licenses for VideoJS and co. as well.

This should be merged after #5292

<img src="https://github.com/user-attachments/assets/9ffe47d9-6c2e-4f4a-ba49-1ef4226dd7ef" width=500 alt="Screenshot of Invidious' /licenses page with this PR"></img>

