### PR TITLE
Store `preferences` in a variable when reused and rename `prefs` to `preferences`

### DIFF
--- a/src/invidious/frontend/misc.cr
+++ b/src/invidious/frontend/misc.cr
@@ -2,9 +2,9 @@ module Invidious::Frontend::Misc
   extend self
 
   def redirect_url(env : HTTP::Server::Context)
-    prefs = env.get("preferences").as(Preferences)
+    preferences = env.get("preferences").as(Preferences)
 
-    if prefs.automatic_instance_redirect
+    if preferences.automatic_instance_redirect
       current_page = env.get?("current_page").as(String)
       return "/redirect?referer=#{current_page}"
     else

--- a/src/invidious/routes/channels.cr
+++ b/src/invidious/routes/channels.cr
@@ -264,11 +264,11 @@ module Invidious::Routes::Channels
     id = env.params.url["id"]
     ucid = env.params.query["ucid"]?
 
-    prefs = env.get("preferences").as(Preferences)
+    preferences = env.get("preferences").as(Preferences)
 
-    locale = prefs.locale
+    locale = preferences.locale
 
-    thin_mode = env.params.query["thin_mode"]? || prefs.thin_mode
+    thin_mode = env.params.query["thin_mode"]? || preferences.thin_mode
     thin_mode = thin_mode == "true"
 
     nojs = env.params.query["nojs"]?

--- a/src/invidious/routes/embed.cr
+++ b/src/invidious/routes/embed.cr
@@ -33,7 +33,8 @@ module Invidious::Routes::Embed
   end
 
   def self.show(env)
-    locale = env.get("preferences").as(Preferences).locale
+    preferences = env.get("preferences").as(Preferences)
+    locale = preferences.locale
     id = env.params.url["id"]
 
     plid = env.params.query["list"]?.try &.gsub(/[^a-zA-Z0-9_-]/, "")
@@ -44,8 +45,6 @@ module Invidious::Routes::Embed
       video_series = md[0].split(",")
       env.params.query.delete("playlist")
     end
-
-    preferences = env.get("preferences").as(Preferences)
 
     if id.includes?("%20") || id.includes?("+") || env.params.query.to_s.includes?("%20") || env.params.query.to_s.includes?("+")
       id = env.params.url["id"].gsub("%20", "").delete("+")

--- a/src/invidious/routes/feeds.cr
+++ b/src/invidious/routes/feeds.cr
@@ -43,13 +43,14 @@ module Invidious::Routes::Feeds
   end
 
   def self.trending(env)
-    locale = env.get("preferences").as(Preferences).locale
+    preferences = env.get("preferences").as(Preferences)
+    locale = preferences.locale
 
     trending_type = env.params.query["type"]?
     trending_type ||= "Default"
 
     region = env.params.query["region"]?
-    region ||= env.get("preferences").as(Preferences).region
+    region ||= preferences.region
 
     begin
       trending, plid = fetch_trending(trending_type, region, locale)

--- a/src/invidious/routes/playlists.cr
+++ b/src/invidious/routes/playlists.cr
@@ -225,10 +225,10 @@ module Invidious::Routes::Playlists
   end
 
   def self.add_playlist_items_page(env)
-    prefs = env.get("preferences").as(Preferences)
-    locale = prefs.locale
+    preferences = env.get("preferences").as(Preferences)
+    locale = preferences.locale
 
-    region = env.params.query["region"]? || prefs.region
+    region = env.params.query["region"]? || preferences.region
 
     user = env.get? "user"
     sid = env.get? "sid"

--- a/src/invidious/routes/preferences.cr
+++ b/src/invidious/routes/preferences.cr
@@ -2,11 +2,10 @@
 
 module Invidious::Routes::PreferencesRoute
   def self.show(env)
-    locale = env.get("preferences").as(Preferences).locale
+    preferences = env.get("preferences").as(Preferences)
+    locale = preferences.locale
 
     referer = get_referer(env)
-
-    preferences = env.get("preferences").as(Preferences)
 
     templated "user/preferences"
   end

--- a/src/invidious/routes/search.cr
+++ b/src/invidious/routes/search.cr
@@ -37,10 +37,10 @@ module Invidious::Routes::Search
   end
 
   def self.search(env)
-    prefs = env.get("preferences").as(Preferences)
-    locale = prefs.locale
+    preferences = env.get("preferences").as(Preferences)
+    locale = preferences.locale
 
-    region = env.params.query["region"]? || prefs.region
+    region = env.params.query["region"]? || preferences.region
 
     query = Invidious::Search::Query.new(env.params.query, :regular, region)
 

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -2,7 +2,8 @@
 
 module Invidious::Routes::Watch
   def self.handle(env)
-    locale = env.get("preferences").as(Preferences).locale
+    preferences = env.get("preferences").as(Preferences)
+    locale = preferences.locale
     region = env.params.query["region"]?
 
     if env.params.query.to_s.includes?("%20") || env.params.query.to_s.includes?("+")
@@ -37,8 +38,6 @@ module Invidious::Routes::Watch
 
     nojs ||= "0"
     nojs = nojs == "1"
-
-    preferences = env.get("preferences").as(Preferences)
 
     user = env.get?("user").try &.as(User)
     if user

--- a/src/invidious/views/embed.ecr
+++ b/src/invidious/views/embed.ecr
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= env.get("preferences").as(Preferences).locale %>">
+<html lang="<%= preferences.locale %>">
 
 <head>
     <meta charset="utf-8">

--- a/src/invidious/views/post.ecr
+++ b/src/invidious/views/post.ecr
@@ -38,7 +38,7 @@
     "params" => {
         "comments": ["youtube"]
     },
-    "preferences" => prefs,
+    "preferences" => preferences,
     "base_url" => "/api/v1/post/#{URI.encode_www_form(id)}/comments",
     "ucid" => ucid
 }.to_pretty_json

--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -1,6 +1,7 @@
 <%
-  locale = env.get("preferences").as(Preferences).locale
-  dark_mode = env.get("preferences").as(Preferences).dark_mode
+  preferences = env.get("preferences").as(Preferences)
+  locale = preferences.locale
+  dark_mode = preferences.dark_mode
 %>
 <!DOCTYPE html>
 <html lang="<%= locale %>">


### PR DESCRIPTION
A little code cleanup on places where `preferences` is used more than one time.