### PR TITLE
chore: Add myself to assignees for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,17 @@ updates:
     directory: "/docker"
     schedule:
       interval: "weekly"
+    assignees:
+      - "Fijxu"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: "weekly"
+    assignees:
+      - "Fijxu"
   - package-ecosystem: "nix"
     directory: /nix
     schedule:
       interval: "weekly"
+    assignees:
+      - "Fijxu"


### PR DESCRIPTION


## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [x] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description

So I get notified about deps updates.
https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/customizing-dependabot-prs#automatically-adding-assignees

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Assigned an owner for weekly automated dependency update requests across Docker, GitHub Actions, and Nix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change assigns weekly Dependabot pull requests for Docker, GitHub Actions, and Nix updates to `Fijxu`. The configuration was parsed and verified to apply that assignee to each of the three configured update entries.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: all three weekly Dependabot update entries are configured with the intended assignee.

The configuration was parsed before and after the change. The prior revision lacked the assignee, while the current revision passed assertions for Docker, GitHub Actions, and Nix with exactly `Fijxu` assigned.

**Files Needing Attention:** No files need further attention; `.github/dependabot.yml` was verified.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Parsed the parent revision's Dependabot configuration and confirmed the weekly Docker update entry had no assignee; parsed the changed configuration and verified Docker, GitHub Actions, and Nix each use a weekly schedule with exactly Fijxu; captured the line-numbered configuration and the before/after diff for all three assignee blocks.
- Verified exact excerpts show Docker: 3-8; GitHub Actions: 9-14; Nix: 15-20; each stanza contains an assignee named Fijxu; the before check failed for Docker because assignees=None (exit code 1) and the after check passed for all three entries (exit code 0); the full commands, working directory, parser output, line-numbered configuration, and PR diff were captured in the artifacts.

<a href="https://app.greptile.com/trex/runs/20134690/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: Add myself to assignees for Depen..."](https://github.com/iv-org/invidious/commit/ce5a8ede2da01fcac4d1c4fb6bf6c9bed5bf45ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55782023)</sub>

<!-- /greptile_comment -->