### PR TITLE
Fix local storyboard requests on Crystal >= 1.16.0

### DIFF
--- a/src/ext/kemal_static_file_handler.cr
+++ b/src/ext/kemal_static_file_handler.cr
@@ -191,5 +191,13 @@ module Kemal
         end
       end
     end
+
+    # See https://github.com/crystal-lang/crystal/issues/15788
+    #
+    # URL fragments also aren't passed along but there isn't an easy way
+    # to retrieve that at the moment.
+    private def redirect_to(context, path)
+      context.response.redirect URI.new(path: URI.encode_path(path.to_s), query: context.request.query)
+    end
   end
 end

--- a/src/invidious/routes/errors.cr
+++ b/src/invidious/routes/errors.cr
@@ -1,9 +1,20 @@
 module Invidious::Routes::ErrorRoutes
   def self.error_404(env)
-    # Workaround for #3117
-    if HOST_URL.empty? && env.request.path.starts_with?("/v1/storyboards/sb")
-      return env.redirect "#{env.request.path[15..]}?#{env.params.query}"
-    end
+    # Workaround for #3117 on versions prior to 1.16.0
+    #
+    # Crystal 1.16.0 fixed the parsing of some weird-looking paths
+    # meaning that `//api/v1/storyboards/sb/i/...` will no longer
+    # get parsed into a request target of `/v1/storyboards/sb/i/...`
+    #
+    # This also means that we won't be able to handle the logic here
+    # because status code error handles are disabled for the API routes
+
+    # We only need to include this workaround on versions prior to 1.16.0
+    {% if compare_versions(Crystal::VERSION, "1.16.0") < 0 %}
+      if HOST_URL.empty? && env.request.path.starts_with?("/v1/storyboards/sb")
+        return env.redirect "#{env.request.path[15..]}?#{env.params.query}"
+      end
+    {% end %}
 
     if md = env.request.path.match(/^\/(?<id>([a-zA-Z0-9_-]{11})|(\w+))$/)
       item = md["id"]


### PR DESCRIPTION
Crystal 1.16.0 fixed the parsing of some weird-looking paths meaning that `//api/v1/storyboards/sb/i/...` will no longer get parsed into a request target of `/v1/storyboards/sb/i/...` within requests.

But the fix is a bit more annoying than just changing a path. The "new" existence  of the double slash means that `StaticFileHandler` will process and redirect the request to a normalized path with only a single slash. This redirect however does not preserve url query parameters which are needed to request storyboards from YouTube.

Then there's the fact that the status code error handlers are disabled for the API routes, meaning that there is no handler to actually process the request with.

This PR patches Kemal's `StaticFileHandler` to preserve query parameters when redirecting, and adds the `/api/v1/storyboard/sb/*` -> `/sb/i/*/` redirect directly into Kemal's `ExceptionHandler` for now.

In the future a dedicated handler should be created to properly handle http status code conditions on the API routes.