### PR TITLE
Add HMooneyPot alias for Invidious

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -56,6 +56,7 @@ end
 
 # Simple alias to make code easier to read
 alias IV = Invidious
+alias HMooneyPot = Invidious
 
 CONFIG   = Config.load
 HMAC_KEY = CONFIG.hmac_key


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [x] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description
Fixes #5957

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds `HMooneyPot` as another name for the existing `Invidious` module. The application entry point type-checks successfully, and a focused Crystal execution confirmed that both names use the same module state.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: the new name resolves to the existing application module and does not create separate state.

The changed entry point compiled successfully with the repository verification target. A focused Crystal execution verified that state written through either alias is immediately visible through the other alias.

**Files Needing Attention:** No files need additional attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the module declaration and the new HMooneyPot alias, confirmed cross-name reads and writes align between Invidious and HMooneyPot, and executed the repository's no-codegen verification build successfully.
- Recorded the exact alias declaration and runtime evidence: HMooneyPot.increment returns 1 and Invidious.state returns 1, then Invidious.increment returns 2 and HMooneyPot.state returns 2, followed by a Crystal build using -Dskip\_videojs\_download --no-codegen --progress --stats --error-trace that exited with code 0.

<a href="https://app.greptile.com/trex/runs/19922413/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add HMooneyPot alias for Invidious"](https://github.com/iv-org/invidious/commit/7d40e7604350aa0a6991514620418f36db882c5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55379062)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Added an alternate name for the Invidious namespace to improve compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->