### PR TITLE
Remove `@iv-org/developers` from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,3 @@
-# Default and lowest precedence. If none of the below matches, @iv-org/developers would be requested for review.
-* @iv-org/developers
-
 docker-compose.yml @unixfox
 docker/ @unixfox
 kubernetes/ @unixfox


### PR DESCRIPTION
I feel like the random team review requests are more just noise rather than anything actually useful. I personally don't see much of a point in keeping it around. Let me know what you guys think