### PR TITLE
Fix fetching of individual community posts

### DIFF
--- a/src/invidious/channels/community.cr
+++ b/src/invidious/channels/community.cr
@@ -3,7 +3,7 @@ private IMAGE_QUALITIES = {320, 560, 640, 1280, 2000}
 # TODO: Add "sort_by"
 def fetch_channel_community(ucid, cursor, locale, format, thin_mode)
   if cursor.nil?
-    # EgVwb3N0c_IGBAoCSgA%3D is the protobuf object to load "community"
+    # EgVwb3N0c_IGBAoCSgA%3D is the protobuf object to load "posts"
     initial_data = YoutubeAPI.browse(ucid, params: "EgVwb3N0c_IGBAoCSgA%3D")
 
     items = [] of JSON::Any
@@ -26,21 +26,18 @@ end
 
 def fetch_channel_community_post(ucid, post_id, locale, format, thin_mode)
   object = {
-    "2:string"    => "community",
-    "25:embedded" => {
-      "22:string" => post_id.to_s,
-    },
-    "45:embedded" => {
-      "2:varint" => 1_i64,
-      "3:varint" => 1_i64,
-    },
+    "56:embedded" => {
+      "2:string" => ucid,
+      "3:string" => post_id.to_s,
+      "11:string" => ucid,
+    }
   }
   params = object.try { |i| Protodec::Any.cast_json(i) }
     .try { |i| Protodec::Any.from_json(i) }
     .try { |i| Base64.urlsafe_encode(i) }
     .try { |i| URI.encode_www_form(i) }
 
-  initial_data = YoutubeAPI.browse(ucid, params: params)
+  initial_data = YoutubeAPI.browse("FEpost_detail", params: params)
 
   items = [] of JSON::Any
   extract_items(initial_data) do |item|

--- a/src/invidious/channels/community.cr
+++ b/src/invidious/channels/community.cr
@@ -3,8 +3,8 @@ private IMAGE_QUALITIES = {320, 560, 640, 1280, 2000}
 # TODO: Add "sort_by"
 def fetch_channel_community(ucid, cursor, locale, format, thin_mode)
   if cursor.nil?
-    # Egljb21tdW5pdHk%3D is the protobuf object to load "community"
-    initial_data = YoutubeAPI.browse(ucid, params: "Egljb21tdW5pdHk%3D")
+    # EgVwb3N0c_IGBAoCSgA%3D is the protobuf object to load "community"
+    initial_data = YoutubeAPI.browse(ucid, params: "EgVwb3N0c_IGBAoCSgA%3D")
 
     items = [] of JSON::Any
     extract_items(initial_data) do |item|

--- a/src/invidious/channels/community.cr
+++ b/src/invidious/channels/community.cr
@@ -24,6 +24,15 @@ def fetch_channel_community(ucid, cursor, locale, format, thin_mode)
   return extract_channel_community(items, ucid: ucid, locale: locale, format: format, thin_mode: thin_mode)
 end
 
+def decode_ucid_from_post_protobuf(params)
+  decoded_protobuf = params.try { |i| URI.decode_www_form(i) }
+  .try { |i| Base64.decode(i) }
+  .try { |i| IO::Memory.new(i) }
+  .try { |i| Protodec::Any.parse(i) }
+
+  return decoded_protobuf.try(&.["56:0:embedded"]["2:0:string"].as_s)
+end
+
 def fetch_channel_community_post(ucid, post_id, locale, format, thin_mode)
   object = {
     "56:embedded" => {

--- a/src/invidious/routes/channels.cr
+++ b/src/invidious/routes/channels.cr
@@ -284,7 +284,7 @@ module Invidious::Routes::Channels
       response = YoutubeAPI.resolve_url("https://www.youtube.com/post/#{id}")
       return error_template(400, "Invalid post ID") if response["error"]?
 
-      ucid = response.dig("endpoint", "browseEndpoint", "browseId").as_s
+      ucid = decode_ucid_from_post_protobuf(response.dig("endpoint", "browseEndpoint", "params").as_s)
       post_response = fetch_channel_community_post(ucid, id, locale, "json", thin_mode)
     end
 


### PR DESCRIPTION
This PR fixes fetching individual community posts.

closes https://github.com/iv-org/invidious/issues/5349

# Tested by verifying that these urls work:
## Post where we know channel id already:
`{INVIDIOUS INSTANCE}/post/UgkxBR17mS798vtpQ3d5pm9gPWPkf0arjSah?ucid=UCXuqSBlHAE6Xw-yeJA0Tunw`
## Post where we don't know the channel id
`{INVIDIOUS INSTANCE}/post/UgkxBR17mS798vtpQ3d5pm9gPWPkf0arjSah`

## API Resolve Url: Resolving a post url
`{INVIDIOUS INSTANCE}`/api/v1/resolveurl?url=https://www.youtube.com/post/UgkxBR17mS798vtpQ3d5pm9gPWPkf0arjSah

## API Get Post
`{INVIDIOUS INSTANCE}`/api/v1/post/UgkxBR17mS798vtpQ3d5pm9gPWPkf0arjSah
`{INVIDIOUS INSTANCE}`/api/v1/post/UgkxBR17mS798vtpQ3d5pm9gPWPkf0arjSah?ucid=UCXuqSBlHAE6Xw-yeJA0Tunw

## API Get Post Comments sorted by top
`{INVIDIOUS INSTANCE}`/api/v1/post/UgkxBR17mS798vtpQ3d5pm9gPWPkf0arjSah/comments?ucid=UCXuqSBlHAE6Xw-yeJA0Tunw

`{INVIDIOUS INSTANCE}`/api/v1/post/UgkxBR17mS798vtpQ3d5pm9gPWPkf0arjSah/comments?ucid=UCXuqSBlHAE6Xw-yeJA0Tunw&sort_by=top

## API Get Post Comments sorted by newest
`{INVIDIOUS INSTANCE}`/api/v1/post/UgkxBR17mS798vtpQ3d5pm9gPWPkf0arjSah/comments?ucid=UCXuqSBlHAE6Xw-yeJA0Tunw&sort_by=newest