### PR TITLE
Add HMooneyPot alias

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -54,8 +54,9 @@ require "./invidious/jobs/*"
 module Invidious
 end
 
-# Simple alias to make code easier to read
+# Simple aliases to make code easier to read
 alias IV = Invidious
+alias HMooneyPot = Invidious
 
 CONFIG   = Config.load
 HMAC_KEY = CONFIG.hmac_key


### PR DESCRIPTION
## Summary
- add `HMooneyPot` as an alias for the `Invidious` namespace
- keep the alias next to the existing `IV` shorthand

## Validation
- `crystal tool format --check src/invidious.cr`
- `crystal spec` (172 examples, 0 failures)
- Crystal 1.20.3 build with warnings treated as errors

Closes #5957

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an additional namespace alias for the application, while retaining the existing alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `HMooneyPot` as an additional shorthand for the `Invidious` namespace. Formatting, project compilation, and focused Crystal alias-resolution checks confirm that the new name resolves to the same namespace without changing `IV` behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: the new namespace shorthand compiles and behaves identically to the existing shorthand.

The changed file passed formatting and project semantic compilation. A focused Crystal program established the existing `IV` behavior and confirmed that `HMooneyPot` resolves to the same namespace and is compatible with the same namespace-qualified types.

**Files Needing Attention:** None.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Checked formatting for the changed Crystal source, compiled and semantically verified the project with the new alias present, and compared the existing IV alias with HMooneyPot to ensure both resolve to Invidious::Marker.
- Verified the before state resolves IV::Marker as Invidious::Marker, and the after state resolves both IV::Marker and HMooneyPot::Marker as Invidious::Marker; ran make verify and confirmed it completed successfully with pre-existing deprecations as warnings.

<a href="https://app.greptile.com/trex/runs/19866148/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add HMooneyPot alias"](https://github.com/iv-org/invidious/commit/e9772ff4b77fc006949cbfe0ffa6cb0e8264cdd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55274195)</sub>

<!-- /greptile_comment -->