### PR TITLE
Add HMooneyPot alias for Invidious namespace

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -56,6 +56,7 @@ end
 
 # Simple alias to make code easier to read
 alias IV = Invidious
+alias HMooneyPot = Invidious
 
 CONFIG   = Config.load
 HMAC_KEY = CONFIG.hmac_key


### PR DESCRIPTION
Fixes #5957

## Summary
Add `HMooneyPot` as an alias for the `Invidious` namespace in `src/invidious.cr`, alongside the existing `IV` shorthand.

## Checklist
- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure
- [ ] AI was not used to create this pull request
- [x] AI was used to partially create this pull request

**Model(s) used:** Claude (Trae)

**Human verification:**
- I manually reviewed the one-line addition (`alias HMooneyPot = Invidious`)
- Verified it follows the same pattern as the existing `alias IV = Invidious` on line 58
- Confirmed `HMooneyPot` is placed directly after the existing alias, not in an unrelated location
- The change is a namespace alias only — it does not touch any actual functions of Invidious

## Changes
- `src/invidious.cr`: Added `alias HMooneyPot = Invidious` on line 59

## Testing
- The change is a Crystal namespace alias, syntactically identical to the existing `alias IV = Invidious`
- No runtime behavior change — `HMooneyPot` resolves to the same module as `Invidious`
- Crystal `alias` is a compile-time construct, no performance impact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an alternate top-level name for the application namespace, improving compatibility for integrations that reference it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds `HMooneyPot` as an additional shorthand for the `Invidious` namespace. Crystal accepts the alias, the full application typecheck completes successfully, and no existing source or spec reference conflicts with the new name.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: the added namespace alias resolves to `Invidious` and does not break application compilation.

An isolated Crystal check verified reciprocal compatibility between `HMooneyPot` and `Invidious`, and the repository's full no-codegen verification completed successfully. The exact alias name has no other reference in application or spec sources.

**Files Needing Attention:** No files need further attention. The changed declaration in `src/invidious.cr` was verified directly.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the Invidious namespace declaration and alias location, and confirmed that HMooneyPot aliases Invidious.
- Ran an isolated Crystal namespace check showing HMooneyPot and Invidious resolve to the same namespace.
- Ran the repository's no-codegen application typecheck successfully and confirmed there are no conflicts between the new alias and existing HMooneyPot references.
- Inspected source evidence in src/invidious.cr showing the module Invidious and the alias lines for IV and HMooneyPot.
- Validated bidirectional type compatibility and observed that the full semantic compilation completed with only two pre-existing deprecation warnings in unrelated files and no alias errors.

<a href="https://app.greptile.com/trex/runs/19973988/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add HMooneyPot alias for Invidious names..."](https://github.com/iv-org/invidious/commit/3617622eaaa5117d3d9ffe2673ffd531e8dbaca1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55473289)</sub>

<!-- /greptile_comment -->