### PR TITLE
dockerfile: compile openssl instead of using the one bundled on the crystal alpine image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,20 @@
-FROM crystallang/crystal:1.16.3-alpine AS builder
+# https://github.com/openssl/openssl/releases/tag/openssl-3.5.2
+ARG OPENSSL_VERSION='3.5.2'
+FROM crystallang/crystal:1.16.3-alpine AS dependabot-crystal
+
+FROM dependabot-crystal AS openssl-builder
+RUN apk add curl perl linux-headers
+
+WORKDIR /
+
+ARG OPENSSL_VERSION
+RUN curl -Ls "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz" | tar xz
+RUN cd openssl-${OPENSSL_VERSION} && ./Configure --openssldir=/etc/ssl && make -j
+
+FROM dependabot-crystal AS builder
 
 RUN apk add --no-cache sqlite-static yaml-static
+RUN apk del openssl-dev openssl-libs-static
 
 ARG release
 
@@ -20,13 +34,19 @@ COPY ./assets/ ./assets/
 COPY ./videojs-dependencies.yml ./videojs-dependencies.yml
 
 RUN crystal spec --warnings all \
-    --link-flags "-lxml2 -llzma"    
+--link-flags "-lxml2 -llzma"    
+
+ARG OPENSSL_VERSION
+COPY --from=openssl-builder /openssl-${OPENSSL_VERSION} /openssl-${OPENSSL_VERSION}
+
 RUN --mount=type=cache,target=/root/.cache/crystal if [[ "${release}" == 1 ]] ; then \
+        PKG_CONFIG_PATH=/openssl-${OPENSSL_VERSION} \
         crystal build ./src/invidious.cr \
         --release \
         --static --warnings all \
         --link-flags "-lxml2 -llzma"; \
     else \
+        PKG_CONFIG_PATH=/openssl-${OPENSSL_VERSION} \
         crystal build ./src/invidious.cr \
         --static --warnings all \
         --link-flags "-lxml2 -llzma"; \


### PR DESCRIPTION
May fix https://github.com/iv-org/invidious/issues/1438

This has been running on my instance for a long time now and the memory usage has been reduced significantly as it can be seen here: https://github.com/iv-org/invidious/issues/1438#issuecomment-3190651286

Although it still increases slowly for some reason, is way better than letting it crash by out of memory.

<img width="1927" height="1231" alt="image" src="https://github.com/user-attachments/assets/38a30de2-99df-4f69-b4c0-1656037f65fe" />

*The memory drops are from Docker daemon restarts while I was configuring some things, Invidious didn't crash by OOM and I didn't restart it manually either*

Since this graphs are from my fork that has some added things that upstream Invidious doesn't have, this may completely fix the memory leak, but I'm not really sure.

I haven't tested arm64 at all so I didn't make any changes to [docker/Dockerfile.arm64](https://github.com/iv-org/invidious/blob/fd8dc93569385f1980c00528e11adcea3d0c37ae/docker/Dockerfile.arm64)