### PR TITLE
Fix button overflow

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -167,6 +167,7 @@ body a.pure-button-primary,
 
 .pure-button-primary,
 .pure-button-secondary {
+  white-space: normal;
   border: 1px solid #a0a0a0;
   border-radius: 3px;
   margin: 0 .4em;


### PR DESCRIPTION
On some languages, the translations inside the buttons can be larger than it's english counterpart, when testing Spanish, the "Add to playlist" button is larger, and it overflows it's parent box:

Before:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/0914d441-3141-40f7-930f-60013bf7ac7d" />

After:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/c9c60b02-cf00-4235-aa6c-ef8e87b2bbb1" />


I've also tested it on others parts of the Invidious interface and seems to look fine.