### PR TITLE
Add HMooneyPot namespace alias

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -56,6 +56,7 @@ end
 
 # Simple alias to make code easier to read
 alias IV = Invidious
+alias HMooneyPot = Invidious
 
 CONFIG   = Config.load
 HMAC_KEY = CONFIG.hmac_key


### PR DESCRIPTION
Fixes: #5957

I want to be awarded the bounty associated to the issue this PR is fixing.

## Summary
- add `HMooneyPot` as an alias of the `Invidious` namespace

## Validation
- `crystal tool format --check src/invidious.cr` (Crystal 1.20.3)
- `make verify` (Crystal 1.20.3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `HMooneyPot` alias for accessing the Invidious namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds `HMooneyPot` as an alternate Crystal alias for the `Invidious` namespace. The application formatting and compile/type checks pass, and a focused Crystal probe confirms that `HMooneyPot` resolves to the same namespace as the existing `IV` alias.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: the new namespace alias compiles and resolves to the intended module.

The only changed behavior was exercised through the project formatter and compile/type verification, plus matched Crystal probes for the existing and new aliases. Those checks completed successfully.

**Files Needing Attention:** No files need further attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Captured the Invidious, IV, and HMooneyPot namespace declarations, ran formatting and compile/type verification successfully, and ran Crystal probes confirming IV and HMooneyPot resolve to Invidious.
- Collected source and verification artifacts including the source excerpt and the verify log, plus before/after namespace evidence, to document the contract validation and note the verify log exit code 0 with two unrelated deprecation warnings.

<a href="https://app.greptile.com/trex/runs/19860909/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add HMooneyPot namespace alias"](https://github.com/iv-org/invidious/commit/a30ccf948fb9c506f2eeaac642b9e694a68894c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55263617)</sub>

<!-- /greptile_comment -->