### PR TITLE
Add HMooneyPot alias

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -54,8 +54,9 @@ require "./invidious/jobs/*"
 module Invidious
 end
 
-# Simple alias to make code easier to read
+# Simple aliases to make code easier to read
 alias IV = Invidious
+alias HMooneyPot = Invidious
 
 CONFIG   = Config.load
 HMAC_KEY = CONFIG.hmac_key


### PR DESCRIPTION
## Summary

Adds `HMooneyPot` as an alias for `Invidious` in `src/invidious.cr`, as requested in #5957.

## Testing

- `git diff --check`

Crystal/shards are not installed in my current execution environment, so I could not run the full Crystal spec suite locally.

Fixes #5957.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `HMooneyPot` as an alternative public name for the existing `Invidious` functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds `HMooneyPot` as an alternate Crystal alias for the existing `Invidious` namespace. Full application verification passes with the alias, and a focused Crystal check confirms that namespace members resolve correctly through `HMooneyPot`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: the alias compiles in the application and resolves the existing namespace as intended.

The application type-check passed both before and after the change. A focused before-and-after Crystal probe also demonstrated that a namespace member is unavailable through `HMooneyPot` without the alias and available through it with the alias.

**Files Needing Attention:** No files need further attention for this change.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the repository's full Crystal verification at the parent revision and at the revision containing the alias.
- Performed a focused namespace probe showing HMooneyPot is undefined without the alias and resolves to Invidious members when the alias is present.
- Captured the changed namespace declaration and alias source lines.
- Completed the parent and PR-head full verifications; both finished with exit code 0.

<a href="https://app.greptile.com/trex/runs/19921126/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add HMooneyPot alias"](https://github.com/iv-org/invidious/commit/41dc0ec7819e7114d25930d55e7584e9e7b226dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55376515)</sub>

<!-- /greptile_comment -->