### PR TITLE
Better documentation for the specific case public_url with companion

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -61,39 +61,32 @@ db:
 ## When this setting is commented out, Invidious companion is not used.
 ## Otherwise, Invidious will proxy the requests to Invidious companion.
 ## 
-## Note: multiple URL can be configured. In this case, invidious will
+## Note: multiple URL can be configured. In this case, Invidious will
 ## randomly pick one every time video data needs to be retrieved. This
 ## URL is then kept in the video metadata cache to allow video playback
 ## to work. Once said cache has expired, requesting that video's data
 ## again will cause a new companion URL to be picked.
 ##
-## The parameter private_url needs to be configured for the internal
-## communication between the companion and Invidious.
-## And public_url is the public URL from which companion is listening
-## to the requests from the user(s).
+## The parameter private_url is required for the internal communication
+## between Invidious companion and Invidious.
 ##
-## If you are using a reverse proxy then you will probably need to
-## configure the public_url to be the same as the domain used for Invidious.
-## Also apply when used from an external IP address (without a domain).
-## Examples: https://MYINVIDIOUSDOMAIN/companion or http://192.168.1.100:8282/companion
-##
-## Both parameter can have identical URL when Invidious is hosted in
-## an internal network or at home or locally (localhost).
-##
-## NOTE: If public_url is omitted, Invidious will use its built-in proxy
-## to route companion requests through /companion, which is useful for
-## simple setups where companion runs on the same network. When using
-## the built-in proxy, CSP headers are not modified since requests
-## stay within the same domain.
+## The optional parameter public_url is the public URL from which 
+## Invidious companion is listening to the requests from the user(s).
+## When this setting is commented out, Invidious proxy all requests to
+## Invidious companion. Useful for simple setups.
+## Otherwise, requests from the user(s) will reach Invidious companion directly.
+## And you will need to configure a reverse proxy with separate routes
+## for Invidious and Invidious companion.
+## Read the post-install documentation for advanced reverse proxy
+## documentation: https://docs.invidious.io/installation/#post-install-configuration
 ##
 ## Accepted values: "http(s)://<IP-HOSTNAME>:<Port>"
 ## Default: <none>
 ##
 #invidious_companion:
 #  - private_url: "http://localhost:8282/companion"
-#    public_url: "http://localhost:8282/companion"
-#  # Example with built-in proxy (omit public_url):
-#  # - private_url: "http://localhost:8282/companion"
+#  # Uncomment for advanced reverse proxy configuration (see above).
+#  # public_url: "http://localhost:8282/companion"
 
 ##
 ## API key for Invidious companion, used for securing the communication


### PR DESCRIPTION
Make it easier to understand what's this parameter. And don't make a big deal about it, just redirect to the documentation for advanced users