### PR TITLE
CI: Use public ARM64 Github actions runners for ARM64 builds.

### DIFF
--- a/.github/workflows/build-nightly-container.yml
+++ b/.github/workflows/build-nightly-container.yml
@@ -17,16 +17,26 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platforms: linux/amd64
+            name: "AMD64"
+            dockerfile: "docker/Dockerfile"
+            tag_suffix: ""
+            # GitHub doesn't has a ubuntu-latest-arm runner
+          - os: ubuntu-24.04-arm
+            platforms: linux/arm64/v8
+            name: "ARM64"
+            dockerfile: "docker/Dockerfile.arm64"
+            tag_suffix: "-arm64"
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -43,45 +53,22 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: quay.io/invidious/invidious
+          flavor: |
+            suffix=${{ matrix.tag_suffix }}
           tags: |
             type=sha,format=short,prefix={{date 'YYYY.MM.DD'}}-,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
             type=raw,value=master,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
           labels: |
             quay.expires-after=12w
 
-      - name: Build and push Docker AMD64 image for Push Event
+      - name: Build and push Docker ${{ matrix.name }} image for Push Event
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: docker/Dockerfile
-          platforms: linux/amd64
+          file:  ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          build-args: |
-            "release=1"
-
-      - name: Docker meta
-        id: meta-arm64
-        uses: docker/metadata-action@v5
-        with:
-          images: quay.io/invidious/invidious
-          flavor: |
-            suffix=-arm64
-          tags: |
-            type=sha,format=short,prefix={{date 'YYYY.MM.DD'}}-,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
-            type=raw,value=master,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
-          labels: |
-            quay.expires-after=12w
-
-      - name: Build and push Docker ARM64 image for Push Event
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/Dockerfile.arm64
-          platforms: linux/arm64/v8
-          labels: ${{ steps.meta-arm64.outputs.labels }}
-          push: true
-          tags: ${{ steps.meta-arm64.outputs.tags }}
           build-args: |
             "release=1"

--- a/.github/workflows/build-stable-container.yml
+++ b/.github/workflows/build-stable-container.yml
@@ -8,16 +8,26 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platforms: linux/amd64
+            name: "AMD64"
+            dockerfile: "docker/Dockerfile"
+            tag_suffix: ""
+            # GitHub doesn't has a ubuntu-latest-arm runner
+          - os: ubuntu-24.04-arm
+            platforms: linux/arm64/v8
+            name: "ARM64"
+            dockerfile: "docker/Dockerfile.arm64"
+            tag_suffix: "-arm64"
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -36,46 +46,21 @@ jobs:
           images: quay.io/invidious/invidious
           flavor: |
             latest=false
+            suffix=${{ matrix.tag_suffix }}
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest
           labels: |
             quay.expires-after=12w
 
-      - name: Build and push Docker AMD64 image for Push Event
+      - name: Build and push Docker ${{ matrix.name }} image for Push Event
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: docker/Dockerfile
-          platforms: linux/amd64
+          file:  ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          build-args: |
-            "release=1"
-
-      - name: Docker meta
-        id: meta-arm64
-        uses: docker/metadata-action@v5
-        with:
-          images: quay.io/invidious/invidious
-          flavor: |
-            latest=false
-            suffix=-arm64
-          tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest
-          labels: |
-            quay.expires-after=12w
-
-      - name: Build and push Docker ARM64 image for Push Event
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/Dockerfile.arm64
-          platforms: linux/arm64/v8
-          labels: ${{ steps.meta-arm64.outputs.labels }}
-          push: true
-          tags: ${{ steps.meta-arm64.outputs.tags }}
           build-args: |
             "release=1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,26 +100,16 @@ jobs:
 
   build-docker-arm64:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
+      - name: Build Docker
+        run: docker compose -f docker-compose-arm64.yml build --build-arg release=0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build Docker ARM64 image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/Dockerfile.arm64
-          platforms: linux/arm64/v8
-          build-args: release=0
+      - name: Run Docker
+        run: docker compose -f docker-compose-arm64.yml up -d
 
       - name: Test Docker
         run: while curl -Isf http://localhost:3000; do sleep 1; done

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -1,0 +1,55 @@
+# Warning: This docker-compose file is made for development purposes.
+# Using it will build an image from the locally cloned repository.
+#
+# If you want to use Invidious in production, see the docker-compose.yml file provided
+# in the installation documentation: https://docs.invidious.io/installation/
+
+version: "3"
+services:
+
+  invidious:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.arm64
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      # Please read the following file for a comprehensive list of all available
+      # configuration options and their associated syntax:
+      # https://github.com/iv-org/invidious/blob/master/config/config.example.yml
+      INVIDIOUS_CONFIG: |
+        db:
+          dbname: invidious
+          user: kemal
+          password: kemal
+          host: invidious-db
+          port: 5432
+        check_tables: true
+        # external_port:
+        # domain:
+        # https_only: false
+        # statistics_enabled: false
+        hmac_key: "CHANGE_ME!!"
+    healthcheck:
+      test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/trending || exit 1
+      interval: 30s
+      timeout: 5s
+      retries: 2
+
+  invidious-db:
+    image: docker.io/library/postgres:14
+    restart: unless-stopped
+    volumes:
+      - postgresdata:/var/lib/postgresql/data
+      - ./config/sql:/config/sql
+      - ./docker/init-invidious-db.sh:/docker-entrypoint-initdb.d/init-invidious-db.sh
+    environment:
+      POSTGRES_DB: invidious
+      POSTGRES_USER: kemal
+      POSTGRES_PASSWORD: kemal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+
+volumes:
+  postgresdata:


### PR DESCRIPTION
Currently, Invidious uses QEMU to build it's ARM64 Invidious image, which is slow (since we are basically using a virtual machine).

This helps with the speed of building ARM64 binaries for Invidious on each release/commit by a lot.

More information about the public ARM64 runners here: https://github.com/orgs/community/discussions/148648

---

Take a look at: https://github.com/Fijxu/invidious/actions/runs/15037532092 and https://github.com/Fijxu/invidious/actions/runs/15037532093

Testing OCI images at https://git.nadeko.net/Fijxu/-/packages/container/invidious_do_not_pull/master-arm64 and https://git.nadeko.net/Fijxu/-/packages/container/invidious_do_not_pull/master