### PR TITLE
Safely parse custom emojis without requiring text key in runs

### DIFF
--- a/src/invidious/comments/content.cr
+++ b/src/invidious/comments/content.cr
@@ -51,7 +51,7 @@ def content_to_comment_html(content, video_id : String? = "")
     # See: https://github.com/iv-org/invidious/issues/3096
     next if run.as_h.empty?
 
-    text = HTML.escape(run["text"].as_s)
+    text = HTML.escape(run["text"]?.try &.as_s || "")
 
     if navigation_endpoint = run.dig?("navigationEndpoint")
       text = parse_link_endpoint(navigation_endpoint, text, video_id)
@@ -66,14 +66,17 @@ def content_to_comment_html(content, video_id : String? = "")
       if run["emoji"]["isCustomEmoji"]?.try &.as_bool
         if emoji_image = run.dig?("emoji", "image")
           emoji_alt = emoji_image.dig?("accessibility", "accessibilityData", "label").try &.as_s || text
-          emoji_thumb = emoji_image["thumbnails"][0]
-          text = String.build do |str|
-            str << %(<img alt=") << emoji_alt << "\" "
-            str << %(src="/ggpht) << URI.parse(emoji_thumb["url"].as_s).request_target << "\" "
-            str << %(title=") << emoji_alt << "\" "
-            str << %(width=") << emoji_thumb["width"] << "\" "
-            str << %(height=") << emoji_thumb["height"] << "\" "
-            str << %(class="channel-emoji" />)
+          if emoji_thumb = emoji_image.dig?("thumbnails", 0)
+            text = String.build do |str|
+              str << %(<img alt=") << emoji_alt << "\" "
+              str << %(src="/ggpht) << URI.parse(emoji_thumb["url"].as_s).request_target << "\" "
+              str << %(title=") << emoji_alt << "\" "
+              str << %(width=") << emoji_thumb["width"]? << "\" "
+              str << %(height=") << emoji_thumb["height"]? << "\" "
+              str << %(class="channel-emoji" />)
+            end
+          else
+            text = emoji_alt
           end
         else
           # Hide deleted channel emoji


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
Gemini 3.7 Flash

**Tool(s) used:**
IDE Agent Assistant

**How was AI used?**
Assisted in identifying the missing `text` key exception in `content_to_comment_html` when parsing emoji runs from YouTube comments/descriptions.

---

## Pull request description

Closes #5888

### Description
When parsing custom emoji runs from YouTube comments and descriptions, YouTube does not include a `text` property on emoji run nodes. 

Previously, `content_to_comment_html` strictly evaluated `HTML.escape(run["text"].as_s)`, which raised a key exception on custom emoji nodes and broke rendering across comments and video descriptions.

This PR uses `run["text"]?` with a fallback and safely checks for thumbnail availability before building the image tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment display when text content or custom emoji thumbnails are missing.
  * Added a fallback to show the emoji label when its thumbnail is unavailable.
  * Prevented errors caused by missing thumbnail dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change makes custom emoji runs tolerate missing `text` fields and missing thumbnail data. Production parser checks confirm both incomplete-data cases now render without raising. However, custom emoji accessibility labels are rendered without escaping in both the no-thumbnail fallback and the thumbnail image attributes, allowing browser-interpreted markup to be injected.

Do not merge until accessibility labels are escaped for both text and HTML attribute output.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Not safe to merge until custom emoji labels are escaped in every rendering context.

Focused production-parser executions confirmed the intended missing-field and missing-thumbnail behavior, and independently reproduced raw HTML output plus injected image event-handler attributes. All identified failures are localized to the custom emoji rendering flow.

**Files Needing Attention:** `src/invidious/comments/content.cr` needs escaping for the no-thumbnail label fallback and for labels interpolated into image attributes.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran a focused contract-validation pass for custom emoji rendering and verified that the optional lookup and empty-string fallback prevent rendering failure.
- T-Rex executed baseline and malicious input tests to verify label escaping and HTML handling, including precise excerpts showing where the unescaped label is assigned.
- T-Rex compared pre- and post-capture behavior to confirm missing text is handled and that the current payload yields the expected custom-emoji HTML; harness execution evidence was retained.
- T-Rex produced proofs for posted P1 findings and prepared reviewer-validation artifacts for each finding.

<a href="https://app.greptile.com/trex/runs/19806100/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **No-thumbnail custom emoji label is emitted without HTML escaping**

   - **Bug**
     - A custom emoji whose image contains `accessibility.accessibilityData.label` but no `thumbnails[0]` is rendered as the raw label. The executable production-parser run returned `<img src=x onerror=alert(1)>` verbatim rather than escaped text.
   - **Cause**
     - `emoji_alt` is read directly from the accessibility label on line 68, and the no-thumbnail branch assigns `text = emoji_alt` on line 79. This bypasses the initial escaping performed for `run["text"]` on line 54.
   - **Fix**
     - Escape the accessibility label before assigning it to output in the no-thumbnail path, e.g. `text = HTML.escape(emoji_alt)`. Review the thumbnail branch separately because the same value is interpolated into HTML attributes.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Custom emoji label injects event-handler attributes into rendered image**

   - **Bug**
     - When a custom emoji has a thumbnail, a label containing quotes and `onerror` is inserted directly into the `alt` and `title` attributes. The executed parser probe rendered `<img alt="smile" onerror="window.trexInjected=1" ...>` and parsed two distinct `onerror` attributes.
   - **Cause**
     - `emoji_alt` at `src/invidious/comments/content.cr:68` is appended without HTML attribute escaping at lines 71 and 73.
   - **Fix**
     - Escape `emoji_alt` for HTML attribute context before interpolating it into both `alt` and `title` (for example, use the project HTML escaping helper on the label before `String.build`), and add a regression test with quotes plus an event-handler payload.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Safely parse custom emojis without requi..."](https://github.com/iv-org/invidious/commit/e5263ef63b7cc8b334327ac8984e86b0b8a66d27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55153564)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->