### PR TITLE
Add ability to view video transcripts to the Invidious frontend

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -833,3 +833,45 @@ h1, h2, h3, h4, h5, p,
 .description-show-transcript-widget > * {
   margin: 0;
 }
+
+.video-transcript {
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
+  height: 30em;
+  padding: 10px;
+  border: 1px solid #a0a0a0;
+  border-radius: 10px;
+}
+
+.video-transcript header {
+  padding-bottom: 5px;
+  border-bottom: 1px solid #a0a0a0;
+} 
+
+.video-transcript > #lines {
+  display: flex;
+  flex-direction: column;
+  overflow: scroll;
+}
+
+.transcript-line, .transcript-title-line {
+  display: flex;
+  align-items: center;
+  padding: 20px 10px;
+  gap: 10px;
+  border-radius: 10px;
+}
+
+.transcript-line > .length {
+  padding: 0px 5px;
+  background: #363636 !important;
+}
+
+.transcript-line > p, .video-transcript > header > h3, .transcript-title-line > h4 {
+  margin: 0;
+}
+
+.transcript-line:hover, .selected.transcript-line, .transcript-title-line:hover, .selected.transcript-title-line {
+  background: #cacaca;
+}

--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -816,3 +816,20 @@ h1, h2, h3, h4, h5, p,
 #download_widget {
     width: 100%;
 }
+
+.description-widget {
+  display: flex;
+  white-space: normal;
+  gap: 15px;
+
+  border-top: 1px solid black;
+}
+
+.description-show-transcript-widget {
+  padding: 10px;
+  flex-direction: column
+}
+
+.description-show-transcript-widget > * {
+  margin: 0;
+}

--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -875,3 +875,17 @@ h1, h2, h3, h4, h5, p,
 .transcript-line:hover, .selected.transcript-line, .transcript-title-line:hover, .selected.transcript-title-line {
   background: #cacaca;
 }
+
+.video-transcript > footer {
+  padding-bottom: 14px;
+  border-top: 1px solid #a0a0a0
+}
+
+.video-transcript > footer > form {
+  display: flex;
+  justify-content: center;
+}
+
+.video-transcript > footer select {
+  width: 75%;
+}

--- a/assets/js/watch.js
+++ b/assets/js/watch.js
@@ -195,3 +195,15 @@ addEventListener('load', function (e) {
         comments.innerHTML = '';
     }
 });
+
+addEventListener("DOMContentLoaded", () => {
+    const transcriptLines = document.getElementById("lines");
+    for (const transcriptLine of transcriptLines.children) {
+        if (transcriptLine.nodeName != "A") continue
+
+        transcriptLine.addEventListener("click", (event) => {
+            event.preventDefault();
+            player.currentTime(transcriptLine.getAttribute('data-jump-time'));
+        })
+    }
+})

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -502,9 +502,9 @@
     "carousel_slide": "Slide {{current}} of {{total}}",
     "carousel_skip": "Skip the Carousel",
     "carousel_go_to": "Go to slide `x`",
-    "video_description_show_transcript_section_label": "Transcripts",
-    "video_description_show_transcript_section_button": "Show transcript",
-    "video_description_show_transcript_section_button_hide": "Hide transcript",
+    "video_description_toggle_transcript_widget_label": "Transcripts",
+    "video_description_toggle_transcript_widget_button_label_show": "Show transcript",
+    "video_description_toggle_transcript_widget_button_label_hide": "Hide transcript",
     "error_transcripts_none_available": "No transcripts are available",
     "transcript_widget_title": "Transcript",
     "transcript_widget_no_js_change_transcript_btn": "Swap"

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -505,5 +505,6 @@
     "video_description_show_transcript_section_label": "Transcripts",
     "video_description_show_transcript_section_button": "Show transcript",
     "video_description_show_transcript_section_button_hide": "Hide transcript",
-    "error_transcripts_none_available": "No transcripts are available"
+    "error_transcripts_none_available": "No transcripts are available",
+    "transcript_widget_title": "Transcript"
 }

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -503,5 +503,7 @@
     "carousel_skip": "Skip the Carousel",
     "carousel_go_to": "Go to slide `x`",
     "video_description_show_transcript_section_label": "Transcripts",
-    "video_description_show_transcript_section_button": "Show transcript"
+    "video_description_show_transcript_section_button": "Show transcript",
+    "video_description_show_transcript_section_button_hide": "Hide transcript",
+    "error_transcripts_none_available": "No transcripts are available"
 }

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -501,5 +501,7 @@
     "toggle_theme": "Toggle Theme",
     "carousel_slide": "Slide {{current}} of {{total}}",
     "carousel_skip": "Skip the Carousel",
-    "carousel_go_to": "Go to slide `x`"
+    "carousel_go_to": "Go to slide `x`",
+    "video_description_show_transcript_section_label": "Transcripts",
+    "video_description_show_transcript_section_button": "Show transcript"
 }

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -506,5 +506,6 @@
     "video_description_show_transcript_section_button": "Show transcript",
     "video_description_show_transcript_section_button_hide": "Hide transcript",
     "error_transcripts_none_available": "No transcripts are available",
-    "transcript_widget_title": "Transcript"
+    "transcript_widget_title": "Transcript",
+    "transcript_widget_no_js_change_transcript_btn": "Swap"
 }

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -162,8 +162,26 @@ module Invidious::Routes::Watch
     captions = captions - preferred_captions
 
     if show_transcripts
-      # Placeholder
-      transcript = true
+      # The transcripts available are the exact same as the amount of captions available. Thus:
+      if !preferred_captions.empty?
+        chosen_transcript = preferred_captions[0]
+        transcript_request_param = Invidious::Videos::Transcript.generate_param(
+          id, chosen_transcript.language_code, chosen_transcript.auto_generated
+        )
+      elsif !captions.empty?
+        chosen_transcript = captions[0]
+        transcript_request_param = Invidious::Videos::Transcript.generate_param(
+          id, chosen_transcript.language_code, chosen_transcript.auto_generated
+        )
+      else
+        return error_template(404, "error_transcripts_none_available")
+      end
+
+      transcript = Invidious::Videos::Transcript.from_raw(
+        YoutubeAPI.get_transcript(transcript_request_param),
+        chosen_transcript.language_code,
+        chosen_transcript.auto_generated,
+      )
     else
       transcript = nil
     end

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -38,6 +38,11 @@ module Invidious::Routes::Watch
     nojs ||= "0"
     nojs = nojs == "1"
 
+    show_transcripts = env.params.query["show_transcripts"]?
+
+    show_transcripts ||= "0"
+    show_transcripts = show_transcripts == "1"
+
     preferences = env.get("preferences").as(Preferences)
 
     user = env.get?("user").try &.as(User)
@@ -155,6 +160,13 @@ module Invidious::Routes::Watch
         params.preferred_captions.index(caption.language_code.split("-")[0])).not_nil!
     }
     captions = captions - preferred_captions
+
+    if show_transcripts
+      # Placeholder
+      transcript = true
+    else
+      transcript = nil
+    end
 
     aspect_ratio = "16:9"
 

--- a/src/invidious/videos/transcript.cr
+++ b/src/invidious/videos/transcript.cr
@@ -80,14 +80,15 @@ module Invidious::Videos
       initial_segments.each do |line|
         if unpacked_line = line["transcriptSectionHeaderRenderer"]?
           line_type = HeadingLine
+          text = (unpacked_line.dig?("sectionHeader", "sectionHeaderViewModel", "headline", "content").try &.as_s) || ""
         else
           unpacked_line = line["transcriptSegmentRenderer"]
+          text = extract_text(unpacked_line["snippet"]) || ""
           line_type = RegularLine
         end
 
         start_ms = unpacked_line["startMs"].as_s.to_i.millisecond
         end_ms = unpacked_line["endMs"].as_s.to_i.millisecond
-        text = extract_text(unpacked_line["snippet"]) || ""
 
         lines << line_type.new(start_ms, end_ms, text)
       end

--- a/src/invidious/views/components/description_toggle_transcripts_widget.ecr
+++ b/src/invidious/views/components/description_toggle_transcripts_widget.ecr
@@ -1,13 +1,13 @@
 <% if captions %>
 <div class="description-widget description-show-transcript-widget">
-    <h4><%=HTML.escape(translate(locale, "video_description_show_transcript_section_label"))%></h4>
+    <h4><%=HTML.escape(translate(locale, "video_description_toggle_transcript_widget_label"))%></h4>
     <% if transcript %>
         <% hide_transcripts_param = env.params.query.dup %>
         <% hide_transcripts_param.delete_all("show_transcripts") %>
 
-        <a class="pure-button pure-button-secondary" href="/watch?<%= hide_transcripts_param %>"><%=HTML.escape(translate(locale, "video_description_show_transcript_section_button_hide"))%></a>
+        <a class="pure-button pure-button-secondary" href="/watch?<%= hide_transcripts_param %>"><%=HTML.escape(translate(locale, "video_description_toggle_transcript_widget_button_label_hide"))%></a>
     <% else %>
-        <a class="pure-button pure-button-secondary" href="/watch?<%= env.params.query %>&show_transcripts=1"><%=HTML.escape(translate(locale, "video_description_show_transcript_section_button"))%></a>
+        <a class="pure-button pure-button-secondary" href="/watch?<%= env.params.query %>&show_transcripts=1"><%=HTML.escape(translate(locale, "video_description_toggle_transcript_widget_button_label_show"))%></a>
     <% end %>
 </div>
 <% end %>

--- a/src/invidious/views/components/description_toggle_transcripts_widget.ecr
+++ b/src/invidious/views/components/description_toggle_transcripts_widget.ecr
@@ -1,0 +1,13 @@
+<% if captions %>
+<div class="description-widget description-show-transcript-widget">
+    <h4><%=HTML.escape(translate(locale, "video_description_show_transcript_section_label"))%></h4>
+    <% if transcript %>
+        <% hide_transcripts_param = env.params.query.dup %>
+        <% hide_transcripts_param.delete_all("show_transcripts") %>
+
+        <a class="pure-button pure-button-secondary" href="/watch?<%= hide_transcripts_param %>"><%=HTML.escape(translate(locale, "video_description_show_transcript_section_button_hide"))%></a>
+    <% else %>
+        <a class="pure-button pure-button-secondary" href="/watch?<%= env.params.query %>&show_transcripts=1"><%=HTML.escape(translate(locale, "video_description_show_transcript_section_button"))%></a>
+    <% end %>
+</div>
+<% end %>

--- a/src/invidious/views/components/no-js-transcript-ui.ecr
+++ b/src/invidious/views/components/no-js-transcript-ui.ecr
@@ -19,5 +19,28 @@
             <% end %> 
         <% end %>
     </div>
-    <footer></footer>
+    <footer>
+        <% transcript_select_args = env.params.query.dup %>
+        <% transcript_select_args.delete_all("use_this_transcript") %>
+        <form class="select-transcript" method="get" action="/watch?<%=transcript_select_args%>">
+            <% # Preserve query parameters %>
+            <% transcript_select_args.each do | k, v | %>
+                <input type="hidden" name="<%=k%>" value="<%=v%>">
+            <% end %>
+
+            <select name="use_this_transcript">
+                <% {preferred_captions, captions}.each do | transcript_list |%>
+                    <% transcript_list.each do | transcript_option | %>
+                        <% if target_transcript.not_nil!.name == transcript_option.name %>
+                            <option value="<%=URI.encode_www_form(transcript_option.name)%>" selected><%=transcript_option.name%></option>
+                        <% else%>
+                            <option value="<%=URI.encode_www_form(transcript_option.name)%>"><%=transcript_option.name%></option>
+                        <% end %>
+                    <% end %>
+                <% end  %>
+            </select>
+
+            <input type="submit" value="<%= translate(locale, "transcript_widget_no_js_change_transcript_btn") %>"/>
+        </form>
+    </footer>
 </section>

--- a/src/invidious/views/components/no-js-transcript-ui.ecr
+++ b/src/invidious/views/components/no-js-transcript-ui.ecr
@@ -1,0 +1,23 @@
+<section class="video-transcript">
+    <header><h3><%=translate(locale, "transcript_widget_title")%></h3></header>
+    <div id="lines">
+        <% transcript_time_url_param = env.params.query.dup %>
+        <% transcript_time_url_param.delete_all("t") %>
+
+        <% transcript.lines.each do | line | %>
+            <% if line.is_a? Invidious::Videos::Transcript::HeadingLine %>
+                <div class="transcript-title-line"> <h4> <%= line.line %> </h4> </div>
+            <% else %>
+                <% jump_time = line.start_ms.total_seconds.to_s %>
+                <% transcript_time_url_param["t"] = jump_time %>
+                <a href="/watch?<%= transcript_time_url_param %>" data-onclick="jump_to_time" data-jump-time="<%=jump_time%>">
+                    <div class="transcript-line">
+                        <p class="length"><%= recode_length_seconds(line.start_ms.total_seconds) %></p>
+                        <p><%= line.line %></p>
+                    </div>
+                </a>
+            <% end %> 
+        <% end %>
+    </div>
+    <footer></footer>
+</section>

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -256,7 +256,14 @@ we're going to need to do it here in order to allow for translations.
                     <div id="descriptionWrapper"><%= video.description_html %></div>
                 <% else %>
                     <input id="descexpansionbutton" type="checkbox"/>
-                    <div id="descriptionWrapper"><%= video.description_html %></div>
+                    <div id="descriptionWrapper"><%-= video.description_html %>
+                        <% if captions %>
+                            <div class="description-widget description-show-transcript-widget">
+                                <h4><%=HTML.escape(translate(locale, "video_description_show_transcript_section_label"))%></h4>
+                                <a class="pure-button pure-button-secondary"><%=HTML.escape(translate(locale, "video_description_show_transcript_section_button"))%></a>
+                            </div>
+                        <% end %>
+                    </div>
                     <label for="descexpansionbutton">
                         <a></a>
                     </label>

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -253,23 +253,13 @@ we're going to need to do it here in order to allow for translations.
 
             <div id="description-box"> <!-- Description -->
                 <% if video.description.size < 200 || params.extend_desc %>
-                    <div id="descriptionWrapper"><%= video.description_html %></div>
+                    <div id="descriptionWrapper"><%= video.description_html %>
+                        <%= rendered "components/description_toggle_transcripts_widget" %>
+                    </div>
                 <% else %>
                     <input id="descexpansionbutton" type="checkbox"/>
                     <div id="descriptionWrapper"><%-= video.description_html %>
-                        <% if captions %>
-                            <div class="description-widget description-show-transcript-widget">
-                                <h4><%=HTML.escape(translate(locale, "video_description_show_transcript_section_label"))%></h4>
-                                <% if transcript %>
-                                    <% hide_transcripts_param = env.params.query.dup %>
-                                    <% hide_transcripts_param.delete_all("show_transcripts") %>
-
-                                    <a class="pure-button pure-button-secondary" href="/watch?<%= hide_transcripts_param %>"><%=HTML.escape(translate(locale, "video_description_show_transcript_section_button_hide"))%></a>
-                                <% else %>
-                                    <a class="pure-button pure-button-secondary" href="/watch?<%= env.params.query %>&show_transcripts=1"><%=HTML.escape(translate(locale, "video_description_show_transcript_section_button"))%></a>
-                                <% end %>
-                            </div>
-                        <% end %>
+                        <%= rendered "components/description_toggle_transcripts_widget" %>
                     </div>
                     <label for="descexpansionbutton">
                         <a></a>

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -317,6 +317,10 @@ we're going to need to do it here in order to allow for translations.
 
     <% if params.related_videos || plid %>
         <div class="pure-u-1 pure-u-lg-1-5">
+            <% if transcript %>
+                <%= rendered "components/no-js-transcript-ui" %>
+            <% end %>
+
             <% if plid %>
                 <div id="playlist" class="h-box"></div>
             <% end %>

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -260,7 +260,14 @@ we're going to need to do it here in order to allow for translations.
                         <% if captions %>
                             <div class="description-widget description-show-transcript-widget">
                                 <h4><%=HTML.escape(translate(locale, "video_description_show_transcript_section_label"))%></h4>
-                                <a class="pure-button pure-button-secondary"><%=HTML.escape(translate(locale, "video_description_show_transcript_section_button"))%></a>
+                                <% if transcript %>
+                                    <% hide_transcripts_param = env.params.query.dup %>
+                                    <% hide_transcripts_param.delete_all("show_transcripts") %>
+
+                                    <a class="pure-button pure-button-secondary" href="/watch?<%= hide_transcripts_param %>"><%=HTML.escape(translate(locale, "video_description_show_transcript_section_button_hide"))%></a>
+                                <% else %>
+                                    <a class="pure-button pure-button-secondary" href="/watch?<%= env.params.query %>&show_transcripts=1"><%=HTML.escape(translate(locale, "video_description_show_transcript_section_button"))%></a>
+                                <% end %>
                             </div>
                         <% end %>
                     </div>


### PR DESCRIPTION
Closes #2564

![transcripts widget](https://github.com/user-attachments/assets/09f208e2-a451-4d44-b5e0-c20932fb4650)
![video description transcript toggle](https://github.com/user-attachments/assets/6ce3a1df-2fb4-4ced-ac92-4465689a3088)

The current description box isn't really designed to hold non preformatted content hence the extraneous spacing at the bottom. Once #4111 is merged the description box should get a redesign to better accommodate these description widgets and how they should be affected by the expand description user preference.
