### PR TITLE
CI: fix wrong if statement for build-docker job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Use ARM64 Dockerfile if ARM64
-        if: ${{ matrix.name }} == "ARM64"
+        if: ${{ matrix.name == 'ARM64' }}
         run: sed -i 's/Dockerfile/Dockerfile.arm64/' docker-compose.yml
 
       - name: Build Docker


### PR DESCRIPTION
I saw the Dockerfile was always changed to `Dockerfile.arm64` on the AMD64 build-docker while watching at https://github.com/iv-org/invidious/pull/5441 because of a syntax error 😅

Now works fine and it's greyed out: https://github.com/Fijxu/invidious/actions/runs/17406402847/job/49411827393

