### PR TITLE
feat(channels): fetch channel videos via InnerTube instead of RSS

### DIFF
--- a/src/invidious/channels/channels.cr
+++ b/src/invidious/channels/channels.cr
@@ -159,36 +159,19 @@ def fetch_channel(ucid, pull_all_videos : Bool)
   LOGGER.debug("fetch_channel: #{ucid}")
   LOGGER.trace("fetch_channel: #{ucid} : pull_all_videos = #{pull_all_videos}")
 
-  namespaces = {
-    "yt"      => "http://www.youtube.com/xml/schemas/2015",
-    "media"   => "http://search.yahoo.com/mrss/",
-    "default" => "http://www.w3.org/2005/Atom",
-  }
-
-  LOGGER.trace("fetch_channel: #{ucid} : Downloading RSS feed")
-  rss = YT_POOL.client &.get("/feeds/videos.xml?channel_id=#{ucid}").body
-  LOGGER.trace("fetch_channel: #{ucid} : Parsing RSS feed")
-  rss = XML.parse(rss)
-
-  author = rss.xpath_node("//default:feed/default:title", namespaces)
-  if !author
-    raise InfoException.new("Deleted or invalid channel")
+  begin
+    about_channel = get_about_info(ucid)
+  rescue ex : ChannelRedirect
+    # Old-style UCIDs can be redirected to a new one by YouTube. The RSS
+    # endpoint used to follow those redirects transparently.
+    about_channel = get_about_info(ex.channel_id)
   end
 
-  author = author.content
-
-  # Auto-generated channels
-  # https://support.google.com/youtube/answer/2579942
-  if author.ends_with?(" - Topic") ||
-     {"Popular on YouTube", "Music", "Sports", "Gaming"}.includes? author
-    auto_generated = true
-  end
-
-  LOGGER.trace("fetch_channel: #{ucid} : author = #{author}, auto_generated = #{auto_generated}")
+  LOGGER.trace("fetch_channel: #{ucid} : author = #{about_channel.author}, auto_generated = #{about_channel.auto_generated}")
 
   channel = InvidiousChannel.new({
     id:         ucid,
-    author:     author,
+    author:     about_channel.author,
     updated:    Time.utc,
     deleted:    false,
     subscribed: nil,
@@ -197,61 +180,30 @@ def fetch_channel(ucid, pull_all_videos : Bool)
   LOGGER.trace("fetch_channel: #{ucid} : Downloading channel videos page")
   videos, continuation = IV::Channel::Tabs.get_videos(channel)
 
-  LOGGER.trace("fetch_channel: #{ucid} : Extracting videos from channel RSS feed")
-  rss.xpath_nodes("//default:feed/default:entry", namespaces).each do |entry|
-    video_id = entry.xpath_node("yt:videoId", namespaces).not_nil!.content
-    title = entry.xpath_node("default:title", namespaces).not_nil!.content
-
-    published = Time.parse_rfc3339(
-      entry.xpath_node("default:published", namespaces).not_nil!.content
-    )
-    updated = Time.parse_rfc3339(
-      entry.xpath_node("default:updated", namespaces).not_nil!.content
-    )
-
-    author = entry.xpath_node("default:author/default:name", namespaces).not_nil!.content
-    ucid = entry.xpath_node("yt:channelId", namespaces).not_nil!.content
-
-    views = entry
-      .xpath_node("media:group/media:community/media:statistics", namespaces)
-      .try &.["views"]?.try &.to_i64? || 0_i64
-
-    channel_video = videos
-      .select(SearchVideo)
-      .select(&.id.== video_id)[0]?
-
-    length_seconds = channel_video.try &.length_seconds
-    length_seconds ||= 0
-
-    live_now = channel_video.try &.badges.live_now?
-    live_now ||= false
-
-    premiere_timestamp = channel_video.try &.premiere_timestamp
-
-    video = ChannelVideo.new({
-      id:                 video_id,
-      title:              title,
-      published:          published,
-      updated:            updated,
-      ucid:               ucid,
-      author:             author,
-      length_seconds:     length_seconds,
-      live_now:           live_now,
-      premiere_timestamp: premiere_timestamp,
-      views:              views,
+  LOGGER.trace("fetch_channel: #{ucid} : Extracting videos from the channel videos tab")
+  videos.select(SearchVideo).each do |video|
+    channel_video = ChannelVideo.new({
+      id:                 video.id,
+      title:              video.title,
+      published:          video.published,
+      updated:            Time.utc,
+      ucid:               video.ucid,
+      author:             video.author,
+      length_seconds:     video.length_seconds,
+      live_now:           video.badges.live_now?,
+      premiere_timestamp: video.premiere_timestamp,
+      views:              video.views,
     })
 
-    LOGGER.trace("fetch_channel: #{ucid} : video #{video_id} : Updating or inserting video")
+    LOGGER.trace("fetch_channel: #{ucid} : video #{video.id} : Updating or inserting video")
 
-    # We don't include the 'premiere_timestamp' here because channel pages don't include them,
-    # meaning the above timestamp is always null
-    was_insert = Invidious::Database::ChannelVideos.insert(video)
+    was_insert = Invidious::Database::ChannelVideos.insert(channel_video)
 
     if was_insert
-      LOGGER.trace("fetch_channel: #{ucid} : video #{video_id} : Inserted, updating subscriptions")
-      NOTIFICATION_CHANNEL.send(VideoNotification.from_video(video))
+      LOGGER.trace("fetch_channel: #{ucid} : video #{video.id} : Inserted, updating subscriptions")
+      NOTIFICATION_CHANNEL.send(VideoNotification.from_video(channel_video))
     else
-      LOGGER.trace("fetch_channel: #{ucid} : video #{video_id} : Updated")
+      LOGGER.trace("fetch_channel: #{ucid} : video #{video.id} : Updated")
     end
   end
 

--- a/src/invidious/channels/channels.cr
+++ b/src/invidious/channels/channels.cr
@@ -161,10 +161,14 @@ def fetch_channel(ucid, pull_all_videos : Bool)
 
   begin
     about_channel = get_about_info(ucid)
+    videos_ucid = ucid
   rescue ex : ChannelRedirect
     # Old-style UCIDs can be redirected to a new one by YouTube. The RSS
-    # endpoint used to follow those redirects transparently.
+    # endpoint used to follow those redirects transparently. Videos are
+    # fetched from the channel they actually live on, while the DB row
+    # keeps the originally requested ID to not break subscriptions.
     about_channel = get_about_info(ex.channel_id)
+    videos_ucid = ex.channel_id
   end
 
   LOGGER.trace("fetch_channel: #{ucid} : author = #{about_channel.author}, auto_generated = #{about_channel.auto_generated}")
@@ -178,7 +182,7 @@ def fetch_channel(ucid, pull_all_videos : Bool)
   })
 
   LOGGER.trace("fetch_channel: #{ucid} : Downloading channel videos page")
-  videos, continuation = IV::Channel::Tabs.get_videos(channel)
+  videos, continuation = IV::Channel::Tabs.get_videos(about_channel.author, videos_ucid)
 
   LOGGER.trace("fetch_channel: #{ucid} : Extracting videos from the channel videos tab")
   videos.select(SearchVideo).each do |video|
@@ -197,7 +201,7 @@ def fetch_channel(ucid, pull_all_videos : Bool)
 
     LOGGER.trace("fetch_channel: #{ucid} : video #{video.id} : Updating or inserting video")
 
-    was_insert = Invidious::Database::ChannelVideos.insert(channel_video)
+    was_insert = Invidious::Database::ChannelVideos.insert(channel_video, with_premiere_timestamp: true)
 
     if was_insert
       LOGGER.trace("fetch_channel: #{ucid} : video #{video.id} : Inserted, updating subscriptions")


### PR DESCRIPTION
> Note: this draft PR description was drafted by an AI assistant (model `ox-alpha`, used via the `opencode` CLI) and will be rewritten in the author's own words before the PR is marked ready for review. Disclosed here per [AI_POLICY.md](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md).

## What

`fetch_channel` no longer uses the `/feeds/videos.xml` RSS endpoint. That endpoint is rate limited and periodically unavailable (#5679), which breaks subscription refreshes, notifications, and channel subscriptions themselves (#5651, #4657).

The function now:
1. Gets channel metadata (author name, auto-generated status, validity) via `get_about_info` (InnerTube browse), following channel redirects explicitly — the RSS endpoint used to follow those transparently.
2. Inserts the first page of the videos tab (InnerTube, ~30 videos) directly, mirroring the existing `pull_all_videos` continuation loop instead of merging RSS entries with InnerTube data.

The `pull_all_videos` continuation loop is unchanged.

## Behavior notes

- ~30 videos are refreshed per run instead of RSS's ~15.
- `premiere_timestamp` is now populated on first-page inserts (InnerTube provides it; the old code had to drop it because RSS lacks it).
- The per-video `updated` column is set to `Time.utc`, matching the existing InnerTube backfill loop (InnerTube has no per-video update timestamp).
- Content that only lives on the streams tab (live-right-now) enters feeds when it reaches the videos tab — same as the existing InnerTube backfill path; real-time coverage continues to come from WebSub pushes.

## AI disclosure

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

**Model(s) used:** ox-alpha
**Tool(s) used:** opencode CLI
**How was AI used?** The change was written by the model; the author reviewed the diff and is performing manual verification.

## Testing

Automated:
- `crystal spec` green on Crystal 1.14–1.20 and lint/formatter green on the author's fork CI. The 1.21.0/nightly build failures reproduce on upstream `master` (pre-existing deprecation warnings, unrelated).
- End-to-end runtime verification is being done from a residential connection, as YouTube rejects InnerTube/PO-token traffic from datacenter IPs.

Manual: pending — screenshots to be posted by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel loading and metadata retrieval, including more reliable handling of redirected channel IDs.
  * Improved initial channel video details, including duration, live status, premiere times, and view counts.
  * Removed incomplete metadata fallbacks that could produce inaccurate channel information.
  * Improved consistency between channel details and the videos displayed when a channel is first loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Channel refreshes now obtain channel details and recent videos through InnerTube rather than the RSS endpoint. The implementation correctly resolves redirected channel IDs for the first videos request, preserves premiere timestamps during database inserts and updates, and continues through paginated video results during a full refresh.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The reviewed channel-refresh changes are safe to merge.

The redirect flow was traced through InnerTube request construction and compiled successfully. A PostgreSQL 14 harness confirmed premiere timestamps persist for inserts and conflict updates, while a deterministic two-page harness confirmed continuation reuse and the short-page stop condition.

**Files Needing Attention:** No additional changes are needed in the reviewed files. Live YouTube responses were not exercised, but the relevant request construction, pagination behavior, and persistence semantics were verified.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the prior and current redirect handling paths and confirmed that the replacement channel ID is used to construct the first InnerTube videos-tab request while the original subscription ID remains stored, and the current application compiled successfully.
- Validated premiere timestamp handling by tracing from the parsed InnerTube video through the channel refresh record and a timezone-aware upsert, confirming the schema stores a timezone-aware timestamp and that upserts preserve the provided value for both new and conflicting rows.
- Ran equivalent mocked two-page video-tab flows against the parent and current implementations and confirmed identical two-page continuation behavior, with the current application compiling successfully.
- Inspected exact code excerpts around ChannelRedirect and Channel Videos logic and confirmed that the current path uses the replacement-ID call, while the build verification completed successfully.
- Verified that the code maps premiere\_timestamp to channel videos and that the database uses a timestamp with time zone, with tests using a disposable Docker PostgreSQL to validate persistence semantics rather than live YouTube responses.

<a href="https://app.greptile.com/trex/runs/20144184/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(channels): fetch videos from redirec..."](https://github.com/iv-org/invidious/commit/8261a28478dd5839f5f20d2453895092281d12cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55793724)</sub>

<!-- /greptile_comment -->