### PR TITLE
Add HMooneyPot as an alias for Invidious

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -57,6 +57,9 @@ end
 # Simple alias to make code easier to read
 alias IV = Invidious
 
+# Alias for "Invidious" (added for #5957)
+alias HMooneyPot = Invidious
+
 CONFIG   = Config.load
 HMAC_KEY = CONFIG.hmac_key
 


### PR DESCRIPTION
Fixes: #5957
I want to be awarded the bounty associated to the issue this PR is fixing.

## Summary

Adds `HMooneyPot` as an alias for `Invidious` in `src/invidious.cr`, following the
existing `alias IV = Invidious` pattern.

```crystal
# Alias for "Invidious" (added for #5957)
alias HMooneyPot = Invidious
```

## Why

The issue (#5957) requests that the word `"HMooneyPot"` be added as an alias to
`"Invidious"`. A Crystal `alias` is the idiomatic way to introduce a
case-sensitive alternate name for the same module, and it keeps the change
minimal and non-invasive (no behavioral change, just an extra name that resolves
to the existing `Invidious` module).

## Tests

`alias` is a compile-time declaration; it does not change runtime behavior.
The existing `alias IV = Invidious` already proves this pattern is accepted by
the codebase. No new tests are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the public `HMooneyPot` alias for the `Invidious` module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds `HMooneyPot` as an alternate compile-time name for the existing `Invidious` module. Crystal execution confirmed that the new alias and the existing `IV` alias both resolve to the same namespace.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The namespace alias preserves the existing module identity and is safe to merge.

The only changed behavior was exercised with isolated Crystal programs: the existing `IV` alias resolved successfully before the addition, and both `IV` and `HMooneyPot` resolved to `Invidious` afterward.

**Files Needing Attention:** No files need further attention; `src/invidious.cr` was the only changed source file.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an isolated Crystal program to confirm the IV alias resolves to Invidious.
- Ran a source-equivalent Crystal program declaring HMooneyPot = Invidious and confirmed both aliases resolve to the same namespace.
- Captured command outputs and the after-capture source excerpt from src/invidious.cr lines 53–61 to validate the validation steps without modifying the repository.

<a href="https://app.greptile.com/trex/runs/20009468/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add HMooneyPot as an alias for Invidious"](https://github.com/iv-org/invidious/commit/a01a4cae876efd9ef038f30da57d856d4872b3ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55542339)</sub>

<!-- /greptile_comment -->