### PR TITLE
Fix notification count of `TRUE`

### DIFF
--- a/assets/js/notifications.js
+++ b/assets/js/notifications.js
@@ -77,7 +77,7 @@ function create_notification_stream(subscriptions) {
 function update_ticker_count() {
     var notification_ticker = document.getElementById('notification_ticker');
 
-    const notification_count = helpers.storage.get(STORAGE_KEY_STREAM);
+    const notification_count = helpers.storage.get(STORAGE_KEY_NOTIF_COUNT);
     if (notification_count > 0) {
         notification_ticker.innerHTML =
             '<span id="notification_count">' + notification_count + '</span> <i class="icon ion-ios-notifications"></i>';

--- a/assets/js/notifications.js
+++ b/assets/js/notifications.js
@@ -77,7 +77,7 @@ function create_notification_stream(subscriptions) {
 function update_ticker_count() {
     var notification_ticker = document.getElementById('notification_ticker');
 
-    const notification_count = helpers.storage.get(STORAGE_KEY_NOTIF_COUNT);
+    const notification_count = helpers.storage.get(STORAGE_KEY_NOTIF_COUNT) || 0;
     if (notification_count > 0) {
         notification_ticker.innerHTML =
             '<span id="notification_count">' + notification_count + '</span> <i class="icon ion-ios-notifications"></i>';


### PR DESCRIPTION
This fixes an issue where the number of notifications can be displayed as `TRUE` rather than
the actual amount of notifications.

See here:
<img width="386" height="60" alt="Screenshot from 2025-07-18 20-08-30" src="https://github.com/user-attachments/assets/9e2c5dd4-40fa-4f97-aeaa-d91e5225143f" />

The issue comes from the `update_ticker_count` function in `notifications.js`. It uses the storage value `STORAGE_KEY_STREAM` which is a boolean value rather than `STORAGE_KEY_NOTIF_COUNT` which is the actual number of notifications.

The issue doesn't always occur because when you refresh the page, the new HTML returned by the server returns the correct amount of notifications, it's only an issue if you receive a new notification while watching a video.