### PR TITLE
CI: Use GitHub actions cache in docker builds

### DIFF
--- a/.github/workflows/build-nightly-container.yml
+++ b/.github/workflows/build-nightly-container.yml
@@ -60,6 +60,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             "release=1"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Docker meta
         id: meta-arm64
@@ -85,3 +87,5 @@ jobs:
           tags: ${{ steps.meta-arm64.outputs.tags }}
           build-args: |
             "release=1"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-stable-container.yml
+++ b/.github/workflows/build-stable-container.yml
@@ -53,6 +53,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             "release=1"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Docker meta
         id: meta-arm64
@@ -79,3 +81,5 @@ jobs:
           tags: ${{ steps.meta-arm64.outputs.tags }}
           build-args: |
             "release=1"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
           file: docker/Dockerfile.arm64
           platforms: linux/arm64/v8
           build-args: release=0
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Test Docker
         run: while curl -Isf http://localhost:3000; do sleep 1; done


### PR DESCRIPTION
We already make use of the mount cache on https://github.com/iv-org/invidious/commit/e2df12b7d66618c21cffc1f75cefeea083f3dbc7 to speed up the compiling on Invidious, but we can also use Github actions for the Dockerfile, which caches packages installed using `apk` and any other layer of the container that can be cached.

For installed packages, it will always use the same cached version (if the cache has not been used on 7 days according to https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy), so on each build, the packages are not going to be updated (https://docs.docker.com/build/cache/invalidation/#run-instructions). I personally think this is better to prevent a possible breakage on an updated package (which is probably not going to happen anyways because we use a specific alpine tag).

