### PR TITLE
fix: resolve channel of related videos published as a collaboration

### DIFF
--- a/spec/invidious/videos/related_video_collaboration_spec.cr
+++ b/spec/invidious/videos/related_video_collaboration_spec.cr
@@ -1,0 +1,103 @@
+require "../../parsers_helper.cr"
+
+Spectator.describe "parse_related_video" do
+  it "extracts the channel of a video published as a collaboration" do
+    # A video published as a collaboration between two channels. Its byline
+    # carries no "browseEndpoint"; it opens a "Collaborators" dialog instead,
+    # and the channel of each collaborator sits inside that dialog.
+    #
+    # See: https://github.com/iv-org/invidious/issues/5722
+    related = JSON.parse(<<-JSON)
+      {
+        "videoId": "dbVdnL6HWOg",
+        "title": { "simpleText": "Professor Jiang Debates Iran War, Trump And China Ties" },
+        "lengthInSeconds": 2241,
+        "shortViewCountText": { "simpleText": "1M views" },
+        "publishedTimeText": { "simpleText": "3 months ago" },
+        "shortBylineText": {
+          "runs": [
+            {
+              "text": "Piers Morgan Uncensored and ProfSteveKeen",
+              "navigationEndpoint": {
+                "showDialogCommand": {
+                  "panelLoadingStrategy": {
+                    "inlineContent": {
+                      "dialogViewModel": {
+                        "customContent": {
+                          "listViewModel": {
+                            "listItems": [
+                              {
+                                "listItemViewModel": {
+                                  "title": { "content": "Piers Morgan Uncensored" },
+                                  "rendererContext": {
+                                    "commandContext": {
+                                      "onTap": {
+                                        "innertubeCommand": {
+                                          "browseEndpoint": { "browseId": "UCatt7TBjfBkiJWx8khav_Gg" }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "listItemViewModel": {
+                                  "title": { "content": "ProfSteveKeen" },
+                                  "rendererContext": {
+                                    "commandContext": {
+                                      "onTap": {
+                                        "innertubeCommand": {
+                                          "browseEndpoint": { "browseId": "UCM1ubsbE-tG9ru61mc3zX8A" }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+      JSON
+
+    parsed = Invidious::Videos::Parser.parse_related_video(related).not_nil!
+
+    expect(parsed["ucid"].as_s).to eq("UCatt7TBjfBkiJWx8khav_Gg")
+    expect(parsed["author"].as_s).to eq("Piers Morgan Uncensored and ProfSteveKeen")
+  end
+
+  it "keeps extracting the channel of a single author video" do
+    related = JSON.parse(<<-JSON)
+      {
+        "videoId": "_g4l7YkDQwA",
+        "title": { "simpleText": "The Diary Of A CEO episode" },
+        "lengthInSeconds": 1337,
+        "shortViewCountText": { "simpleText": "2.1M views" },
+        "publishedTimeText": { "simpleText": "1 month ago" },
+        "shortBylineText": {
+          "runs": [
+            {
+              "text": "The Diary Of A CEO",
+              "navigationEndpoint": {
+                "browseEndpoint": { "browseId": "UCGq-a57w-aPwyi3pW7XLiHw" }
+              }
+            }
+          ]
+        }
+      }
+      JSON
+
+    parsed = Invidious::Videos::Parser.parse_related_video(related).not_nil!
+
+    expect(parsed["ucid"].as_s).to eq("UCGq-a57w-aPwyi3pW7XLiHw")
+    expect(parsed["author"].as_s).to eq("The Diary Of A CEO")
+  end
+end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -28,6 +28,13 @@ module Invidious::Videos::Parser
 
     ucid = channel_info.try { |ci| HelperExtractors.get_browse_id(ci) }
 
+    # Videos published as a collaboration have no "browseEndpoint" in their
+    # byline, so the channel has to be read from the "Collaborators" dialog
+    # that the byline opens instead. See `get_collaborator_browse_id`.
+    if ucid.nil? || ucid.empty?
+      ucid = channel_info.try { |ci| HelperExtractors.get_collaborator_browse_id(ci) }
+    end
+
     short_view_count = related.try do |r|
       HelperExtractors.get_short_view_count(r).to_s
     end

--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -1143,6 +1143,21 @@ module HelperExtractors
   def self.get_browse_id(container)
     return container.dig?("navigationEndpoint", "browseEndpoint", "browseId").try &.as_s || ""
   end
+
+  # Videos published as a collaboration have no "browseEndpoint" in their
+  # byline. Their byline opens a "Collaborators" dialog instead, which holds
+  # the channel of every collaborator. Retrieves the ID of the first entry,
+  # which is the channel the video was published on.
+  #
+  # Returns an empty string when it's unable to do so
+  def self.get_collaborator_browse_id(container)
+    return container.dig?(
+      "navigationEndpoint", "showDialogCommand", "panelLoadingStrategy",
+      "inlineContent", "dialogViewModel", "customContent", "listViewModel",
+      "listItems", 0, "listItemViewModel", "rendererContext", "commandContext",
+      "onTap", "innertubeCommand", "browseEndpoint", "browseId"
+    ).try &.as_s || ""
+  end
 end
 
 # Parses an item from Youtube's JSON response into a more usable structure.


### PR DESCRIPTION
Related videos published as a collaboration between several channels carry no "browseEndpoint" in their byline. Their byline opens a "Collaborators" dialog instead, which holds the channel of each collaborator, so `get_browse_id` returned an empty string and the recommendation was rendered without a link to the channel.

Fall back to the first entry of that dialog, which is the channel the video was published on.

Fixes #5722

## Checklist

- [x ] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ x] AI was used to partially create this pull request


**Model(s) used (and thinking/reasoning level if relevant):**
<!-opus 5.0. -->

**Tool(s) used:**
<!-- claude code -->

**How was AI used?**
<!code was written by human and reviewed tested and improved by ai-->

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Related videos featuring collaborations now retain the correct channel identity.
  * Improved collaborator information extraction when multiple creators are listed.
  * Standard single-author video attribution remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change restores channel links for related videos published as collaborations. When a byline opens a collaborators dialog instead of containing a direct channel link, the parser now uses the first collaborator’s channel ID; ordinary single-author bylines continue using their existing direct channel ID.

Focused Crystal checks passed for collaboration payloads, direct-byline payloads, and malformed collaborator-dialog payloads. Missing dialogs and empty collaborator lists return an empty channel ID without crashing.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The collaboration channel-link behavior is safe to merge for the reviewed payload shapes.

Execution verified that dialog-only collaboration bylines resolve to the first collaborator channel, ordinary bylines preserve their direct channel ID, and absent or empty dialog data does not crash parsing.

**Files Needing Attention:** No additional files need attention for the reviewed behavior.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated direct browse-ID extraction on a dialog-only collaboration byline; it returns an empty ID without the fallback, and the focused collaboration parser spec passed with both examples, including the first collaborator channel ID.
- Validated the focused direct-byline Crystal example; it passed with the original direct channel ID, and the complete collaboration parser spec passed for both direct and fallback, with the guarded fallback preserving a non-empty direct browse ID.
- Parsed malformed related-video inputs both with and without a collaborators dialog; parsing completed with empty channel IDs, illustrating the null-safe parser and dialog traversal guarding behavior.
- Reviewed end-to-end test runs of the related-video collaboration specs; before and after results exited with code 0 and no failures, with code evidence captured.
- Observed missing-dialog and empty-first-entry runtime checks exiting 0, printing PASS with empty UCID, and artifacts saved/uploaded via TREX artifact mechanism.

<a href="https://app.greptile.com/trex/runs/19639895/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve channel of related videos p..."](https://github.com/iv-org/invidious/commit/f708bda6e465c140f6a80ccaf2bba87f0b356983) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54836282)</sub>

<!-- /greptile_comment -->