### PR TITLE
Add missing xml.text on "title" element for channels RSS

### DIFF
--- a/src/invidious/routes/feeds.cr
+++ b/src/invidious/routes/feeds.cr
@@ -202,7 +202,7 @@ module Invidious::Routes::Feeds
         xml.element("link", rel: "self", href: "#{HOST_URL}#{env.request.resource}")
         xml.element("id") { xml.text "yt:channel:#{ucid}" }
         xml.element("yt:channelId") { xml.text ucid }
-        xml.element("title") { author }
+        xml.element("title") { xml.text author }
         xml.element("link", rel: "alternate", href: "#{HOST_URL}/channel/#{ucid}")
 
         xml.element("author") do


### PR DESCRIPTION
Without `xml.text` the returned title for `feed/channel/UCld68syR8Wi-GY_n4CaoJGA` and any other channel feed was empty.

```
  <yt:channelId>UCld68syR8Wi-GY_n4CaoJGA</yt:channelId>
  <title/> <-- EMPTY
  <link rel="alternate" href="https://devel-inv-2.nadeko.net/channel/UCld68syR8Wi-GY_n4CaoJGA"/>
```

After adding `xml.text` to it, the output is:

```
  <yt:channelId>UCld68syR8Wi-GY_n4CaoJGA</yt:channelId>
  <title>Brodie Robertson</title>
  <link rel="alternate" href="https://devel-inv-2.nadeko.net/channel/UCld68syR8Wi-GY_n4CaoJGA"/>
  ```

Taken from https://git.nadeko.net/Fijxu/invidious/issues/130