### PR TITLE
Extract published time and view count from all metadata rows in LockupViewModel

### DIFF
--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -661,8 +661,9 @@ private module Parsers
 
         metadata = item_contents.dig("metadata", "lockupMetadataViewModel")
         title = metadata.dig("title", "content").as_s
-        # Contains the views of the video and the published time of the video.
-        metadata_parts = metadata.dig("metadata", "contentMetadataViewModel", "metadataRows", 0, "metadataParts").try &.as_a
+        # Contains the views of the video and the published time of the video (supports multiple creators).
+        metadata_rows = metadata.dig?("metadata", "contentMetadataViewModel", "metadataRows").try &.as_a
+        metadata_parts = metadata_rows.try &.flat_map { |row| row.dig?("metadataParts").try &.as_a || [] of JSON::Any }
 
         view_count_text = metadata_parts.try &.find { |item| item["icon"]?.nil? && item.dig?("text", "content").try &.as_s.includes?("views") }
           .try &.dig("text", "content").as_s


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
Gemini 3.7 Flash 

**Tool(s) used:**
IDE Agent Assistant

**How was AI used?**
Assisted in tracing the `LockupViewModelParser` InnerTube JSON response structure for collaborative video items and verifying the `metadataRows` array extraction logic.

---

## Pull request description

Closes #5740

### Description
When a YouTube video features multiple creators/collaborators, YouTube places the collaborator list inside `metadataRows[0]` and shifts the view count and published timestamp into `metadataRows[1]`.

Previously, `LockupViewModelParser` only inspected `metadataRows[0]`, resulting in missing view counts and published dates on collaborative videos. This PR iterates across all `metadataRows` so that both single-author and multi-author videos have their view counts and timestamps extracted accurately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video metadata parsing to accurately extract view counts and publication dates when information is distributed across multiple metadata rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change updates lockup-video parsing so it can collect metadata parts from every metadata row, supporting collaborative cards that separate creator details from view counts and publication times.

A focused fixture verified that lockup videos without `metadataRows` now parse as normal videos and retain their fallback values instead of becoming problematic timeline items.

### T-Rex validation blocked

- **tool — standalone parser fixture:** The focused collaborative-card fixture could not compile the full extractor dependency graph because the temporary harness reached a `Category.new` constructor that requires the complete application model setup. The later-row view-count and publication-time assertions therefore did not execute. [Configure VMs](https://app.greptile.com/-/settings/trex#environments)
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The verified missing-metadata fallback is safe, but the main collaborative-card scenario still needs a completed runtime check before merge confidence can increase.

The parser code combines metadata parts from all rows, and a before/after fixture confirmed the nil-row fallback works. The later-row fixture stopped during compilation before its assertions ran, leaving the central view-count and published-time behavior unresolved.

**Files Needing Attention:** src/invidious/yt_backend/extractors.cr needs a focused fixture or project-integrated spec covering a collaborative lockup video with view-count and published-time values in a later metadata row.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a lockup-video fixture without metadataRows against the parent revision and the reviewed revision; the parent revision produced a ProblematicTimelineItem, while the reviewed revision produced a SearchVideo preserving the asserted fallback author, channel ID, views, publication time, duration, and title.
- Attempted focused parser validation with a temporary fixture for metadata in a later row, but compilation stopped at extractor line 460, so the later-row view-count and publication-time assertions did not execute.
- T-Rex produced proof for a posted P2 finding; see the corresponding review comment for details.
- Inspected the extractor code around the metadata handling and attempted to run the lockup metadata parse fixture, but the run exited early due to a compilation error; no artifact was uploaded for this check.
- Executed a before/after lockup-video test with no metadata rows; the before run in the parent commit produced a ProblematicTimelineItem and the after run produced a SearchVideo with all asserted fallback values; the paired commands and outputs were captured as logs.

<a href="https://app.greptile.com/trex/runs/19805206/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/invidious/yt_backend/extractors.cr`, line 460 ([link](https://github.com/iv-org/invidious/blob/71d9409ecae742f66cc45dc4ee182720f53cc928/src/invidious/yt_backend/extractors.cr#L460)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Focused parser validation did not execute**

   - **Bug**
     - The temporary actual-parser fixture could not compile the full extractor dependency graph. The latest captured execution stopped at src/invidious/yt_backend/extractors.cr:460 because Category only exposed a DB::ResultSet constructor in the standalone harness, so the later-metadata-row assertions did not run.
   - **Cause**
     - The temporary standalone harness loaded the broad extractor source without the complete application model dependency graph.
   - **Fix**
     - Run the existing parser in the complete project test environment or provide all model definitions required by the extractor module, then execute the same two fixtures.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Extract published time and view count fr..."](https://github.com/iv-org/invidious/commit/71d9409ecae742f66cc45dc4ee182720f53cc928) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55151948)</sub>

<!-- /greptile_comment -->