### PR TITLE
fix(parser): restore channel link on related videos with multiple creators

### DIFF
--- a/spec/invidious/videos/related_videos_extract_spec.cr
+++ b/spec/invidious/videos/related_videos_extract_spec.cr
@@ -1,0 +1,125 @@
+require "../../parsers_helper.cr"
+
+Spectator.describe "parse_related_video" do
+  it "parses a related video from a single-creator channel" do
+    related = JSON.parse(%({
+      "videoId": "BtlWoqWLm9Q",
+      "title": {"simpleText": "Secret History #4: How Evil Triumphs"},
+      "shortBylineText": {
+        "runs": [
+          {
+            "text": "Predictive History",
+            "navigationEndpoint": {
+              "clickTrackingParams": "CAA=",
+              "commandMetadata": {
+                "webCommandMetadata": {
+                  "url": "/channel/UC11aHtNnc5bEPLI4jf6mnYg",
+                  "webPageType": "WEB_PAGE_TYPE_CHANNEL",
+                  "rootVe": 3611,
+                  "apiUrl": "/youtubei/v1/browse"
+                }
+              },
+              "browseEndpoint": {
+                "browseId": "UC11aHtNnc5bEPLI4jf6mnYg",
+                "canonicalBaseUrl": "/@PredictiveHistory"
+              }
+            }
+          }
+        ]
+      },
+      "lengthInSeconds": 7250,
+      "shortViewCountText": {"simpleText": "3.2M views"},
+      "publishedTimeText": {"simpleText": "11 months ago"}
+    }))
+
+    related_video = Invidious::Videos::Parser.parse_related_video(related)
+
+    expect(related_video).not_to be_nil
+
+    expect(related_video.not_nil!["author"].as_s).to eq("Predictive History")
+    expect(related_video.not_nil!["ucid"].as_s).to eq("UC11aHtNnc5bEPLI4jf6mnYg")
+    expect(related_video.not_nil!["short_view_count"].as_s).to eq("3.2M")
+  end
+
+  it "parses a related video with multiple creators (collab)" do
+    related = JSON.parse(%({
+      "videoId": "Qifsxitq_q4",
+      "title": {"simpleText": "Professor Brian Greene: The Threat of AI"},
+      "shortBylineText": {
+        "runs": [
+          {
+            "text": "The Diary Of A CEO and World Science Festival",
+            "navigationEndpoint": {
+              "clickTrackingParams": "CAA=",
+              "showDialogCommand": {
+                "panelLoadingStrategy": {
+                  "inlineContent": {
+                    "dialogViewModel": {
+                      "customContent": {
+                        "listViewModel": {
+                          "listItems": [
+                            {
+                              "listItemViewModel": {
+                                "title": {"content": "The Diary Of A CEO"},
+                                "rendererContext": {
+                                  "commandContext": {
+                                    "onTap": {
+                                      "innertubeCommand": {
+                                        "clickTrackingParams": "CAA=",
+                                        "commandMetadata": {
+                                          "webCommandMetadata": {
+                                            "url": "/channel/UCGq-a57w-aPwyi3pW7XLiHw",
+                                            "webPageType": "WEB_PAGE_TYPE_CHANNEL",
+                                            "rootVe": 3611,
+                                            "apiUrl": "/youtubei/v1/browse"
+                                          }
+                                        },
+                                        "browseEndpoint": {
+                                          "browseId": "UCGq-a57w-aPwyi3pW7XLiHw"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "listItemViewModel": {
+                                "title": {"content": "World Science Festival"},
+                                "rendererContext": {
+                                  "commandContext": {
+                                    "onTap": {
+                                      "innertubeCommand": {
+                                        "browseEndpoint": {
+                                          "browseId": "UCshBEKIPwFyXClTBFRwBaBA"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "lengthInSeconds": 7400,
+      "shortViewCountText": {"simpleText": "1M views"},
+      "publishedTimeText": {"simpleText": "4 days ago"}
+    }))
+
+    related_video = Invidious::Videos::Parser.parse_related_video(related)
+
+    expect(related_video).not_to be_nil
+
+    expect(related_video.not_nil!["author"].as_s).to eq("The Diary Of A CEO and World Science Festival")
+    expect(related_video.not_nil!["ucid"].as_s).to eq("UCGq-a57w-aPwyi3pW7XLiHw")
+  end
+end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -28,6 +28,19 @@ module Invidious::Videos::Parser
 
     ucid = channel_info.try { |ci| HelperExtractors.get_browse_id(ci) }
 
+    # Videos with multiple creators (collabs) have no browse endpoint on the
+    # byline run. YouTube instead embeds a "Collaborators" dialog under the
+    # run's navigation endpoint, where each list item carries the browse
+    # endpoint of one of the creators. Use the first one as fallback.
+    if ucid.try &.empty?
+      ucid = channel_info.try &.dig?(
+        "navigationEndpoint", "showDialogCommand", "panelLoadingStrategy",
+        "inlineContent", "dialogViewModel", "customContent", "listViewModel",
+        "listItems", 0, "listItemViewModel", "rendererContext", "commandContext",
+        "onTap", "innertubeCommand", "browseEndpoint", "browseId"
+      ).try &.as_s
+    end
+
     short_view_count = related.try do |r|
       HelperExtractors.get_short_view_count(r).to_s
     end


### PR DESCRIPTION
> Note: this draft PR description was drafted by an AI assistant (model `ox-alpha`, used via the `opencode` CLI) and will be rewritten in the author's own words before the PR is marked ready for review. Disclosed here per [AI_POLICY.md](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md).

## What

On videos with multiple creators (collabs), the related-videos sidebar showed the channel name as plain text with no link.

Root cause: for collab videos, YouTube puts no `browseEndpoint` on the byline run — instead the run's `navigationEndpoint` carries a `showDialogCommand` ("Collaborators" dialog) whose list items each contain a proper `browseEndpoint.browseId`. `parse_related_video` only read `runs[0]`'s browse endpoint, so `ucid` came back empty and the watch template skipped the link (`watch.ecr` renders the anchor only when `rv["ucid"]` is non-empty).

## Fix

When the byline run yields no `browseId`, fall back to the first entry of the embedded Collaborators dialog and use its `browseEndpoint.browseId`. Author text is left unchanged.

## Related videos data

Verified against live `/next` responses (WEB client): single-creator runs carry `browseEndpoint.browseId`; collab runs carry `showDialogCommand` → `listViewModel.listItems[].listItemViewModel.rendererContext.commandContext.onTap.innertubeCommand.browseEndpoint.browseId`.

## AI disclosure

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

**Model(s) used:** ox-alpha
**Tool(s) used:** opencode CLI
**How was AI used?** The parser change and the new spec file were written by the model; the author reviewed the diff and is performing manual verification (screenshots to be posted in this PR).

## Testing

Automated:
- New spec `spec/invidious/videos/related_videos_extract_spec.cr` covering both the single-creator path and the collab fallback path.
- Full CI matrix validated on the author's fork (`crystal spec` green on Crystal 1.14–1.20, lint/formatter green, Docker build green). The 1.21.0/nightly build failures reproduce on upstream `master` (pre-existing deprecation warnings, unrelated).
- An attempt at full end-to-end verification (Docker stack with invidious-companion on GitHub Actions) was blocked by YouTube rejecting PO-token validation from datacenter IPs; manual verification is therefore being done from a residential connection instead.

Manual: pending — reproduction of the bug on an unpatched instance and verification of the patched build, with screenshots, to be posted by the author.
