### PR TITLE
Remove text captcha due to textcaptcha.com being down

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -64,8 +64,6 @@
     "User ID": "User ID",
     "Password": "Password",
     "Time (h:mm:ss):": "Time (h:mm:ss):",
-    "Text CAPTCHA": "Text CAPTCHA",
-    "Image CAPTCHA": "Image CAPTCHA",
     "Sign In": "Sign In",
     "Register": "Register",
     "E-mail": "E-mail",

--- a/src/invidious/user/captcha.cr
+++ b/src/invidious/user/captcha.cr
@@ -4,8 +4,6 @@ struct Invidious::User
   module Captcha
     extend self
 
-    private TEXTCAPTCHA_URL = URI.parse("https://textcaptcha.com")
-
     def generate_image(key)
       second = Random::Secure.rand(12)
       second_angle = second * 30
@@ -58,20 +56,6 @@ struct Invidious::User
       return {
         question: image,
         tokens:   {generate_response(answer, {":login"}, key, use_nonce: true)},
-      }
-    end
-
-    def generate_text(key)
-      response = make_client(TEXTCAPTCHA_URL, &.get("/github.com/iv.org/invidious.json").body)
-      response = JSON.parse(response)
-
-      tokens = response["a"].as_a.map do |answer|
-        generate_response(answer.as_s, {":login"}, key, use_nonce: true)
-      end
-
-      return {
-        question: response["q"].as_s,
-        tokens:   tokens,
       }
     end
   end

--- a/src/invidious/views/user/login.ecr
+++ b/src/invidious/views/user/login.ecr
@@ -25,44 +25,17 @@
                         <% end %>
 
                         <% if captcha %>
-                            <% case captcha_type when %>
-                            <% when "image" %>
-                                <% captcha = captcha.not_nil! %>
-                                <img style="width:50%" src='<%= captcha[:question] %>'/>
-                                <% captcha[:tokens].each_with_index do |token, i| %>
-                                    <input type="hidden" name="token[<%= i %>]" value="<%= HTML.escape(token) %>">
-                                <% end %>
-                                <input type="hidden" name="captcha_type" value="image">
-                                <label for="answer"><%= translate(locale, "Time (h:mm:ss):") %></label>
-                                <input type="text" name="answer" type="text" placeholder="h:mm:ss">
-                            <% else # "text" %>
-                                <% captcha = captcha.not_nil! %>
-                                <% captcha[:tokens].each_with_index do |token, i| %>
-                                    <input type="hidden" name="token[<%= i %>]" value="<%= HTML.escape(token) %>">
-                                <% end %>
-                                <input type="hidden" name="captcha_type" value="text">
-                                <label for="answer"><%= captcha[:question] %></label>
-                                <input type="text" name="answer" type="text" placeholder="<%= translate(locale, "Answer") %>">
+                            <% captcha = captcha.not_nil! %>
+                            <img style="width:50%" src='<%= captcha[:question] %>'/>
+                            <% captcha[:tokens].each_with_index do |token, i| %>
+                                <input type="hidden" name="token[<%= i %>]" value="<%= HTML.escape(token) %>">
                             <% end %>
+                            <label for="answer"><%= translate(locale, "Time (h:mm:ss):") %></label>
+                            <input type="text" name="answer" type="text" placeholder="h:mm:ss">
 
                             <button type="submit" name="action" value="signin" class="pure-button pure-button-primary">
                                 <%= translate(locale, "Register") %>
                             </button>
-
-                            <% case captcha_type when %>
-                            <% when "image" %>
-                                <label>
-                                    <button type="submit" name="change_type" class="pure-button pure-button-primary" value="text">
-                                        <%= translate(locale, "Text CAPTCHA") %>
-                                    </button>
-                                </label>
-                            <% else # "text" %>
-                                <label>
-                                    <button type="submit" name="change_type" class="pure-button pure-button-primary" value="image">
-                                        <%= translate(locale, "Image CAPTCHA") %>
-                                    </button>
-                                </label>
-                            <% end %>
                         <% else %>
                             <button type="submit" name="action" value="signin" class="pure-button pure-button-primary">
                                 <%= translate(locale, "Sign In") %>/<%= translate(locale, "Register") %>


### PR DESCRIPTION
Fixes https://github.com/iv-org/invidious/issues/5295

textcaptcha.com seems to be down since April and it does not appear that service will be restored.

Text captchas can be easily automated using free LLMs, so keeping the text captcha is more like a gate to create accounts in mass on public Invidious instances.

It also gives headaches like bots automating account creation to modify the videos that appear on the popular page of each public instance (since the popular page is based on the subscriptions of the registered users).