### PR TITLE
chore(ameba): Do not exclude /api routes from Lint/UselessAssign

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -7,7 +7,7 @@ Lint/UselessAssign:
   Excluded:
   - src/invidious.cr
   - src/invidious/helpers/errors.cr
-  - src/invidious/routes/**/*.cr
+  - src/invidious/routes/*.cr
 
 # Ignore false negative (if !db.query_one?...)
 Lint/UnreachableCode:


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [x] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description

Routes bellow files under `src/invidious/routes/` are used to render ECR, and they can take variables from the functions, they appear as unused variables for Ameba, but they are used in the ECR files as the comments says, but it also excluded the `src/invidious/routes/api` files, which are used for the API and do not render any ECR, so useless assigns in `src/invidious/routes/api` files can be safely removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to apply the unused-assignment exception only to route files directly under the designated routes directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->