### PR TITLE
Add support for encrypted query parameters

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -568,6 +568,21 @@ hmac_key: "CHANGE_ME!!"
 ##
 #playlist_length_limit: 500
 
+##
+## Encrypts query params 'ip' and 'pot'
+## This is useful if you don't want to leak the IP address
+## and PoToken used when fetching a Youtube video.
+##
+## Note: This will only work if the 'Proxy videos' preference is enabled
+## on the Player preferences. Users that do not have 'Proxy videos' enabled
+## will be able to see the IP address and PoToken used on videoplayback
+## requests.
+##
+## Accepted values: true, false
+## Default: false
+##
+#encrypt_query_params: false
+
 #########################################
 #
 #  Default user preferences

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -183,6 +183,8 @@ class Config
   # Playlist length limit
   property playlist_length_limit : Int32 = 500
 
+  property encrypt_query_params : Bool = false
+
   def disabled?(option)
     case disabled = CONFIG.disable_proxy
     when Bool

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -1,5 +1,3 @@
-require "uri/params/serializable"
-
 # See http://www.evanmiller.org/how-not-to-sort-by-average-rating.html
 def ci_lower_bound(pos, n)
   if n == 0
@@ -411,15 +409,20 @@ def invidious_companion_encrypt(data)
 end
 
 struct PrivateParams
-  include URI::Params::Serializable
   include JSON::Serializable
 
   property ip : String = ""
-  property pot : String = ""
+  property pot : String? = nil
+
+  def initialize(@ip, @pot)
+  end
 end
 
 def encrypt_query_params(query_params : URI::Params) : String
-  private_params = PrivateParams.from_www_form(query_params.to_s).to_json
+  private_params = PrivateParams.new(
+    query_params["ip"],
+    query_params["pot"]?,
+  ).to_json
   encrypted_data = ecb_without_salt(private_params, CONFIG.hmac_key, :encrypt)
   return Base64.urlsafe_encode(encrypted_data)
 end

--- a/src/invidious/http_server/utils.cr
+++ b/src/invidious/http_server/utils.cr
@@ -9,6 +9,13 @@ module Invidious::HttpServer
 
       # Add some URL parameters
       params = url.query_params
+      if CONFIG.encrypt_query_params
+        encrypted_data = encrypt_query_params(params)
+        params["enc"] = "true"
+        params["data"] = encrypted_data
+        params.delete("ip")
+        params.delete("pot")
+      end
       params["host"] = url.host.not_nil! # Should never be nil, in theory
       params["region"] = region if !region.nil?
       url.query_params = params

--- a/src/invidious/http_server/utils.cr
+++ b/src/invidious/http_server/utils.cr
@@ -14,7 +14,7 @@ module Invidious::HttpServer
         params["enc"] = "true"
         params["data"] = encrypted_data
         params.delete("ip")
-        params.delete("pot")
+        params.delete("pot") if params.has_key?("pot")
       end
       params["host"] = url.host.not_nil! # Should never be nil, in theory
       params["region"] = region if !region.nil?

--- a/src/invidious/routes/video_playback.cr
+++ b/src/invidious/routes/video_playback.cr
@@ -6,8 +6,10 @@ module Invidious::Routes::VideoPlayback
 
     if query_params["enc"]? == "true"
       decrypted_data = decrypt_query_params(query_params["data"])
-      query_params["ip"] = decrypted_data.ip
-      query_params["pot"] = decrypted_data.pot
+      query_params.add("ip", decrypted_data.ip)
+      if pot = decrypted_data.pot
+        query_params.add("pot", pot)
+      end
       query_params.delete("enc")
       query_params.delete("data")
     end

--- a/src/invidious/routes/video_playback.cr
+++ b/src/invidious/routes/video_playback.cr
@@ -4,6 +4,14 @@ module Invidious::Routes::VideoPlayback
     locale = env.get("preferences").as(Preferences).locale
     query_params = env.params.query
 
+    if query_params["enc"]? == "true"
+      decrypted_data = decrypt_query_params(query_params["data"])
+      query_params["ip"] = decrypted_data.ip
+      query_params["pot"] = decrypted_data.pot
+      query_params.delete("enc")
+      query_params.delete("data")
+    end
+
     fvip = query_params["fvip"]? || "3"
     mns = query_params["mn"]?.try &.split(",")
     mns ||= [] of String


### PR DESCRIPTION
May close https://github.com/iv-org/invidious/issues/2142

Encrypts sensitive query parameters that should be hidden to users like `ip` and `pot` using the `hmac_key` config option. 

Taken from https://github.com/iv-org/invidious-companion/pull/65

There is some problems with this current implementation:
- The `hmac_key` config option needs to be at least 16 characters, if we force it, that will break some setups on a new update. I have thought of 3 ways to fix this:
  -  add characters to the `hmac_key` for the `ecb_without_salt` function until it has 16 (which is the minimum required for AES) if it's less than 16
  - use `invidious_companion_key`
  - introduce a new config option like `invidious_companion_key` but to encrypt the video query parameters.
- IP address and PoToken are still leaked if the video is not proxied and quality is set to medium, but that can be solved by forcing `Proxy videos` player preferences (Like I did here: https://git.nadeko.net/Fijxu/invidious/commit/7c9f79e1f146c59370bbe5e7abe82d37ec5fd5de). This will depend of the instance maintainer operator since proxying every video will use a lot of bandwidth, specially on public instances
- Any other videoplayback proxy without support for the encrypted parameters will not work, like https://github.com/TeamPiped/piped-proxy and https://github.com/TeamPiped/http3-ytproxy (But my fork supports it: https://git.nadeko.net/Fijxu/http3-ytproxy/src/commit/a6a33526a494a0719139602ec99c437dd64d81ef/internal/paths/videoplayback.go#L77)

Since Invidious companion will be become the official way to fetch youtube videos and videoplayback proxying, this may not be very useful on the future since companion is already able to encrypt the `ip` and `pot` query parameters, but will work for old setups that are still using `inv_sig_helper` for whatever reason (low memory capacity for example, since Invidious companion uses way more memory than `inv_sig_helper`)