### PR TITLE
feat: show message for unsupported Crystal versions at compile time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,11 +107,12 @@ help:
 	@echo ""
 	@echo "Build options available for this Makefile:"
 	@echo ""
-	@echo "  RELEASE          Make a release build            (Default: 1)"
-	@echo "  STATIC           Link libraries statically       (Default: 0)"
+	@echo "  RELEASE              Make a release build                     (Default: 1)"
+	@echo "  STATIC               Link libraries statically                (Default: 0)"
 	@echo ""
-	@echo "  API_ONLY         Build invidious without a GUI   (Default: 0)"
-	@echo "  NO_DBG_SYMBOLS   Strip debug symbols             (Default: 0)"
+	@echo "  API_ONLY             Build invidious without a GUI            (Default: 0)"
+	@echo "  NO_DBG_SYMBOLS       Strip debug symbols                      (Default: 0)"
+	@echo "  SKIP_VERSION_CHECK   Skips the Crystal compiler version check (Default: 0)"
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ RELEASE  := 1
 STATIC   := 0
 
 NO_DBG_SYMBOLS := 0
+SKIP_VERSION_CHECK := 0
 
 FLAGS ?=
 
@@ -27,6 +28,9 @@ ifeq ($(API_ONLY), 1)
   FLAGS += -Dapi_only
 endif
 
+ifeq ($(SKIP_VERSION_CHECK), 1)
+  FLAGS += -Dskip_version_check
+endif
 
 # -----------------------
 #  Main

--- a/shard.yml
+++ b/shard.yml
@@ -10,7 +10,7 @@ targets:
     main: src/invidious.cr
 
 description: |
-   Invidious is an alternative front-end to YouTube 
+   Invidious is an alternative front-end to YouTube
 
 dependencies:
   pg:
@@ -40,7 +40,7 @@ development_dependencies:
     github: crystal-ameba/ameba
     version: ~> 1.6.1
 
-crystal: ">= 1.10.0, < 2.0.0"
+crystal: ">= 1.20.0, < 2.0.0"
 
 license: AGPL-3.0-only
 

--- a/shard.yml
+++ b/shard.yml
@@ -40,7 +40,7 @@ development_dependencies:
     github: crystal-ameba/ameba
     version: ~> 1.6.1
 
-crystal: ">= 1.20.0, < 2.0.0"
+crystal: ">= 1.14.0, < 2.0.0"
 
 license: AGPL-3.0-only
 

--- a/shard.yml
+++ b/shard.yml
@@ -40,7 +40,7 @@ development_dependencies:
     github: crystal-ameba/ameba
     version: ~> 1.6.1
 
-crystal: ">= 1.14.0, < 2.0.0"
+crystal: ">= 1.14.1, < 2.0.0"
 
 license: AGPL-3.0-only
 

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -64,7 +64,7 @@ require "./invidious/jobs/*"
     {% if compare_versions(Crystal::VERSION, minimum_version) < 0 %}
       {{ raise "Crystal version #{minimum_version} or newer is required to build Invidious. \
         You currently have Crystal version #{Crystal::VERSION} installed. \
-        We recommend that you install it following the way that the Crystal compiler itself recommend for your OS, see: https://crystal-lang.org/install/" }}
+        We recommend that you install it following the way that the team behind the Crystal compiler itself recommend for your OS, see: https://crystal-lang.org/install/" }}
     {% end %}
   {% end %}
 {% end %}

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -51,7 +51,7 @@ require "./invidious/jobs/base_job"
 require "./invidious/jobs/*"
 
 # Show a nice message for unsupported versions of the Crystal compiler,
-# encouraging the user compiling Invidiou, to update it's Crystal compiler
+# encouraging the user compiling Invidious, to update it's Crystal compiler
 # version.
 {% if compare_versions(Crystal::VERSION, "1.12.0") < 0 %}
   {{ raise "Crystal version 1.12.0 or newer is required to build Invidious, \

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -50,7 +50,7 @@ require "./invidious/routes/**"
 require "./invidious/jobs/base_job"
 require "./invidious/jobs/*"
 
-# Show a nice message for unsupported versions of the Crystal compiler,
+# Show a nice message in case the current Crystal compiler version is unsupoported```
 # encouraging the user compiling Invidious to update it```
 # version.
 {% begin %}

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -57,7 +57,7 @@ require "./invidious/jobs/*"
   {{ raise "Crystal version 1.14.1 or newer is required to build Invidious. \
     You currently have Crystal version #{Crystal::VERSION} installed. \
     update it to a new version to be able to build Invidious. \
-    For more information, visit the official Crystal compiler website: https://crystal-lang.org/install/" }}
+    We recommend that you install it following the way that the Crystal compiler itself recommend for your OS, see: https://crystal-lang.org/install/" }}
 {% end %}
 
 # Declare the base namespace for invidious

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -53,10 +53,13 @@ require "./invidious/jobs/*"
 # Show a nice message for unsupported versions of the Crystal compiler,
 # encouraging the user compiling Invidious, to update it's Crystal compiler
 # version.
-{% if compare_versions(Crystal::VERSION, "1.14.1") < 0 %}
-  {{ raise "Crystal version 1.14.1 or newer is required to build Invidious. \
-    You currently have Crystal version #{Crystal::VERSION} installed. \
-    We recommend that you install it following the way that the Crystal compiler itself recommend for your OS, see: https://crystal-lang.org/install/" }}
+{% begin %}
+  {% minimum_version = "1.14.1" %}
+  {% if compare_versions(Crystal::VERSION, minimum_version) < 0 %}
+    {{ raise "Crystal version #{minimum_version} or newer is required to build Invidious. \
+      You currently have Crystal version #{Crystal::VERSION} installed. \
+      We recommend that you install it following the way that the Crystal compiler itself recommend for your OS, see: https://crystal-lang.org/install/" }}
+  {% end %}
 {% end %}
 
 # Declare the base namespace for invidious

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -58,13 +58,15 @@ require "./invidious/jobs/*"
   # or weird installations that lack the `shard.yml` file when compiling
   # Invidious.
   {% if !flag?(:skip_version_check) %}
-    {% shard_yml = read_file("shard.yml") %}
-    {% crystal_constraint = shard_yml.split('\n').find(&.starts_with?("crystal:")) %}
-    {% minimum_version = crystal_constraint.split('"')[1].split(",").first.split(">=").last.strip %}
-    {% if compare_versions(Crystal::VERSION, minimum_version) < 0 %}
-      {{ raise "Crystal version #{minimum_version} or newer is required to build Invidious. \
-        You currently have Crystal version #{Crystal::VERSION} installed. \
-        We recommend that you install it following the way that the team behind the Crystal compiler itself recommend for your OS, see: https://crystal-lang.org/install/" }}
+    {% if file_exists?("#{__DIR__}/../shard.yml") %}
+      {% shard_yml = read_file("#{__DIR__}/../shard.yml") %}
+      {% crystal_constraint = shard_yml.split('\n').find(&.starts_with?("crystal:")) %}
+      {% minimum_version = crystal_constraint.split('"')[1].split(",").first.split(">=").last.strip %}
+      {% if compare_versions(Crystal::VERSION, minimum_version) < 0 %}
+        {{ raise "Crystal version #{minimum_version} or newer is required to build Invidious. \
+          You currently have Crystal version #{Crystal::VERSION} installed. \
+          We recommend that you install it following the way that the team behind the Crystal compiler itself recommend for your OS, see: https://crystal-lang.org/install/" }}
+      {% end %}
     {% end %}
   {% end %}
 {% end %}

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -59,7 +59,7 @@ require "./invidious/jobs/*"
   # Invidious.
   {% if !flag?(:skip_version_check) %}
     {% shard_yml = read_file("shard.yml") %}
-    {% crystal_constraint = shard_yml.split('\n').find { |line| line.starts_with?("crystal:") } %}
+    {% crystal_constraint = shard_yml.split('\n').find(&.starts_with?("crystal:")) %}
     {% minimum_version = crystal_constraint.split('"')[1].split(",").first.split(">=").last.strip %}
     {% if compare_versions(Crystal::VERSION, minimum_version) < 0 %}
       {{ raise "Crystal version #{minimum_version} or newer is required to build Invidious. \

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -56,7 +56,8 @@ require "./invidious/jobs/*"
 {% if compare_versions(Crystal::VERSION, "1.12.0") < 0 %}
   {{ raise "Crystal version 1.12.0 or newer is required to build Invidious, \
     you currently have Crystal version #{Crystal::VERSION}, \
-    update it to a new version to be able to build Invidious." }}
+    update it to a new version to be able to build Invidious. \
+    For more information, visit the official Crystal compiler website: https://crystal-lang.org/install/" }}
 {% end %}
 
 # Declare the base namespace for invidious

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -56,7 +56,6 @@ require "./invidious/jobs/*"
 {% if compare_versions(Crystal::VERSION, "1.14.1") < 0 %}
   {{ raise "Crystal version 1.14.1 or newer is required to build Invidious. \
     You currently have Crystal version #{Crystal::VERSION} installed. \
-    update it to a new version to be able to build Invidious. \
     We recommend that you install it following the way that the Crystal compiler itself recommend for your OS, see: https://crystal-lang.org/install/" }}
 {% end %}
 

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -55,7 +55,7 @@ require "./invidious/jobs/*"
 # version.
 {% if compare_versions(Crystal::VERSION, "1.14.1") < 0 %}
   {{ raise "Crystal version 1.14.1 or newer is required to build Invidious. \
-    you currently have Crystal version #{Crystal::VERSION}, \
+    You currently have Crystal version #{Crystal::VERSION} installed. \
     update it to a new version to be able to build Invidious. \
     For more information, visit the official Crystal compiler website: https://crystal-lang.org/install/" }}
 {% end %}

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -53,8 +53,8 @@ require "./invidious/jobs/*"
 # Show a nice message for unsupported versions of the Crystal compiler,
 # encouraging the user compiling Invidious, to update it's Crystal compiler
 # version.
-{% if compare_versions(Crystal::VERSION, "1.12.0") < 0 %}
-  {{ raise "Crystal version 1.12.0 or newer is required to build Invidious, \
+{% if compare_versions(Crystal::VERSION, "1.14.1") < 0 %}
+  {{ raise "Crystal version 1.14.1 or newer is required to build Invidious, \
     you currently have Crystal version #{Crystal::VERSION}, \
     update it to a new version to be able to build Invidious. \
     For more information, visit the official Crystal compiler website: https://crystal-lang.org/install/" }}

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -51,7 +51,7 @@ require "./invidious/jobs/base_job"
 require "./invidious/jobs/*"
 
 # Show a nice message for unsupported versions of the Crystal compiler,
-# encouraging the user compiling Invidious, to update it's Crystal compiler
+# encouraging the user compiling Invidious to update it```
 # version.
 {% begin %}
   # `-Dskip_version_check` compile-time flag, for development purposes

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -54,11 +54,18 @@ require "./invidious/jobs/*"
 # encouraging the user compiling Invidious, to update it's Crystal compiler
 # version.
 {% begin %}
-  {% minimum_version = "1.14.1" %}
-  {% if compare_versions(Crystal::VERSION, minimum_version) < 0 %}
-    {{ raise "Crystal version #{minimum_version} or newer is required to build Invidious. \
-      You currently have Crystal version #{Crystal::VERSION} installed. \
-      We recommend that you install it following the way that the Crystal compiler itself recommend for your OS, see: https://crystal-lang.org/install/" }}
+  # `-Dskip_version_check` compile-time flag, for development purposes
+  # or weird installations that lack the `shard.yml` file when compiling
+  # Invidious.
+  {% if !flag?(:skip_version_check) %}
+    {% shard_yml = read_file("shard.yml") %}
+    {% crystal_constraint = shard_yml.split('\n').find { |line| line.starts_with?("crystal:") } %}
+    {% minimum_version = crystal_constraint.split('"')[1].split(",").first.split(">=").last.strip %}
+    {% if compare_versions(Crystal::VERSION, minimum_version) < 0 %}
+      {{ raise "Crystal version #{minimum_version} or newer is required to build Invidious. \
+        You currently have Crystal version #{Crystal::VERSION} installed. \
+        We recommend that you install it following the way that the Crystal compiler itself recommend for your OS, see: https://crystal-lang.org/install/" }}
+    {% end %}
   {% end %}
 {% end %}
 

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -50,6 +50,15 @@ require "./invidious/routes/**"
 require "./invidious/jobs/base_job"
 require "./invidious/jobs/*"
 
+# Show a nice message for unsupported versions of the Crystal compiler,
+# encouraging the user compiling Invidiou, to update it's Crystal compiler
+# version.
+{% if compare_versions(Crystal::VERSION, "1.12.0") < 0 %}
+  {{ raise "Crystal version 1.12.0 or newer is required to build Invidious, \
+    you currently have Crystal version #{Crystal::VERSION}, \
+    update it to a new version to be able to build Invidious." }}
+{% end %}
+
 # Declare the base namespace for invidious
 module Invidious
 end

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -54,7 +54,7 @@ require "./invidious/jobs/*"
 # encouraging the user compiling Invidious, to update it's Crystal compiler
 # version.
 {% if compare_versions(Crystal::VERSION, "1.14.1") < 0 %}
-  {{ raise "Crystal version 1.14.1 or newer is required to build Invidious, \
+  {{ raise "Crystal version 1.14.1 or newer is required to build Invidious. \
     you currently have Crystal version #{Crystal::VERSION}, \
     update it to a new version to be able to build Invidious. \
     For more information, visit the official Crystal compiler website: https://crystal-lang.org/install/" }}


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [x] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description

Show a nice message for unsupported versions of the Crystal compiler, encouraging the user compiling Invidious, to update it's Crystal compiler version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Updated the minimum supported Crystal version to 1.14.0 while retaining support for versions below 2.0.0.
  * Added an automatic compile-time check for the installed Crystal version.
  * Outdated compiler errors now show the required version, detected version, and upgrade guidance.
  * Added a build option to bypass the version check when necessary.
  * Updated build help to document the version-check option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds a Crystal compiler compatibility check, resolves the project manifest from the source tree, and provides a Makefile bypass for non-standard builds. Compilation succeeded when invoked through an absolute entrypoint from a directory without `shard.yml`, when the source-root manifest was absent, and with the normal source-root manifest.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The compiler guard’s normal, manifest-free, and external-working-directory paths completed successfully.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the authored executable check to compile the application with --no-codegen -Dskip\_videojs\_download in three configurations: a copied source root without shard.yml, an absolute entrypoint from a manifest-free directory, and the normal repository-root build.
- Observed that all three compilations exited with code 0, and the normal build produced only deprecation warnings, confirming that the compiler guard does not depend on the caller working directory and safely skips manifest reads when the manifest is absent.
- Uploaded the authored executable check and its captured execution output, including the exact commands and working directories used for the three builds.

<a href="https://app.greptile.com/trex/runs/20136189/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["skip version checking if shard.yml file ..."](https://github.com/iv-org/invidious/commit/59dd9c919162402aacf46eeef34d9c4c97bb63be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51303517)</sub>

<!-- /greptile_comment -->