### PR TITLE
feat: add clickable hashtag support in titles

### DIFF
--- a/spec/invidious/frontend/video_title_spec.cr
+++ b/spec/invidious/frontend/video_title_spec.cr
@@ -1,0 +1,73 @@
+require "../../../src/invidious/frontend/video_title"
+require "spectator"
+
+Spectator.configure do |config|
+  config.fail_blank
+  config.randomize
+end
+
+Spectator.describe Invidious::Frontend::VideoTitle do
+  it "links hashtags at the start and end of a title" do
+    expect(described_class.to_html("#music live #concert")).to eq(
+      %(<a href="/hashtag/music">#music</a> live <a href="/hashtag/concert">#concert</a>)
+    )
+  end
+
+  it "keeps surrounding punctuation outside links" do
+    expect(described_class.to_html("(#one), [#two]! {#three}. #four-five")).to eq(
+      %((<a href="/hashtag/one">#one</a>), [<a href="/hashtag/two">#two</a>]! {<a href="/hashtag/three">#three</a>}. <a href="/hashtag/four">#four</a>-five)
+    )
+  end
+
+  it "preserves case, numbers and underscores" do
+    expect(described_class.to_html("#Open_Source2026 #123")).to eq(
+      %(<a href="/hashtag/Open_Source2026">#Open_Source2026</a> <a href="/hashtag/123">#123</a>)
+    )
+  end
+
+  it "supports Unicode letters and combining marks with encoded paths" do
+    expect(described_class.to_html("🎵 #日本語 #cafe\u0301 #हिन्दी")).to eq(
+      %(🎵 <a href="/hashtag/%E6%97%A5%E6%9C%AC%E8%AA%9E">#日本語</a> <a href="/hashtag/cafe%CC%81">#cafe\u0301</a> <a href="/hashtag/%E0%A4%B9%E0%A4%BF%E0%A4%A8%E0%A5%8D%E0%A4%A6%E0%A5%80">#हिन्दी</a>)
+    )
+  end
+
+  it "preserves whitespace between consecutive hashtags" do
+    expect(described_class.to_html("#one\t#two\n#three")).to eq(
+      %(<a href="/hashtag/one">#one</a>\t<a href="/hashtag/two">#two</a>\n<a href="/hashtag/three">#three</a>)
+    )
+  end
+
+  it "recognizes quoted hashtags and Unicode whitespace" do
+    expect(described_class.to_html(%('#one' "#two"\u00a0#three))).to eq(
+      %(&#39;<a href="/hashtag/one">#one</a>&#39; &quot;<a href="/hashtag/two">#two</a>&quot;\u00a0<a href="/hashtag/three">#three</a>)
+    )
+  end
+
+  it "does not link word suffixes, URL fragments or bare hashes" do
+    title = "C# C#Sharp word#tag https://example.com/#fragment https://example.com?q=#section # ##tag #!"
+    expect(described_class.to_html(title)).to eq(title)
+  end
+
+  it "escapes markup and quotes while preserving the displayed title" do
+    expect(described_class.to_html(%(<script>alert("x")</script> #safe & 'quoted'))).to eq(
+      %(&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; <a href="/hashtag/safe">#safe</a> &amp; &#39;quoted&#39;)
+    )
+  end
+
+  it "does not turn escaped character references into hashtags" do
+    expect(described_class.to_html(%(' " &#123; &amp; #ok))).to eq(
+      %(&#39; &quot; &amp;#123; &amp;amp; <a href="/hashtag/ok">#ok</a>)
+    )
+  end
+
+  it "escapes attempted attribute injection after a hashtag" do
+    expect(described_class.to_html(%(#tag" onclick="alert(1)))).to eq(
+      %(<a href="/hashtag/tag">#tag</a>&quot; onclick=&quot;alert(1))
+    )
+  end
+
+  it "handles empty titles and titles without hashtags" do
+    expect(described_class.to_html("")).to eq("")
+    expect(described_class.to_html("Music & video")).to eq("Music &amp; video")
+  end
+end

--- a/src/invidious/frontend/video_title.cr
+++ b/src/invidious/frontend/video_title.cr
@@ -1,0 +1,28 @@
+require "html"
+require "uri"
+
+module Invidious::Frontend::VideoTitle
+  extend self
+
+  # Keep word-internal hashes, URL fragments and HTML entities as plain text.
+  HASHTAG = /(^|[\s\p{Z}(\[{"'])#([\p{L}\p{N}_][\p{L}\p{M}\p{N}_]*)/
+
+  def to_html(title : String) : String
+    String.build do |html|
+      offset = 0
+
+      # Match the original text, not escaped entities (which may contain '#').
+      title.scan(HASHTAG) do |match|
+        html << HTML.escape(title.byte_slice(offset, match.byte_begin(0) - offset))
+        html << HTML.escape(match[1])
+
+        tag = match[2]
+        html << %(<a href="/hashtag/) << URI.encode_www_form(tag, space_to_plus: false) << %(">#)
+        html << HTML.escape(tag) << "</a>"
+        offset = match.byte_end(0)
+      end
+
+      html << HTML.escape(title.byte_slice(offset, title.bytesize - offset))
+    end
+  end
+end

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -93,7 +93,7 @@ we're going to need to do it here in order to allow for translations.
 
 <div class="h-box">
     <h1>
-        <%= title %>
+        <%= Invidious::Frontend::VideoTitle.to_html(video.title) %>
         <% if params.listen %>
             <a title="<%=I18n.translate(locale, "Video mode")%>" id="link-iv-listen" data-base-url="/watch?<%= env.params.query %>&listen=0" href="/watch?<%= env.params.query %>&listen=0">
                 <i class="icon ion-ios-videocam"></i>


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [ ] AI was not used to create this pull request
- [x] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):** GPT 6 Astra with Medium Reasoning
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:** Codex desktop app
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description

This PR implements the functionality of clickable hashtags in a video title. Upon clicking, it navigates the user to that specific hashtag's webpage where other videos of that same topic can be explored.


### Manual Verification


- I reviewed all 3 changed files and understood the code along with the reasoning behind the engineering decisions and I made sure that the code introduced in this PR follows the convention of this repository. Like, using the preexisting `/hashtag/:hashtag` route pattern.

- Test demonstration:
<img width="576" height="324" alt="image" src="https://github.com/user-attachments/assets/205765b2-df7d-4c64-a5c1-b911ab4131b2" />


Hovering over this hashtag in the title shows the redirect link to `.../hashtag/ItShouldBeIllegalTo`. The corresponding youtube video : https://www.youtube.com/watch?v=cVYf2OXRXjs


<img width="576" height="324" alt="image" src="https://github.com/user-attachments/assets/707174bd-fbc5-4647-aae8-69f4600658d8" />


On clicking it navigates me to the correct page.
 

- I tested on more such hashtags as well as plain title videos too to ensure that they don't behave oddly as a side-effect. The regex check prevents unintended hashtags, like in "C#", URL fragments, etc, from breaking the title's behaviour. 


- Ordinary title text is HTML-escaped and Hashtags are URI-encoded to prevent injections and support different scripts respectively. 


### Automated Checks

The automated checks verified the following things:
- Crystal formatting passed
- Ameba inspection passed
-  Full docker build succeeded
- Tested 11 examples of title content edge-cases (Japanese characters, HTML, unicode whitespaces, bare hashes in titles, etc) all passed on Crystal 1.16.3 and 1.21.0
- Compilation of the application was successful
- Only 2 preexisting deprecation warnings surfaced by Crystal 1.21.0 (Not introduced in this PR)


Fixes: #442
I want to be awarded the bounty associated to the issue this PR is fixing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Video titles now automatically link valid hashtags to searchable hashtag pages.
  - Hashtag links support Unicode characters, punctuation, and encoded titles while preserving surrounding formatting.

- **Bug Fixes**
  - Improved title rendering with consistent HTML escaping, including quotes, special characters, and potentially unsafe attribute content.
  - Prevented invalid hashtags, URL fragments, and hashtags embedded within words from becoming links.

- **Tests**
  - Added coverage for hashtag linking, Unicode and whitespace handling, escaping, and titles without hashtags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63257575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: no defects were reproduced in the changed title-rendering flow.

What we checked:
- Escaped title and hashtag rendering: The helper escapes unmatched title content and displayed tag text, while URI-encoding the tag before inserting it in the href. Runtime cases confirmed markup and attempted attribute injection render as inert escaped text. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Existing hashtag route compatibility: Generated links use the registered `/hashtag/:hashtag` route and the same form-style encoding used by hashtag pagination. Runtime route matching and decoding preserved ASCII and Unicode tags. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- False hashtag link creation: The matcher accepts a hash only at the start or after an allowed boundary, and matching occurs before HTML escaping. Runtime checks confirmed URL fragments, word-internal hashes, numeric entities, and escaped entities stay non-clickable. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Plain title preservation: After scanning, the helper appends all remaining source content with HTML escaping. Direct runtime assertions and the focused specification confirmed empty, plain, and unrecognized-hash titles retain their intended rendered text. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Validated hostile title inputs render safely through the Crystal title helper across 11 examples. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Verified generated ASCII and Unicode hashtag links route correctly and decode back to the original tags. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Confirmed URL fragments, word-internal hashes, numeric entity text, and escaped entity text are handled as non-clickable except for valid whitespace-prefixed hashtags that render internal links. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details open><summary><h3>Summary</h3></summary>

- This change makes supported hashtags in watch-page video titles open the matching internal hashtag results page. The title renderer safely escapes title content, generates compatible encoded links, avoids linking URL fragments and word-internal hashes, and preserves ordinary titles.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Add clickable hashtags to video titles"](https://github.com/iv-org/invidious/commit/ae946c1cb515d9052ed2cc5b54dd2b894e9a86a5)</sub>

<!-- /greptile_comment -->