### PR TITLE
pages/watch: URL encode 'action' in download widget

### DIFF
--- a/src/invidious/frontend/watch_page.cr
+++ b/src/invidious/frontend/watch_page.cr
@@ -32,7 +32,7 @@ module Invidious::Frontend::WatchPage
     return String.build(4000) do |str|
       str << "<form"
       str << " class=\"pure-form pure-form-stacked\""
-      str << " action='#{url}'"
+      str << " action='" << URI.encode_www_form(url) << "'"
       str << " method='post'"
       str << " rel='noopener'"
       str << " target='_blank'>"


### PR DESCRIPTION
Caught in the review of PR 5224, but forgot to click on "send review" in time. I realized that too late, after the PR was already merged.