### PR TITLE
Prevent player microformat from being overwritten by the next microformat

### DIFF
--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -102,6 +102,9 @@ def extract_video_info(video_id : String)
   # Don't fetch the next endpoint if the video is unavailable.
   if {"OK", "LIVE_STREAM_OFFLINE", "LOGIN_REQUIRED"}.any?(playability_status)
     next_response = YoutubeAPI.next({"videoId": video_id, "params": ""})
+    # Remove the microformat returned by the /next endpoint on some videos
+    # to prevent player_response microformat from being overwritten.
+    next_response.reject!("microformat")
     player_response = player_response.merge(next_response)
   end
 


### PR DESCRIPTION
Closes https://github.com/iv-org/invidious/issues/5443

The player microformat is what we need to get the published date, premiere timestamp, allowed regions and more information of the video.

Youtube introduced a new `microformat.microformatDataRenderer` in the next endpoint which overwrote the player microformat `microformat.playerMicroformatRenderer` when merged

Here is a small piece of code to see how the player microformat gets overwritten: https://gist.github.com/Fijxu/79ddab062a572bc1b1bf7cf48eefe72f