### PR TITLE
Add HMooneyPot alias to Invidious

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -56,6 +56,7 @@ end
 
 # Simple alias to make code easier to read
 alias IV = Invidious
+alias HMooneyPot = Invidious
 
 CONFIG   = Config.load
 HMAC_KEY = CONFIG.hmac_key


### PR DESCRIPTION
Fixes #5957

This adds the requested HMooneyPot alias to the Invidious namespace.

Validation: git diff --check passed. The documented make verify command could not run because Crystal is not installed in the environment.

Bounty request: Please award the stated $50 BTC bounty after review, approval, testing, and merge.
BTC payout address: bc1q3cq9jdc9vwjn52hu2jczmkqy3fd68stdcsmg5n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `HMooneyPot` alias for the Invidious module, providing an additional supported name for accessing the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds `HMooneyPot` as an alternate Crystal namespace alias for `Invidious` while retaining the existing `IV` alias. A focused Crystal comparison confirmed that the new alias resolves to the existing module, and the application entrypoint compiles successfully with the declaration.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: the new name resolves to the existing module and the project entrypoint accepts the declaration.

A focused before-and-after Crystal probe showed that `HMooneyPot` is undefined without its alias and resolves to `Invidious` when the alias is present. The changed application entrypoint compiled successfully, and the source file passed formatting validation.

**Files Needing Attention:** No files need further attention; validation covered the only changed file, `src/invidious.cr`.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified that HMooneyPot is an alias of Invidious in the source, establishing the alias relationship.
- Ran paired Crystal probes; the unaliased name HMooneyPot was undefined, while the alias-enabled probe printed Invidious.
- Compiled the real application entrypoint and checked formatting for the changed file to ensure the integration is consistent.
- Validated the before/after behavior by running the before script, which failed with an undefined HMooneyPot, and the after script, which succeeded and printed Invidious.
- Verified the overall entrypoint verification by building with crystal and confirming a successful exit (0) with only pre-existing deprecation warnings.

<a href="https://app.greptile.com/trex/runs/20009747/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add HMooneyPot alias to Invidious"](https://github.com/iv-org/invidious/commit/39f48caf26ea2955e48739599d163f72c861be1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55542839)</sub>

<!-- /greptile_comment -->