### PR TITLE
Make caption text selectable

### DIFF
--- a/assets/css/player.css
+++ b/assets/css/player.css
@@ -86,6 +86,7 @@ ul.vjs-menu-content::-webkit-scrollbar {
   background-color: rgba(0, 0, 0, 0.75) !important;
   border-radius: 9px !important;
   padding: 5px !important;
+  pointer-events: auto;
 }
 
 .vjs-play-control,


### PR DESCRIPTION
I think it would be really nice to be able to select and copy the caption text. The caption container has `pointer-events` disabled as it would otherwise eat the mouse input for the whole player area. But re-enabling `pointer-events` for just the text container makes the text selectable without affecting the player outside of the area with text.