### PR TITLE
Show message when connection to the database is not possible

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -60,7 +60,13 @@ alias IV = Invidious
 CONFIG   = Config.load
 HMAC_KEY = CONFIG.hmac_key
 
-PG_DB       = DB.open CONFIG.database_url
+PG_DB = begin
+  DB.open CONFIG.database_url
+rescue ex
+  puts "Failed to connect to PostgreSQL database: #{ex.cause.try &.message}"
+  puts "Check your 'config.yml' database settings or PostgreSQL settings."
+  exit(1)
+end
 ARCHIVE_URL = URI.parse("https://archive.org")
 PUBSUB_URL  = URI.parse("https://pubsubhubbub.appspot.com")
 REDDIT_URL  = URI.parse("https://www.reddit.com")


### PR DESCRIPTION
This gives a better message when something goes wrong on the database connection. May not be better for debugging purposes, but the error messages returned are from PostgreSQL

![image](https://github.com/user-attachments/assets/13d2ff6f-e7d5-4a16-b496-d7d5201fe81f)
