### PR TITLE
Display "Erroneous CAPTCHA" for invalid captchas

### DIFF
--- a/src/invidious/routes/login.cr
+++ b/src/invidious/routes/login.cr
@@ -98,6 +98,8 @@ module Invidious::Routes::Login
 
             begin
               validate_request(tokens[0], answer, env.request, HMAC_KEY, locale)
+            rescue ex : InfoException
+              return error_template(400, InfoException.new("Erroneous CAPTCHA"))
             rescue ex
               return error_template(400, ex)
             end


### PR DESCRIPTION
Closes https://github.com/iv-org/invidious/issues/5388

"Erroneous CAPTCHA" is already added to the locales, it was unused.

It could also be `return error_template(400, InfoException.new("#{translate(locale, "Erroneous CAPTCHA")}: #{ex.message}"))` to display more details about the error, but a simple "Erroneous CAPTCHA" seems enough to me.

Note: Using `return error_template(400, InfoException.new("#{translate(locale, "Erroneous CAPTCHA")}: #{ex.message}"))` will try to translate the message of `InfoException`, so it will always warn about a missing translation key:

```
2025-10-08 13:31:49 UTC [warn] i18n: Missing translation key "CAPTCHA no válido: Erroneous token"
```